### PR TITLE
Make promise tracing opt-in for better performance

### DIFF
--- a/app/controllers/promise_tree.js
+++ b/app/controllers/promise_tree.js
@@ -35,6 +35,14 @@ export default Ember.ArrayController.extend({
   neverCleared: not('wasCleared'),
   shouldRefresh: and('isEmpty', 'neverCleared'),
 
+  // Keep track of promise stack traces.
+  // It is opt-in due to performance reasons.
+  instrumentWithStack: false,
+
+  stackChanged: function() {
+    this.port.send('promise:setInstrumentWithStack', { instrumentWithStack: this.get('instrumentWithStack') });
+  }.observes('instrumentWithStack').on('init'),
+
   init: function() {
     // List-view does not support item controllers
     this.reopen({

--- a/app/models/promise.js
+++ b/app/models/promise.js
@@ -1,5 +1,9 @@
 import escapeRegExp from "utils/escape_reg_exp";
 var typeOf = Ember.typeOf;
+var computed = Ember.computed;
+var or = computed.or;
+var equal = computed.equal;
+var not = computed.not;
 
 var dateComputed = function() {
   return Ember.computed(
@@ -29,13 +33,13 @@ export default Ember.Object.extend({
     return parent.get('level') + 1;
   }.property('parent.level'),
 
-  isSettled: Ember.computed.or('isFulfilled', 'isRejected'),
+  isSettled: or('isFulfilled', 'isRejected'),
 
-  isFulfilled: Ember.computed.equal('state', 'fulfilled'),
+  isFulfilled: equal('state', 'fulfilled'),
 
-  isRejected: Ember.computed.equal('state', 'rejected'),
+  isRejected: equal('state', 'rejected'),
 
-  isPending: Ember.computed.not('isSettled'),
+  isPending: not('isSettled'),
 
   children: function() {
     return [];

--- a/app/templates/promise_item.handlebars
+++ b/app/templates/promise_item.handlebars
@@ -7,9 +7,11 @@
       </span>
     </div>
     <div class="list-tree__right-helper">
-      <div class="send-trace-to-console" {{action "tracePromise" model}} title="Trace promise in console" data-label="trace-promise-btn">
-        Trace
-      </div>
+      {{#if hasStack}}
+        <div class="send-trace-to-console" {{action "tracePromise" model}} title="Trace promise in console" data-label="trace-promise-btn">
+          Trace
+        </div>
+      {{/if}}
     </div>
   </div>
   <div class="cell cell_size_medium">

--- a/app/templates/promise_tree_toolbar.handlebars
+++ b/app/templates/promise_tree_toolbar.handlebars
@@ -14,4 +14,9 @@
   <button data-label="filter" {{bind-attr class="isRejectedFilter:active :toolbar__radio"}} {{action "setFilter" "rejected"}} >Rejected</button>
   <button data-label="filter" {{bind-attr class="isPendingFilter:active :toolbar__radio"}} {{action "setFilter" "pending"}} >Pending</button>
   <button data-label="filter" {{bind-attr class="isFulfilledFilter:active :toolbar__radio"}} {{action "setFilter" "fulfilled"}} >Fulfilled</button>
+
+
+  <div class="toolbar__checkbox" data-label="with-stack">
+    {{input type="checkbox" checked=instrumentWithStack id="instrument-with-stack"}} <label for="instrument-with-stack">Trace promises</label>
+  </div>
 </div>

--- a/ember_debug/promise_debug.js
+++ b/ember_debug/promise_debug.js
@@ -70,6 +70,10 @@ var PromiseDebug = Ember.Object.extend(PortMixin, {
         stack.splice(0, 2, ['Ember Inspector (Promise Trace): ' + (promise.get('label') || '')]);
         this.get("adapter").log(stack.join("\n"));
       }
+    },
+
+    setInstrumentWithStack: function(message) {
+      Ember.RSVP.configure('instrument-with-stack', message.instrumentWithStack);
     }
   },
 
@@ -148,6 +152,7 @@ var PromiseDebug = Ember.Object.extend(PortMixin, {
     if (promise.get('settledAt')) {
       serialized.settledAt = promise.get('settledAt').getTime();
     }
+    serialized.hasStack = !!promise.get('stack');
     return serialized;
   },
 

--- a/test/ember_extension/promise_test.js
+++ b/test/ember_extension/promise_test.js
@@ -11,7 +11,8 @@ function generatePromise(props) {
     state: 'created',
     value: null,
     reason: null,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    hasStack: false
   }, props);
 }
 
@@ -248,12 +249,12 @@ test("Chained promises", function() {
   });
 });
 
-test("Trace", function() {
+test("Can trace promise when there is a stack", function() {
   visit('/promises');
 
   andThen(function() {
     port.trigger('promise:promisesUpdated', {
-      promises: [generatePromise({ guid: 1 })]
+      promises: [generatePromise({ guid: 1, hasStack: true })]
     });
     wait();
   });
@@ -267,6 +268,40 @@ test("Trace", function() {
 
 });
 
+
+test("Trace button hidden if promise has no stack", function() {
+  visit('/promises');
+
+  andThen(function() {
+    port.trigger('promise:promisesUpdated', {
+      promises: [generatePromise({ guid: 1, hasStack: false })]
+    });
+    wait();
+  });
+
+  andThen(function() {
+    equal(findByLabel('trace-promise-btn').length, 0);
+  });
+
+});
+
+test("Toggling promise trace option", function() {
+  expect(3);
+
+  visit('/promises');
+
+  andThen(function() {
+    var input = findByLabel('with-stack').find('input');
+    ok(!input.prop('checked'), 'should not be checked by default');
+    return click(input);
+  });
+
+  andThen(function() {
+    equal(name, 'promise:setInstrumentWithStack');
+    equal(message.instrumentWithStack, true);
+  });
+
+});
 
 test("Logging error stack trace in the console", function() {
   visit('/promises');


### PR DESCRIPTION
RSVP used to send a stack trace with every promise by default.   Now is is disabled by default due to the high performance cost.

This PR adds a checkbox called "Trace promises" to enable the RSVP flag `instrument-with-promises` to start storing stack traces along with promise info. 

https://github.com/tildeio/rsvp.js/pull/303

cc @stefanpenner 
