### PR TITLE
Fix Missing Scrollbars

### DIFF
--- a/css/fake_table.css
+++ b/css/fake_table.css
@@ -3,13 +3,6 @@
   display: flex;
   -webkit-flex-direction: row;
   flex-direction: row;
-
-  /*
-     Fixes chrome repaint issue when scrolling quickly in list-view.
-     See http://stackoverflow.com/a/16474152/1765925
-  */
-  -webkit-transform: translate3d(0, 0, 0);
-
 }
 
 .cell {


### PR DESCRIPTION
This fixes a bug where scrollbars go missing (or appear beneath list view items).

It removes a CSS hack that was used to fix a Chrome rendering bug (see http://stackoverflow.com/a/16474152/1765925). The StackOverflow question has been updated mentioning that the Chrome bug has since been fixed. Removing the hack doesn’t appear to affect rendering during scrolling.

Before:

![screen shot 2014-09-10 at 09 10 12](https://cloud.githubusercontent.com/assets/111734/4215501/09d6dc46-38cf-11e4-8845-d53b695947e7.png)

After:

![screen shot 2014-09-10 at 09 09 53](https://cloud.githubusercontent.com/assets/111734/4215503/15d388aa-38cf-11e4-886d-1f1beda34ce5.png)
