### PR TITLE
Use new Ember instrumentation details in render tree

### DIFF
--- a/ember_debug/models/profile_manager.js
+++ b/ember_debug/models/profile_manager.js
@@ -1,10 +1,12 @@
 import ProfileNode from 'models/profile_node';
+var scheduleOnce = Ember.run.scheduleOnce;
+var emberA = Ember.A;
 
 /**
  * A class for keeping track of active rendering profiles as a list.
  */
 var ProfileManager = function() {
-  this.profiles = Em.A();
+  this.profiles = emberA();
   this.current = null;
   this.currentSet = [];
   this._profilesAddedCallbacks = [];
@@ -26,7 +28,7 @@ ProfileManager.prototype = {
     if (!this.current) {
       this.currentSet.push(profileNode);
       // If so, schedule an update of the profile list
-      Em.run.scheduleOnce('afterRender', this, this._profilesFinished);
+      scheduleOnce('afterRender', this, this._profilesFinished);
     }
   },
 

--- a/ember_debug/models/profile_node.js
+++ b/ember_debug/models/profile_node.js
@@ -3,22 +3,35 @@
 
   @class ProfileNode
 **/
+var get = Ember.get;
+var guidFor = Ember.guidFor;
+
 var ProfileNode = function(start, payload, parent) {
+  var name;
   this.start = start;
   this.timestamp = Date.now();
+
   if (payload) {
-    if (payload.template) { this.name = payload.template; }
-    if (payload.object) {
-      var name = payload.object.toString();
-      var match = name.match(/:(ember\d+)>$/);
-      this.name =  name.replace(/:?:ember\d+>$/, '').replace(/^</, '');
-      if (match && match.length > 1) {
-        this.viewGuid = match[1];
+    if (payload.template) {
+      name = payload.template;
+    } else if (payload.view) {
+      var view = payload.view;
+      name = get(view, 'instrumentDisplay') || get(view, '_debugContainerKey');
+      this.viewGuid = guidFor(view);
+    }
+
+    if (!name && payload.object) {
+      name = payload.object.toString().replace(/:?:ember\d+>$/, '').replace(/^</, '');
+      if (!this.viewGuid) {
+        var match = name.match(/:(ember\d+)>$/);
+        if (match && match.length > 1) {
+          this.viewGuid = match[1];
+        }
       }
     }
-  } else {
-    this.name = "unknown view";
   }
+
+  this.name = name || 'Unknown view';
 
   if (parent) { this.parent = parent; }
   this.children = [];

--- a/test/ember_debug/profile_node_test.js
+++ b/test/ember_debug/profile_node_test.js
@@ -1,5 +1,7 @@
 import ProfileNode from 'models/profile_node';
 
+module("ProfileNode");
+
 test("It can create a ProfileNode", function() {
   var p = new ProfileNode(1001, {template: 'application'});
 
@@ -12,7 +14,7 @@ test("It can create a ProfileNode", function() {
 
 test("with no payload it has an unknown name", function() {
   var p = new ProfileNode(1234);
-  equal(p.name, "unknown view");
+  equal(p.name, "Unknown view");
 });
 
 test("It can extract the name from an object payload", function() {
@@ -56,4 +58,14 @@ test("Can be serialized as JSON", function() {
   p1.finish(1004);
 
   ok(JSON.stringify(p1), "it can serialize due to no cycles in the object");
+});
+
+test("Name takes the following priority: display, containerKey, object", function() {
+  var p;
+  p = new ProfileNode(1000, {view: { instrumentDisplay: 'donuts', _debugContainerKey: 'candy'}, object: 'coffee'});
+  equal(p.name, 'donuts');
+  p = new ProfileNode(1000, {view: {_debugContainerKey: 'candy'}, object:' coffee'});
+  equal(p.name, 'candy');
+  p = new ProfileNode(1000, {object:'coffee'});
+  equal(p.name, 'coffee');
 });


### PR DESCRIPTION
This is wip to have clearer render performance labels.  (For example `{{each}}` instead of `Ember._MetamorphView`)

Will merge when the instrumentation details are added to Ember core.

/ cc @rjackson
