### PR TITLE
Websocket adapter for use with ember-cli-remote-inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ dist_bookmarklet/vendor/
 dist_bookmarklet/panes/ember_extension.css
 dist_bookmarklet/panes/ember_extension.js
 
+dist_websocket/images/
+dist_websocket/ember_debug/
+dist_websocket/vendor/
+dist_websocket/panes/ember_extension.css
+dist_websocket/panes/ember_extension.js
+
 .mozilla-addon-sdk
 
 aws.json

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -39,7 +39,9 @@ module.exports = function(grunt) {
     'copy:firefox_extension',
     'wrap:firefox_ember_debug',
     'copy:bookmarklet_extension',
-    'wrap:bookmarklet_ember_debug'
+    'wrap:bookmarklet_ember_debug',
+    'copy:websocket_extension',
+    'wrap:websocket_ember_debug'
   ]);
 
   grunt.registerTask('build_ember_debug', [

--- a/app/adapters/websocket.js
+++ b/app/adapters/websocket.js
@@ -1,0 +1,38 @@
+import BasicAdapter from "adapters/basic";
+
+var computed = Ember.computed;
+
+var WebsocketAdapter = BasicAdapter.extend({
+  init: function() {
+    this._super();
+    this._connect();
+  },
+
+  sendMessage: function(options) {
+    options = options || {};
+    this.get('socket').emit('emberInspectorMessage', options);
+  },
+
+  socket: computed(function() {
+    return window.EMBER_INSPECTOR_CONFIG.remoteDebugSocket;
+  }).property(),
+
+  _connect: function() {
+    var self = this;
+    this.get('socket').on('emberInspectorMessage', function(message) {
+      Ember.run(function() {
+        self._messageReceived(message);
+      });
+    });
+  },
+  
+  _disconnect: function() {
+    this.get('socket').removeAllListeners("emberInspectorMessage");
+  },
+
+  willDestroy: function() {
+    this._disconnect();
+  }
+});
+
+export default WebsocketAdapter;

--- a/dist_websocket/panes/index.html
+++ b/dist_websocket/panes/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="/vendor/loader.js"></script>
+    <script src="/vendor/resolver.js"></script>
+    <script src="/vendor/jquery.js"></script>
+    <script src="/vendor/handlebars.js"></script>
+    <script src="/vendor/ember.prod.js"></script>
+    <script src="/vendor/list-view.prod.js"></script>
+    <script src="/panes/ember_extension.js"></script>
+    {{ remote-port }}
+    <script src="/panes/start.js"></script>
+    <link href="/panes/ember_extension.css" rel="stylesheet">
+  </head>
+  <body>
+  </body>
+</html>

--- a/dist_websocket/panes/start.js
+++ b/dist_websocket/panes/start.js
@@ -1,0 +1,3 @@
+window.EmberExtension = requireModule('app')['default'].create({
+  adapter: 'websocket'
+});

--- a/ember_debug/adapters/websocket.js
+++ b/ember_debug/adapters/websocket.js
@@ -1,0 +1,38 @@
+import BasicAdapter from "adapters/basic";
+
+var computed = Ember.computed;
+
+var WebsocketAdapter = BasicAdapter.extend({
+  init: function() {
+    this._super();
+    this._connect();
+  },
+
+  sendMessage: function(options) {
+    options = options || {};
+    this.get('socket').emit('emberInspectorMessage', options);
+  },
+
+  socket: computed(function() {
+    return window.EMBER_INSPECTOR_CONFIG.remoteDebugSocket;
+  }).property(),
+
+  _connect: function() {
+    var self = this;
+    this.get('socket').on('emberInspectorMessage', function(message) {
+      Ember.run(function() {
+        self._messageReceived(message);
+      });
+    });
+  },
+  
+  _disconnect: function() {
+    this.get('socket').removeAllListeners("emberInspectorMessage");
+  },
+
+  willDestroy: function() {
+    this._disconnect();
+  }
+});
+
+export default WebsocketAdapter;

--- a/ember_debug/vendor/startup_wrapper.js
+++ b/ember_debug/vendor/startup_wrapper.js
@@ -98,7 +98,7 @@ if (typeof adapter !== 'undefined') {
     }
     var documentElement = document.documentElement;
     var interval = setInterval(function() {
-      if (documentElement.dataset.emberExtension && Ember.BOOTED) {
+      if ((documentElement.dataset.emberExtension || (EMBER_INSPECTOR_CONFIG && EMBER_INSPECTOR_CONFIG.remoteDebugSocket)) && Ember.BOOTED) {
        clearInterval(interval);
        callback();
       }

--- a/tasks/options/copy.js
+++ b/tasks/options/copy.js
@@ -70,6 +70,25 @@ module.exports = {
       dest: 'dist_bookmarklet/panes/ember_extension.css'
     }]
   },
+  websocket_extension: {
+    files: [{
+      src: ['tmp/public/ember_extension.js'],
+      dest: 'dist_websocket/panes/ember_extension.js'
+    }, {
+      expand: true,
+      cwd: 'vendor',
+      src: ['**'],
+      dest: 'dist_websocket/vendor/'
+    }, {
+      expand: true,
+      cwd: 'dist_common/images',
+      src: ['**'],
+      dest: 'dist_websocket/images/'
+    }, {
+      src: ['tmp/public/ember_extension.css'],
+      dest: 'dist_websocket/panes/ember_extension.css'
+    }]
+  },  
   tests: {
     files: [
     {

--- a/tasks/options/wrap.js
+++ b/tasks/options/wrap.js
@@ -19,5 +19,12 @@ module.exports = {
     options: {
       wrapper: ['(function(adapter) {\n', '\n}("bookmarklet"))']
     }
+  },
+  websocket_ember_debug: {
+    src: ['tmp/public/ember_debug.js'],
+    dest: 'dist_websocket/ember_debug/ember_debug.js',
+    options: {
+      wrapper: ['(function(adapter) {\n', '\n}("websocket"))']
+    }
   }
 };


### PR DESCRIPTION
**Still WIP but ready for first feedback**

Closes #235 - VERY related to https://github.com/joostdevries/ember-cli-remote-inspector
#### Added a websocket adapter to both the inspector and ember-debug.

This adapter uses a global called `remoteDebugSocket` which is set by the ember-cli-remote-debug addon.
#### Added a `_disconnect` method to the adapter

Needed to cleanup when changing what app to inspect. This is called right before `app.reset`
#### Added build tasks + dist for websocket version

By doing this, `ember-cli-remote-inspector` can just list the latest version from ember inspector as a dependency and work from there.

Not done (yet):
- Tests
- Documentation
