### PR TITLE
fix highlightedElment when page direction is rtl

### DIFF
--- a/ember_debug/view_debug.js
+++ b/ember_debug/view_debug.js
@@ -213,6 +213,8 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       backgroundColor: "rgba(255, 255, 255, 0.7)",
       border: "2px solid rgb(102, 102, 102)",
       padding: "0",
+      right: "auto",
+      direction: "ltr",
       boxSizing: "border-box",
       color: "rgb(51, 51, 255)",
       fontFamily: "Menlo, sans-serif",


### PR DESCRIPTION
fix highlightedElment when page direction is rtl;

screen before Patch : http://tinyurl.com/kr8w3m8
screen after Patch : http://tinyurl.com/lnmtc3a
chrome bug : http://code.google.com/p/chromium/issues/detail?id=231048
