### PR TITLE
Fix name in column 'Name'

### DIFF
--- a/ember_debug/view_debug.js
+++ b/ember_debug/view_debug.js
@@ -587,8 +587,8 @@ function viewDescription(view) {
         if (parentClassName = className.match(/^\(subclass of (.*)\)/)) {
           className = parentClassName[1];
         }
-        name = className.split('.')[1];
-        name = name.charAt(0).toLowerCase() + name.substr(1);
+        name = className.split('.').pop();
+        name = Ember.String.camelize(name);
       }
     }
 


### PR DESCRIPTION
Take in account that we might have more than one namespace before the
name of the class.

Fix https://github.com/emberjs/ember-inspector/issues/177
