### PR TITLE
Allow app__main to shrink when app__right-col is expanded

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -68,7 +68,7 @@
 }
 
 
-@media only all and (max-width: 1500px) {
+@media only all and (max-width: 1200px) {
   .app__right-col {
     position: absolute;
     right: 0;

--- a/extension_dist/panes/ember_extension.css
+++ b/extension_dist/panes/ember_extension.css
@@ -68,7 +68,7 @@
 }
 
 
-@media only all and (max-width: 1500px) {
+@media only all and (max-width: 1200px) {
   .app__right-col {
     position: absolute;
     right: 0;


### PR DESCRIPTION
Currently when the width is less than 1500px the app__right-col is absolutely positioned which causes the app__main to display behind it when it is expanded. 

This PR removes the absolute positioning which allows the app_main to shrink to fit when expanding app__right-col
## Before

![before](https://f.cloud.github.com/assets/200528/1050401/4da9e768-10b9-11e3-9d61-295f5aadebbf.png)
## After

![after](https://f.cloud.github.com/assets/200528/1050400/4dacdd38-10b9-11e3-991b-4e590c843784.png)
