### PR TITLE
FIX: enabling page-mod on file urls needs an explicit matcher

### DIFF
--- a/dist_firefox/lib/tomster-tabs.js
+++ b/dist_firefox/lib/tomster-tabs.js
@@ -79,6 +79,7 @@ module.exports = tomsterTabs;
 // ember debug messages when needed
 let pageMod = PageMod({
   include: "*",
+  include: ["*", "file://*"],
   attachTo: ["top", "frame", "existing"],
   contentScriptFile: data.url('content-script.js'),
   contentScriptOptions: {


### PR DESCRIPTION
small fix needed to enable file urls on page-mod in the Firefox addon.

to be merged into #182
