### PR TITLE
Allow the inspected object to be sent to the console.

### DIFF
--- a/app/controllers/mixin_stack.js
+++ b/app/controllers/mixin_stack.js
@@ -15,6 +15,13 @@ var MixinStackController = Ember.ArrayController.extend({
     if(this.get('isNested')) {
       this.get('controllers.application').popMixinDetails();
     }
+  },
+
+  sendObjectToConsole: function(obj) {
+    var objectId = Ember.get(obj, 'objectId');
+    this.get('port').send('objectInspector:sendToConsole', {
+      objectId: objectId
+    });
   }
 });
 

--- a/app/templates/mixin_stack.handlebars
+++ b/app/templates/mixin_stack.handlebars
@@ -4,6 +4,7 @@
       <button {{action "popStack"}} data-label="object-inspector-back" {{bindAttr class=":object-inspector__back isNested:object-inspector__back_state_enabled:object-inspector__back_state_disabled"}}></button>
     {{/if}}
     <span data-label="object-name" class="object-inspector__name">{{firstObject.name}}</span>
+    <button class="object-inspector__send-object-btn" {{action sendObjectToConsole firstObject}} data-label="send-object-to-console-btn"><img src="/images/send.png" title="Send object to console"></button>
   </h1>
   {{#if trail}}
     <h2 class="object-inspector__header-trail" data-label="object-trail">{{trail}}</h2>

--- a/css/object_inspector.css
+++ b/css/object_inspector.css
@@ -24,9 +24,7 @@
   font-weight: bold;
   margin-bottom: 0;
   width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-flex;
 }
 
 .object-inspector__header-trail {
@@ -60,4 +58,27 @@
 
 .object-inspector__back_state_disabled {
   opacity: 0.4;
+}
+
+.object-inspector__name {
+  -webkit-flex-basis: 0px;
+  -webkit-flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.object-inspector__send-object-btn {
+  border: none;
+  background: none;
+  margin: 0;
+  padding: 0;
+  width: 15px;
+  opacity: 1;
+}
+
+.object-inspector__send-object-btn img {
+  margin-right: 3px;
+  width: 16px;
 }

--- a/ember_debug/object_inspector.js
+++ b/ember_debug/object_inspector.js
@@ -56,7 +56,14 @@ var ObjectInspector = Ember.Object.extend(PortMixin, {
 
   sendToConsole: function(objectId, prop) {
     var object = this.sentObjects[objectId];
-    var value = Ember.get(object, prop);
+    var value;
+
+    if (Ember.isNone(prop)) {
+      value = this.sentObjects[objectId];
+    } else {
+      value =  Ember.get(object, prop);
+    }
+    
     window.$E = value;
     console.log('Ember Inspector ($E): ', value);
   },

--- a/extension_dist/ember_debug/ember_debug.js
+++ b/extension_dist/ember_debug/ember_debug.js
@@ -480,7 +480,14 @@ define("object_inspector",
 
       sendToConsole: function(objectId, prop) {
         var object = this.sentObjects[objectId];
-        var value = Ember.get(object, prop);
+        var value;
+
+        if (Ember.isNone(prop)) {
+          value = this.sentObjects[objectId];
+        } else {
+          value =  Ember.get(object, prop);
+        }
+    
         window.$E = value;
         console.log('Ember Inspector ($E): ', value);
       },

--- a/extension_dist/panes/ember_extension.css
+++ b/extension_dist/panes/ember_extension.css
@@ -482,9 +482,7 @@ a {
   font-weight: bold;
   margin-bottom: 0;
   width: 100%;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-flex;
 }
 
 .object-inspector__header-trail {
@@ -520,6 +518,28 @@ a {
   opacity: 0.4;
 }
 
+.object-inspector__name {
+  -webkit-flex-basis: 0px;
+  -webkit-flex-grow: 1;
+  -webkit-flex-shrink: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.object-inspector__send-object-btn {
+  border: none;
+  background: none;
+  margin: 0;
+  padding: 0;
+  width: 15px;
+  opacity: 1;
+}
+
+.object-inspector__send-object-btn img {
+  margin-right: 3px;
+  width: 16px;
+}
 .split {
   height: 100%;
 }

--- a/extension_dist/panes/ember_extension.js
+++ b/extension_dist/panes/ember_extension.js
@@ -248,6 +248,13 @@ define("controllers/mixin_stack",
         if(this.get('isNested')) {
           this.get('controllers.application').popMixinDetails();
         }
+      },
+
+      sendObjectToConsole: function(obj) {
+        var objectId = Ember.get(obj, 'objectId');
+        this.get('port').send('objectInspector:sendToConsole', {
+          objectId: objectId
+        });
       }
     });
 
@@ -1445,7 +1452,11 @@ function program3(depth0,data) {
   hashTypes = {};
   hashContexts = {};
   data.buffer.push(escapeExpression(helpers._triageMustache.call(depth0, "firstObject.name", {hash:{},contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
-  data.buffer.push("</span>\n  </h1>\n  ");
+  data.buffer.push("</span>\n    <button class=\"object-inspector__send-object-btn\" ");
+  hashTypes = {};
+  hashContexts = {};
+  data.buffer.push(escapeExpression(helpers.action.call(depth0, "sendObjectToConsole", "firstObject", {hash:{},contexts:[depth0,depth0],types:["ID","ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
+  data.buffer.push(" data-label=\"send-object-to-console-btn\"><img src=\"/images/send.png\" title=\"Send object to console\"></button>\n  </h1>\n  ");
   hashTypes = {};
   hashContexts = {};
   stack1 = helpers['if'].call(depth0, "trail", {hash:{},inverse:self.noop,fn:self.program(3, program3, data),contexts:[depth0],types:["ID"],hashContexts:hashContexts,hashTypes:hashTypes,data:data});

--- a/test/ember_extension/object_inspector_test.js
+++ b/test/ember_extension/object_inspector_test.js
@@ -324,6 +324,12 @@ test("Send to console", function() {
     equal(name, 'objectInspector:sendToConsole');
     equal(message.objectId, 'object-id');
     equal(message.property, 'myProp');
+  })
+  .clickByLabel('send-object-to-console-btn')
+  .then(function() {
+    equal(name, 'objectInspector:sendToConsole');
+    equal(message.objectId, 'object-id');
+    equal(message.property, undefined);
   });
 
 });


### PR DESCRIPTION
I kept finding myself wanting to interact in the console with the actual object I was currently inspecting, not just its properties. This adds a "Send object to console" button next to the inspected object, similar to the button next to properties.

![screenshot-ember-extension-send-inspected-object-to-console](https://f.cloud.github.com/assets/1930208/970458/ea28782c-05d6-11e3-84bc-8d9fe6a0bf0c.png)
