### PR TITLE
highlightView doesn't correctly position the overlay unless window.scrol...

### DIFF
--- a/ember_debug/view_debug.js
+++ b/ember_debug/view_debug.js
@@ -196,6 +196,12 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       rect = element.getBoundingClientRect();
     }
 
+    // take into account the scrolling position as mentioned in docs
+    // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
+    rect = Ember.$().extend({}, rect);
+    rect.top = rect.top + window.scrollY;
+    rect.left = rect.left + window.scrollX;
+
     var templateName = view.get('templateName') || view.get('_debugTemplateName'),
         controller = view.get('controller'),
         model = controller && controller.get('model');

--- a/extension_dist/ember_debug/ember_debug.js
+++ b/extension_dist/ember_debug/ember_debug.js
@@ -1316,6 +1316,12 @@ define("view_debug",
           rect = element.getBoundingClientRect();
         }
 
+        // take into account the scrolling position as mentioned in docs
+        // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
+        rect = Ember.$().extend({}, rect);
+        rect.top = rect.top + window.scrollY;
+        rect.left = rect.left + window.scrollX;
+
         var templateName = view.get('templateName') || view.get('_debugTemplateName'),
             controller = view.get('controller'),
             model = controller && controller.get('model');


### PR DESCRIPTION
...lx and window.scrollY are added to `top` and `left` as described in https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect

> The amount of scrolling that has been done of the viewport area (or any other scrollable element) is taken into account when computing the bounding rectangle. This means that the top and left property change their values as soon as the scrolling position changes (so their values are relative to the viewport and not absolute). If this is not the desired behaviour just add the current scrolling position to the top and left property (via window.scrollX and window.scrollY) to get constant values independent from the current scrolling position.

If `scrollX` and `scrollY` are not taken into account, the overlays will not be positioned correctly:

_before:_
![incorrect scroll offset 2013-08-26 19 16 00](https://f.cloud.github.com/assets/1930208/1030035/8f3d9c28-0ea8-11e3-854e-003d6ccc709b.png)

_after:_
![correct scroll offset 2013-08-26 19 39 14](https://f.cloud.github.com/assets/1930208/1030044/c1d2b1b4-0ea8-11e3-92c7-a481748ee086.png)
