### PR TITLE
Use SVG badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Ember Inspector [![Build Status](https://secure.travis-ci.org/emberjs/ember-inspector.png?branch=master)](http://travis-ci.org/emberjs/ember-inspector)
+Ember Inspector [![Build Status](https://secure.travis-ci.org/emberjs/ember-inspector.svg?branch=master)](https://travis-ci.org/emberjs/ember-inspector)
 ===============
 
 Adds an Ember tab to Chrome or Firefox Developer Tools that allows you to inspect


### PR DESCRIPTION
Travis now provides a SVG replacement for the PNG status badge, which is much easier to read on retina displays. For example, this is the difference from my perspective:

![screen shot 2014-05-08 at 8 35 05 pm](https://cloud.githubusercontent.com/assets/688886/2923570/86b8cc86-d71a-11e3-850c-d2dcc0347071.png)
