### PR TITLE
support of rtl direction

### DIFF
--- a/panes/ember-debug.js
+++ b/panes/ember-debug.js
@@ -346,11 +346,11 @@ function getStyle(el,styleProp){
 
 function isRTL() {
 	var html = getStyle('html','direction');
-	if (html) {
+	if (html == "rtl") {
 		return true;
 	}
 	var body = getStyle(null,'direction');
-	if (body) {
+	if (body == "rtl") {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
getBoundingClientRect on  absolute element when direction page is rtl is incorrect.

bug report : http://code.google.com/p/chromium/issues/detail?id=231048
