### PR TITLE
Fix "re-open ember panel on Firefox"

### DIFF
--- a/app/adapters/firefox.js
+++ b/app/adapters/firefox.js
@@ -4,17 +4,22 @@ var FirefoxAdapter = BasicAdapter.extend({
 
   sendMessage: function(options) {
     options = options || {};
-    var event = document.createEvent("CustomEvent");
-    event.initCustomEvent("ember-extension-send", true, true, options);
-    document.documentElement.dispatchEvent(event);
+    window.parent.postMessage(options, "*");
   },
 
   _connect: function() {
     var self = this;
-    window.addEventListener("ember-extension-receive", function(evt) {
-      // We clone the object so that Ember prototype extensions
-      // are applied.
-      self._messageReceived(Ember.$.extend(true, {}, evt.detail));
+    // NOTE: chrome adapter sends a appId message on connect (not needed on firefox)
+    //this.sendMessage({ appId: "test" });
+    window.addEventListener("message", function(evt) {
+      // check if the event is originated by our privileged ember inspector code
+      if (evt.isTrusted) {
+        // We clone the object so that Ember prototype extensions
+        // are applied.
+        self._messageReceived(Ember.$.extend(true, {}, evt.data));
+      } else {
+        console.log("EMBER INSPECTOR: ignored post message", evt);
+      }
     }, false);
   }.on('init')
 });


### PR DESCRIPTION
This commit fix a bug in the Firefox addon code:

if a user close and re-open the ember inspector on a target page, the ember inspector devtool panel does not detect the Ember App in the target page anymore.

This issue (related to lost messages due to a not yet connected worker) is resolved using postMessage API as message channel between Firefox add-on code and Ember Inspector DevTool panel 
(and this new approach simplifies firefox addon code as a nice side-effect)  
