### PR TITLE
Account for document.body being absent.

### DIFF
--- a/extension_dist/content-script.js
+++ b/extension_dist/content-script.js
@@ -21,4 +21,6 @@ function listenToPort(port) {
   port.start();
 }
 // let ember-debug know that content script has executed
-document.body.dataset.emberExtension = 1;
+if (document.body) {
+  document.body.dataset.emberExtension = 1;
+}


### PR DESCRIPTION
This fixes a problem I've run into a lot where on reloading a page I get an exception here which breaks since I have debugging on uncaught errors turned on.
