### PR TITLE
Clean up DOM if no Ember application

### DIFF
--- a/ember_debug/vendor/startup_wrapper.js
+++ b/ember_debug/vendor/startup_wrapper.js
@@ -67,8 +67,22 @@ if (typeof adapter !== 'undefined') {
     onReady(function() {
       if (window.Ember) {
         callback();
-      } else {
-        window.addEventListener('Ember.Application', callback, false);
+        return;
+      }
+
+      // If here, there is either no Ember, or Ember is being loaded
+      // asynchronously. Give it half a second, and then clean up.
+      var asyncEmberTimeout = setTimeout(function() {
+        removeData(document.documentElement, 'emberExtension');
+        removeData(document.body, 'emberExtension');
+        window.removeListener('Ember.Application', invokeCallback, false);
+      }, 500);
+
+      window.addEventListener('Ember.Application', invokeCallback, false);
+
+      function invokeCallback() {
+        clearTimeout(asyncEmberTimeout);
+        callback();
       }
     });
   }
@@ -103,6 +117,12 @@ if (typeof adapter !== 'undefined') {
        callback();
       }
     }, 1);
+  }
+
+  function removeData(el, name) {
+    if (el && el.dataset.hasOwnProperty(name)) {
+      delete el.dataset[name]
+    }
   }
 
 }(currentAdapter));


### PR DESCRIPTION
Not everything I do is written with Ember, and I keep doing double-takes when I see `data-ember-extension="1"` when I'm not expecting to be in an Ember app.

This PR hooks into the `onReady` call in `onEmberReady`. It gives the async loaders half a second to load up Ember and fire the `'Ember.Application'` event. If we hit the half-second, give up and remove the added attributes. (500 ms is an arbitrary delay, just picked what felt like a reasonable number)

I looked to make the minimal set of changes necessary for this, and there may be edge cases I haven't thought of, and maybe even extra stuff (I didn't check for globals) that could be removed. I'd welcome and appreciate any feedback.
