### PR TITLE
Add link to GitHub issues

### DIFF
--- a/app/templates/main.handlebars
+++ b/app/templates/main.handlebars
@@ -8,6 +8,11 @@
     <div class="split__panel__bd">
       {{partial "nav"}}
     </div>
+    <div class="split__panel__ft">
+      <a target="_blank" href="https://github.com/emberjs/ember-inspector/issues">
+        Submit an Issue
+      </a>
+    </div>
   {{/draggable-column}}
 
   <div class="split__panel">

--- a/css/split.css
+++ b/css/split.css
@@ -45,6 +45,8 @@
   display: flex;
   -webkit-flex: none;
   flex: none;
+  -webkit-flex-direction: column;
+  flex-direction: column;
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -55,8 +57,6 @@
 }
 
 .split__panel__hd {
-  -webkit-flex-direction: column;
-  flex-direction: column;
   border-bottom-width: 1px;
   border-bottom-style: solid;
   background: #fff;
@@ -87,6 +87,10 @@
 
 .split__panel--sidebar-1 .split__panel__bd {
   background: #e8e8e8;
+}
+
+.split__panel--sidebar-1 > .split__panel__ft {
+  text-align: center;
 }
 
 .split__panel--sidebar-2 .split__panel__bd {


### PR DESCRIPTION
(To encourage users to file issues.)

The link sits in the bottom of the main navigation column. It links to the issues index page to help reduce duplicate issues.

![screen shot 2014-09-21 at 22 56 26](https://cloud.githubusercontent.com/assets/111734/4350185/53661890-41da-11e4-97b7-5f71ff121d5e.png)
