### PR TITLE
Put render time before item name, for ergonomics

### DIFF
--- a/app/templates/render_item.handlebars
+++ b/app/templates/render_item.handlebars
@@ -4,8 +4,8 @@
 
       <span {{bind-attr title="name"}}>
         <span class="cell__arrow"></span>
-        <span data-label="render-profile-name">{{name}}</span>
         <span class="pill pill_not-clickable" data-label="render-profile-duration">{{ms-to-time duration}}</span>
+        <span data-label="render-profile-name">{{name}}</span>
       </span>
     </div>
     <div class="cell cell_value_numeric"  data-label="render-profile-timestamp">


### PR DESCRIPTION
This makes it easier to scan the list of render times and see what's slow--if the time is to the right of the name, the variable length of the name makes it hard to compare the times.  It'd be even better to color code the pills (slower == redder), but I couldn't figure out a straightforward way to do that.