### PR TITLE
Add the ability to customize properties in object inspector

### DIFF
--- a/app/controllers/mixin_detail.js
+++ b/app/controllers/mixin_detail.js
@@ -1,7 +1,9 @@
 var MixinDetailController = Ember.ObjectController.extend({
   needs: ['mixinDetails'],
 
-  isExpanded: Ember.computed.equal('model.name', 'Own Properties'),
+  isExpanded: function() {
+    return this.get('model.expand') && this.get('model.properties.length') > 0;
+  }.property('model.expand', 'model.properties.length'),
 
   objectId: Ember.computed.alias('controllers.mixinDetails.objectId'),
 

--- a/ember_debug/object_inspector.js
+++ b/ember_debug/object_inspector.js
@@ -133,16 +133,26 @@ var ObjectInspector = Ember.Object.extend(PortMixin, {
         self = this;
 
     var ownProps = propertiesForMixin({ mixins: [{ properties: object }] });
-    mixinDetails.push({ name: "Own Properties", properties: ownProps });
+    mixinDetails.push({ name: "Own Properties", properties: ownProps, expand: true });
 
     mixins.forEach(function(mixin) {
-      mixin.toString();
       var name = mixin[Ember.NAME_KEY] || mixin.ownerConstructor || Ember.guidFor(name);
       mixinDetails.push({ name: name.toString(), properties: propertiesForMixin(mixin) });
     });
 
     applyMixinOverrides(mixinDetails);
-    calculateCachedCPs(object, mixinDetails);
+
+    var propertyInfo = null;
+    if (object._debugInfo && typeof object._debugInfo === 'function') {
+      propertyInfo = object._debugInfo().propertyInfo;
+      mixinDetails = customizeProperties(mixinDetails, propertyInfo);
+    }
+
+    var expensiveProperties = null;
+    if (propertyInfo) {
+      expensiveProperties = propertyInfo.expensiveProperties;
+    }
+    calculateCPs(object, mixinDetails, expensiveProperties);
 
     var objectId = this.retainObject(object);
 
@@ -322,7 +332,9 @@ function inspect(value) {
   }
 }
 
-function calculateCachedCPs(object, mixinDetails) {
+function calculateCPs(object, mixinDetails, expensiveProperties) {
+  expensiveProperties = expensiveProperties || [];
+
   mixinDetails.forEach(function(mixin) {
     mixin.properties.forEach(function(item) {
       if (item.overridden) {
@@ -330,13 +342,114 @@ function calculateCachedCPs(object, mixinDetails) {
       }
       if (item.value.computed) {
         var cache = Ember.cacheFor(object, item.name);
-        if (cache !== undefined) {
+        if (cache !== undefined || expensiveProperties.indexOf(item.name) === -1) {
           item.value = inspectValue(Ember.get(object, item.name));
           item.value.computed = true;
         }
       }
     });
   });
+}
+
+/**
+  Customizes an object's properties
+  based on the property `propertyInfo` of
+  the object's `_debugInfo` method.
+
+  Possible options:
+    - `groups` An array of groups that contains the properties for each group
+      For example:
+      ```javascript
+      groups: [
+        { name: 'Attributes', properties: ['firstName', 'lastName'] },
+        { name: 'Belongs To', properties: ['country'] }
+      ]
+      ```
+    - `includeOtherProperties` Boolean,
+      - `true` to include other non-listed properties,
+      - `false` to only include given properties
+    - `skipProperties` Array containing list of properties *not* to include
+    - `skipMixins` Array containing list of mixins *not* to include
+    - `expensiveProperties` An array of computed properties that are too expensive.
+       Adding a property to this array makes sure the CP is not calculated automatically.
+
+  Example:
+  ```javascript
+  {
+    propertyInfo: {
+      includeOtherProperties: true,
+      skipProperties: ['toString', 'send', 'withTransaction'],
+      skipMixins: [ 'Ember.Evented'],
+      calculate: ['firstName', 'lastName'],
+      groups: [
+        {
+          name: 'Attributes',
+          properties: [ 'id', 'firstName', 'lastName' ],
+          expand: true // open by default
+        },
+        {
+          name: 'Belongs To',
+          properties: [ 'maritalStatus', 'avatar' ],
+          expand: true
+        },
+        {
+          name: 'Has Many',
+          properties: [ 'phoneNumbers' ],
+          expand: true
+        },
+        {
+          name: 'Flags',
+          properties: ['isLoaded', 'isLoading', 'isNew', 'isDirty']
+        }
+      ]
+    }
+  }
+  ```
+*/
+function customizeProperties(mixinDetails, propertyInfo) {
+  var newMixinDetails = [],
+      neededProperties = {},
+      groups = propertyInfo.groups || [],
+      skipProperties = propertyInfo.skipProperties || [],
+      skipMixins = propertyInfo.skipMixins || [];
+
+  if(groups.length) {
+    mixinDetails[0].expand = false;
+  }
+
+  groups.forEach(function(group) {
+    group.properties.forEach(function(prop) {
+      neededProperties[prop] = true;
+    });
+  });
+
+  mixinDetails.forEach(function(mixin) {
+    var newProperties = [];
+    mixin.properties.forEach(function(item) {
+      if (skipProperties.indexOf(item.name) !== -1) {
+        return true;
+      }
+      if (!item.overridden && neededProperties[item.name]) {
+        neededProperties[item.name] = item;
+      } else {
+        newProperties.push(item);
+      }
+    });
+    mixin.properties = newProperties;
+    if (skipMixins.indexOf(mixin.name) === -1) {
+      newMixinDetails.push(mixin);
+    }
+  });
+
+  groups.slice().reverse().forEach(function(group) {
+    var newMixin = { name: group.name, expand: group.expand, properties: [] };
+    group.properties.forEach(function(prop) {
+      newMixin.properties.push(neededProperties[prop]);
+    });
+    newMixinDetails.unshift(newMixin);
+  });
+
+  return newMixinDetails;
 }
 
 function isComputed(value) {
@@ -347,6 +460,5 @@ function isComputed(value) {
 function inspectController(controller) {
   return controller.get('_debugContainerKey') || controller.toString();
 }
-
 
 export = ObjectInspector;

--- a/extension_dist/panes/ember_extension.js
+++ b/extension_dist/panes/ember_extension.js
@@ -60,7 +60,9 @@ define("controllers/mixin_detail",
     var MixinDetailController = Ember.ObjectController.extend({
       needs: ['mixinDetails'],
 
-      isExpanded: Ember.computed.equal('model.name', 'Own Properties'),
+      isExpanded: function() {
+        return this.get('model.expand') && this.get('model.properties.length') > 0;
+      }.property('model.expand', 'model.properties.length'),
 
       objectId: Ember.computed.alias('controllers.mixinDetails.objectId'),
 

--- a/test/ember_extension/object_inspector_test.js
+++ b/test/ember_extension/object_inspector_test.js
@@ -8,6 +8,7 @@ var objectAttr = {
   details: [
     {
       name: 'Own Properties',
+      expand: true,
       properties: [{
         name: 'id',
         value: 1
@@ -27,6 +28,7 @@ function objectToInspect() {
     details: [
       {
         name: 'First Detail',
+        expand: false,
         properties: [{
           name: 'numberProperty',
           value: {
@@ -87,7 +89,6 @@ test("The object displays correctly", function() {
 });
 
 test("Object details", function() {
-
 
   var $firstDetail, $secondDetail;
 
@@ -235,6 +236,7 @@ test("Properties are bound to the application properties", function() {
       objectId: 'object-id',
       details: [{
         name: 'Own Properties',
+        expand: true,
         properties: [{
           name: 'boundProp',
           value: {
@@ -302,6 +304,7 @@ test("Send to console", function() {
       objectId: 'object-id',
       details: [{
         name: 'Own Properties',
+        expand: true,
         properties: [{
           name: 'myProp',
           value: {


### PR DESCRIPTION
By adding a `_debugInfo` method to an object, we can now customize how the properties will appear in the object inspector.

There's a [PR](https://github.com/emberjs/data/pull/1106) in parallel to Ember Data to add `_debugInfo` to `DS.Model`.

Example with Ember Data:

![extension_screenshot](https://f.cloud.github.com/assets/1061742/903690/5a951104-fbb1-11e2-9c5a-ae736c119ca5.png)

`_debugInfo` returned value:

``` javascript

propertyInfo: {
  // include other mixins/properties not listed here
  includeOtherProperties: true,
  // do not display these properties
  skipProperties: [],
  // do not display these mixins along with their properties
  skipMixins: [],
  // don't calculate these CPs automatically (unless cached)
  expensiveProperties: [
    'businessLine', 
    'organization',
    'linkedOrganization', 
    'planGroupsProducts', 
    'productConditionsClauses'
  ],
  groups: [
    {
      name: 'Attributes',
      properties: ['id', 'code', 'name' ],
      expand: true // open by default
    },
    {
      name: 'Belongs To',
      properties: [ 'businessLine', 'organization', 'linkedOrganization' ],
      expand: true
    },
    {
      name: 'Has Many',
      properties: [ 'planGroupsProducts', 'productConditionClauses' ],
      expand: true
    },
    {
      name: 'Flags',
      properties: ['isLoaded', 'isDirty', 'isSaving', 'isDeleted', 'isError', 'isNew', 'isValid']
    }
   ]
  }
```
