### PR TITLE
adds hash history styling for route tree urls

### DIFF
--- a/ember_debug/route_debug.js
+++ b/ember_debug/route_debug.js
@@ -95,7 +95,7 @@ var buildSubTree = function(routeTree, route) {
 
       if (i === handlers.length - 1) {
         // it is a route, get url
-        subTree[handler].value.url = getURL(route.segments);
+        subTree[handler].value.url = getURL(container, route.segments);
         subTree[handler].value.type = 'route';
       } else {
         // it is a resource, set children object
@@ -123,7 +123,8 @@ function arrayizeChildren(routeTree) {
   return obj;
 }
 
-function getURL(segments) {
+function getURL(container, segments) {
+  var locationImplementation = container.lookup('router:main').location;
   var url = [];
   for (var i = 0; i < segments.length; i++) {
     var name = null;
@@ -140,7 +141,7 @@ function getURL(segments) {
   }
 
   url = '/' + url.join('/');
-
+  url = locationImplementation.formatURL(url);
   return url;
 }
 


### PR DESCRIPTION
I'm pretty new to Ember, and found it confusing that the URLs in the route tree didn't display properly when I was using the hash history implementation. I think it would be more intuitive if this feature checked which implementation was being used, and displayed the URLs appropriately.

This makes the URLs more verbose if the user is using hash history, but it provides accurate URLs for accessing the appropriate routes. If this is something that you think is worth adding, I can look into how to check for which implementation of the location API is being used.

I made some small code changes to demonstrate what I'm thinking. Thanks for your time.
