### PR TITLE
Improve ApplicationView detection in ViewDebug

### DIFF
--- a/ember_debug/view_debug.js
+++ b/ember_debug/view_debug.js
@@ -13,6 +13,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
 
   namespace: null,
 
+  application: oneWay('namespace.application').readOnly(),
   adapter: oneWay('namespace.adapter').readOnly(),
   port: oneWay('namespace.port').readOnly(),
   objectInspector: oneWay('namespace.objectInspector').readOnly(),
@@ -231,7 +232,13 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
   },
 
   viewTree: function() {
-    var rootView = Ember.View.views[$('.ember-application > .ember-view').attr('id')];
+    var emberApp = this.get('application');
+    if (!emberApp) {
+      return false;
+    }
+
+    var applicationViewId = $(emberApp.rootElement).find('> .ember-view').attr('id');
+    var rootView = Ember.View.views[applicationViewId];
     // In case of App.reset view is destroyed
     if (!rootView) {
       return false;

--- a/test/ember_debug/view_tree_test.js
+++ b/test/ember_debug/view_tree_test.js
@@ -253,3 +253,29 @@ test("Supports a view with a string as model", function() {
     equal(message.tree.children[0].value.model.type, 'type-string');
   });
 });
+
+test("Supports applications that don't have the ember-application CSS class", function() {
+  var name = null, message = null,
+      $rootElement = $('body');
+
+  visit('/simple')
+  .then(function() {
+    ok($rootElement.hasClass('ember-application'), "The rootElement has the .ember-application CSS class");
+    $rootElement.removeClass('ember-application');
+
+    // Restart the inspector
+    EmberDebug.start();
+    port = EmberDebug.port;
+
+    port.reopen({
+      send: function(n, m) {
+        name = n;
+        message = m;
+      }
+    });
+  });
+  visit('/simple')
+  .then(function() {
+    equal(name, 'view:viewTree');
+  });
+});


### PR DESCRIPTION
Stops relying on the `ember-application` CSS class and uses the application's `rootElement` instead.

Fixes #135 
