### PR TITLE
Add `title` Attribute to View Tree Cells

### DIFF
--- a/app/templates/view_item.handlebars
+++ b/app/templates/view_item.handlebars
@@ -5,11 +5,13 @@
     </div>
   </div>
 
-  <div {{bind-attr class=":cell hasElement:cell_clickable"}} {{action "inspectElement"}} data-label="view-template">{{unbound value.template}}</div>
+  <div {{bind-attr class=":cell hasElement:cell_clickable"}} {{action "inspectElement"}} data-label="view-template">
+    <span title="{{unbound value.template}}">{{unbound value.template}}</span>
+  </div>
   <div {{bind-attr class=":cell"}} data-label="view-model">
     {{#if hasModel}}
       <div {{bind-attr class=":list-tree__limited modelInspectable:cell_clickable"}} {{action "inspectModel" value.model.objectId}}>
-        {{unbound value.model.name}}
+        <span title="{{unbound value.model.name}}">{{unbound value.model.name}}</span>
       </div>
       <div class="list-tree__right-helper">
         {{send-to-console action="sendModelToConsole" param=value.objectId}}
@@ -21,7 +23,7 @@
   <div {{bind-attr class=":cell"}} data-label="view-controller">
     {{#if hasController}}
       <div {{bind-attr class=":list-tree__limited hasController:cell_clickable"}} {{action "inspect" value.controller.objectId}} >
-        {{unbound value.controller.name}}
+        <span title="{{unbound value.controller.name}}">{{unbound value.controller.name}}</span>
       </div>
       <div class="list-tree__right-helper">
         {{send-to-console action="sendObjectToConsole" param=value.controller.objectId}}
@@ -31,7 +33,7 @@
   <div {{bind-attr class=":cell"}} data-label="view-class">
     {{#if hasView}}
       <div {{bind-attr class=":list-tree__limited hasView:cell_clickable"}} {{action "inspectView"}} >
-        {{unbound value.viewClass}}
+        <span title="{{unbound value.viewClass}}">{{unbound value.viewClass}}</span>
       </div>
       <div class="list-tree__right-helper">
         {{send-to-console action="sendObjectToConsole" param=value.objectId}}

--- a/test/ember_extension/view_tree_test.js
+++ b/test/ember_extension/view_tree_test.js
@@ -114,6 +114,10 @@ test("It should correctly diplay the view tree", function() {
       durations.push(label('view-duration', this));
     });
 
+    var titleTips = find('span[title]:not([data-label])').map(function (i, node) {
+      return node.getAttribute('title');
+    }).toArray().sort();
+
     deepEqual(controllerNames, [
       'App.ApplicationController',
       'App.PostsController',
@@ -143,6 +147,20 @@ test("It should correctly diplay the view tree", function() {
       '1.00ms',
       '2.50ms'
     ], 'expected render durations');
+
+    deepEqual(titleTips, [
+      'App.ApplicationController',
+      'App.ApplicationView',
+      'App.CommentsController',
+      'App.CommentsView',
+      'App.PostsController',
+      'App.PostsView',
+      'CommentsArray',
+      'PostsArray',
+      'application',
+      'comments',
+      'posts'
+    ], 'expected title tips');
   });
 
 });


### PR DESCRIPTION
Long names of classes tend to trail off in the DIV cells. This change adds a `title` attribute with the full name of the object in question.
## Preview

![preview](https://cloud.githubusercontent.com/assets/3300/3004805/7ecc9a68-ddbc-11e3-9032-a2f1b2556440.png)
## TODO
- [x] Add tests (Can someone point me in the direction to do this? I'm still figuring the layout of this project out)
- [ ] Manual testing in Firefox
## Open Questions
- [x] Is there a way to add the `title` attribute as an unbound property? I imagine this is probably a good idea for performance reasons.
