### PR TITLE
use "document.defaultView.eval" in place of deprecated evalInWindow

### DIFF
--- a/dist_firefox/data/content-script.js
+++ b/dist_firefox/data/content-script.js
@@ -50,20 +50,12 @@ function onEmberVersion(message) {
 
 function onInjectEmberDebug() {
   //console.debug("ON INJECT EMBER DEBUG ON:", window.location.href);
-  try {
-    evalInWindow(self.options.emberDebugScript, unsafeWindow);
-  } catch(e) {
-    console.error("evalInWindow is not supported on this Firefox version", e);
-  }
+  document.defaultView.eval(self.options.emberDebugScript);
 }
 
 function injectInPageScript() {
   if (window.document.readyState == "complete") {
-    try {
-      evalInWindow(self.options.emberInPageScript, unsafeWindow);
-    } catch(e) {
-      console.error("evalInWindow is not supported on this Firefox version", e);
-    }
+    document.defaultView.eval(self.options.emberInPageScript);
   } else {
     setTimeout(injectInPageScript, 100);
   }


### PR DESCRIPTION
document.defaultView.eval works like evalInWindow on Firefox >= 34 
and it works correctly even on previous Firefox versions.
(tested on Firefox >= 29)

fix #233
