### PR TITLE
Ensure Ember debug is executed at the correct time

### DIFF
--- a/assets/ember-debug.js
+++ b/assets/ember-debug.js
@@ -1,18 +1,11 @@
 /*jshint boss:true*/
-(function() {
-
-if (Ember.Debug) { return; }
 
 console.debug("Ember Debugger Active");
 
 var sentObjects = {},
     boundObservers = {};
 
-if (document.readyState === 'complete') {
-  activateDebugger();
-} else {
-  document.addEventListener('DOMContentLoaded', activateDebugger);
-}
+activateDebugger();
 
 function retainObject(object) {
   var meta = Ember.meta(object),
@@ -76,7 +69,6 @@ function activateDebugger() {
     } else if (message.type === 'hideLayer') {
       hideLayer();
     } else if (message.type === 'getTree') {
-      console.log('getTree');
       sendTree();
     }
   });
@@ -145,7 +137,7 @@ function activateDebugger() {
       var details = mixinsForObject(object);
       port1.postMessage({ from: 'inspectedWindow', parentObject: objectId, property: property, objectId: details.objectId, name: object.toString(), details: details.mixins });
     } else {
-      console.log(object);
+      // console.log(object);
     }
   }
 
@@ -263,6 +255,7 @@ function activateDebugger() {
 
     appendChildren(rootView, children, retained);
 
+
     return tree;
   }
 
@@ -295,7 +288,6 @@ function activateDebugger() {
 
   function sendTree() {
     var tree = viewTree();
-
     port1.postMessage({
       from: 'inspectedWindow',
       type: 'viewTree',
@@ -492,5 +484,3 @@ function controllerName(controller) {
 
   return name;
 }
-
-})();

--- a/assets/startup_wrapper.js
+++ b/assets/startup_wrapper.js
@@ -1,0 +1,61 @@
+/**
+  This is a wrapper for `ember-debug.js`
+  Wraps the script in a function,
+  and ensures that the script is executed
+  only after the dom is ready
+  and the application has initialized.
+
+  Also responsible for sending the first tree.
+**/
+(function() {
+
+  function start() {
+    {{emberDebug}}
+  }
+
+  onReady(function() {
+    if (!Ember.Debug) {
+      start();
+    }
+    Ember.Debug.sendTree();
+  });
+
+
+  function onReady(callback) {
+    if (document.readyState === 'complete') {
+      onApplicationStart(callback);
+    } else {
+      document.addEventListener( "DOMContentLoaded", function(){
+        document.removeEventListener( "DOMContentLoaded", arguments.callee, false );
+        onApplicationStart(callback);
+      }, false );
+    }
+  }
+
+  // There's probably a better way
+  // to determine when the application starts
+  // but this definitely works
+  function onApplicationStart(callback) {
+    if (!Ember) {
+      return;
+    }
+    var body = document.getElementsByTagName('body')[0];
+    var interval = setInterval(function() {
+      if (body.dataset.contentScriptLoaded && hasViews()) {
+       clearInterval(interval);
+       callback();
+      }
+    }, 10);
+  }
+
+  function hasViews() {
+    var views = Ember.View.views;
+    for(var i in views) {
+      if (views.hasOwnProperty(i)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+}());

--- a/content-script.js
+++ b/content-script.js
@@ -20,4 +20,5 @@ function listenToPort(port) {
 
   port.start();
 }
-
+// let ember-debug know that content script has executed
+document.getElementsByTagName('body')[0].dataset.contentScriptLoaded = 1;

--- a/panes/object-inspector.js
+++ b/panes/object-inspector.js
@@ -109,7 +109,6 @@
       classNameBindings: 'isPinned',
 
       isPinned: function() {
-        console.log(this.get('controller.pinnedNode'));
         return this.get('node') === this.get('controller.pinnedNode');
       }.property('node', 'controller.pinnedNode'),
 
@@ -224,20 +223,22 @@ chrome.devtools.network.onNavigated.addListener(function() {
 });
 
 function injectDebugger() {
-  var url = chrome.extension.getURL('panes/ember-debug.js');
 
   var xhr = new XMLHttpRequest();
-  xhr.open("GET", chrome.extension.getURL('/panes/ember-debug.js'), false);
+  xhr.open("GET", chrome.extension.getURL('/assets/ember-debug.js'), false);
   xhr.send();
+  var emberDebug = xhr.responseText;
 
-  setTimeout(function() {
-    chrome.devtools.inspectedWindow.eval(xhr.responseText, function() {
-      console.log("Asking for tree");
-      setTimeout(function() {
-        window.getTree();
-      }, 200);
-    });
-  }, 200);
+  xhr = new XMLHttpRequest();
+  xhr.open("GET", chrome.extension.getURL('/assets/startup_wrapper.js'), false);
+  xhr.send();
+  var startupWrapper = xhr.responseText;
+
+  // make sure ember debug runs
+  // after application has initialized
+  emberDebug = startupWrapper.replace("{{emberDebug}}", emberDebug);
+
+  chrome.devtools.inspectedWindow.eval(emberDebug);
 }
 
 injectDebugger();


### PR DESCRIPTION
The extension stops working when you refresh the page because ember-debug is injected too soon.

I made sure ember-debug is executed after the application has initialized and rendered, and after content-script has executed.  Also did some refactoring.

Aside from some remaining issues, the extension can now be used as it will always start up correctly.

Fixes #4 
