### PR TITLE
update the icon url to the new location (Firefox addon)

### DIFF
--- a/dist_firefox/lib/tomster-devtool-panel.js
+++ b/dist_firefox/lib/tomster-devtool-panel.js
@@ -27,11 +27,10 @@ exports.openEmberInspector = function () {
 exports.devtoolTabDefinition = {
   id: "ember-inspector",
   ordinal: 7,
-  icon: self.data.url("images/icon19.png"),
+  icon: self.data.url("panes/assets/images/icon19.png"),
   url: self.data.url("devtool-panel.html"),
   label: "Ember",
   tooltip: "Ember Inspector",
-
   isTargetSupported: function(target) {
     return target.isLocalTab;
   },

--- a/dist_firefox/lib/tomster-locationbar-button.js
+++ b/dist_firefox/lib/tomster-locationbar-button.js
@@ -20,7 +20,7 @@ function enable() {
 
   button = UrlbarButton({
     id: TOMSTER_BUTTON_ID,
-    image : data.url("images/icon19.png"),
+    image : data.url("panes/assets/images/icon19.png"),
     // TODO: Warning for a panel hooked to a locationbar button:
     // "Passing a DOM node to Panel.show() method is an unsupported feature
     //  that will be soon replaced. See:


### PR DESCRIPTION
This small change update the location of the devtool panel and locationbar tomster icons (and fix the missing icon in the Firefox addon)
