### PR TITLE
enable private-browsing permission on firefox addon

### DIFF
--- a/dist_firefox/package.json
+++ b/dist_firefox/package.json
@@ -4,5 +4,6 @@
     "version": "0.0.4",
     "fullName": "Ember Inspector",
     "id": "ember-inspector@emberjs.com",
-    "description": "Tool for debugging Ember applications."
+    "description": "Tool for debugging Ember applications.",
+    "permissions": {"private-browsing": true}
 }


### PR DESCRIPTION
This change enable "private-browsing" permission on the firefox addon to be able to inspect target tab in private mode windows.

Fix #82
