### PR TITLE
update grunt-mozilla-addon-sdk deps to prevent issues on build_xpi using dirs with space chars

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "glob": "~3.2.1",
     "grunt-contrib-compress": "~0.5.2",
     "grunt-ember-s3": "~1.0.4",
-    "grunt-mozilla-addon-sdk": "~0.3.1",
+    "grunt-mozilla-addon-sdk": "~0.3.2",
     "grunt-wrap": "~0.3.0"
   }
 }


### PR DESCRIPTION
small tweak to the package.json

fix #83
