### PR TITLE
FIX: workaround firebug console.debug/console.log exception

### DIFF
--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -1,4 +1,10 @@
 var BasicAdapter = Ember.Object.extend({
+  debug: function() {
+    console.debug.apply(console, arguments);
+  },
+  log: function() {
+    console.log.apply(console, arguments);
+  },
   /**
     Used to send messages to EmberExtension
 

--- a/ember_debug/adapters/firefox.js
+++ b/ember_debug/adapters/firefox.js
@@ -6,6 +6,25 @@ var FirefoxAdapter = BasicAdapter.extend({
     this._connect();
   },
 
+  debug: function() {
+    // WORKAROUND: temporarily workaround issues with firebug console object:
+    // - https://github.com/tildeio/ember-extension/issues/94
+    // - https://github.com/firebug/firebug/pull/109
+    // - https://code.google.com/p/fbug/issues/detail?id=7045
+    try {
+      this._super.apply(this, arguments);
+    } catch(e) { }
+  },
+  log: function() {
+    // WORKAROUND: temporarily workaround issues with firebug console object:
+    // - https://github.com/tildeio/ember-extension/issues/94
+    // - https://github.com/firebug/firebug/pull/109
+    // - https://code.google.com/p/fbug/issues/detail?id=7045
+    try {
+      this._super.apply(this, arguments);
+    } catch(e) { }
+  },
+
   sendMessage: function(options) {
     options = options || {};
     var event = document.createEvent("CustomEvent");

--- a/ember_debug/ember_debug.js
+++ b/ember_debug/ember_debug.js
@@ -6,8 +6,6 @@ import ViewDebug from "view_debug";
 import RouteDebug from "route_debug";
 import DataDebug from "data_debug";
 
-console.debug("Ember Debugger Active");
-
 var EmberDebug;
 
 EmberDebug = Ember.Namespace.create({
@@ -29,6 +27,7 @@ EmberDebug = Ember.Namespace.create({
 
     this.reset();
 
+    this.get("adapter").debug("Ember Debugger Active");
   },
 
   destroyContainer: function() {

--- a/ember_debug/object_inspector.js
+++ b/ember_debug/object_inspector.js
@@ -18,6 +18,8 @@ function inspect(value) {
 var ObjectInspector = Ember.Object.extend(PortMixin, {
   namespace: null,
 
+  adapter: Ember.computed.alias('namespace.adapter'),
+
   port: Ember.computed.alias('namespace.port'),
 
   application: Ember.computed.alias('namespace.application'),
@@ -91,7 +93,8 @@ var ObjectInspector = Ember.Object.extend(PortMixin, {
     }
 
     window.$E = value;
-    console.log('Ember Inspector ($E): ', value);
+
+    this.get("adapter").log('Ember Inspector ($E): ', value);
   },
 
   digIntoObject: function(objectId, property) {


### PR DESCRIPTION
Firebug console.debug/console.log raise an exception when called from javascript code injected from a content-script.

fix #94 
