### PR TITLE
FIX: eval in-page-script.js instead of injecting it using a script tag

### DIFF
--- a/dist_firefox/data/content-script.js
+++ b/dist_firefox/data/content-script.js
@@ -27,7 +27,6 @@ function init() {
 }
 
 function onCleanupListeners() {
-  console.debug("DETACHING CONTENT SCRIPT", window.location && window.location.href);
   try {
     window.removeEventListener("message", onEmberVersion, true);
   } catch(e) {}
@@ -51,17 +50,20 @@ function onEmberVersion(message) {
 
 function onInjectEmberDebug() {
   //console.debug("ON INJECT EMBER DEBUG ON:", window.location.href);
-  // NOTE: evalInWindow needs Firefox >= 30.0
-  evalInWindow(self.options.emberDebugScript, unsafeWindow);
+  try {
+    evalInWindow(self.options.emberDebugScript, unsafeWindow);
+  } catch(e) {
+    console.error("evalInWindow is not supported on this Firefox version", e);
+  }
 }
 
 function injectInPageScript() {
   if (window.document.readyState == "complete") {
-    // inject JS into the page to check for an app on domready
-    var script = document.createElement('script');
-    script.type = "text/javascript";
-    script.src = self.options.inPageScriptURL;
-    if (document.body) document.body.appendChild(script);
+    try {
+      evalInWindow(self.options.emberInPageScript, unsafeWindow);
+    } catch(e) {
+      console.error("evalInWindow is not supported on this Firefox version", e);
+    }
   } else {
     setTimeout(injectInPageScript, 100);
   }

--- a/dist_firefox/lib/tomster-tabs.js
+++ b/dist_firefox/lib/tomster-tabs.js
@@ -83,8 +83,8 @@ let pageMod = PageMod({
   attachTo: ["top", "frame", "existing"],
   contentScriptFile: data.url('content-script.js'),
   contentScriptOptions: {
-    inPageScriptURL: data.url('in-page-script.js'),
-    emberDebugScript: data.load("ember_debug/ember_debug.js")
+    emberDebugScript: data.load("ember_debug/ember_debug.js"),
+    emberInPageScript: data.load("in-page-script.js")
   },
   contentScriptWhen: "start",
   onAttach: (worker) => {


### PR DESCRIPTION
This small change should fix #225 

NOTE: Unfortunately _evalInWindow_ will be dropped by Firefox >= 34 (https://bugzilla.mozilla.org/show_bug.cgi?id=1042840), in the mean time I'm working on a better solution then using unsafeWindow.eval (which is too risky to be called on every navigated webpage by the user browser).
