### PR TITLE
FIX: force white background on Firefox (fix #114)

### DIFF
--- a/dist_firefox/data/panes/index.html
+++ b/dist_firefox/data/panes/index.html
@@ -10,6 +10,12 @@
     <script src="ember_extension.js"></script>
     <script src="start.js"></script>
     <link href="ember_extension.css" rel="stylesheet">
+    <style type="text/css">
+      /* FIX: fix background style issue on Firefox 28 */
+      body {
+        background: white;
+      }
+    </style>
   </head>
   <body>
   </body>


### PR DESCRIPTION
This PR fixes an issue on Firefox >= 28, which is related to the background style of next "Firefox Developer Tools".

NOTE: Currently I chose to introduce it as a workaround directly in the Firefox addon panel HTML source, because Firefox 28 is not yet released.
