### PR TITLE
EmberDebug should start before the application initializes

### DIFF
--- a/app/adapters/chrome.js
+++ b/app/adapters/chrome.js
@@ -37,8 +37,7 @@ export default  BasicAdapter.extend({
   }.on('init'),
 
   _injectDebugger: function() {
-    loadEmberDebug();
-    chrome.devtools.inspectedWindow.eval(emberDebug);
+    chrome.devtools.inspectedWindow.eval(loadEmberDebug());
     chrome.devtools.inspectedWindow.onResourceAdded.addListener(function(opts) {
       if (opts.type === 'document') {
         sendIframes([opts.url]);
@@ -48,13 +47,22 @@ export default  BasicAdapter.extend({
 
   willReload: function() {
     this._injectDebugger();
+  },
+
+  /**
+    We handle the reload here so we can inject
+    scripts as soon as possible into the new page.
+  */
+  reloadTab: function() {
+    chrome.devtools.inspectedWindow.reload({
+      injectedScript: loadEmberDebug()
+    });
   }
 });
 
 function sendIframes(urls) {
-  loadEmberDebug();
   urls.forEach(function(url) {
-    chrome.devtools.inspectedWindow.eval(emberDebug, { frameURL: url });
+    chrome.devtools.inspectedWindow.eval(loadEmberDebug(), { frameURL: url });
   });
 }
 
@@ -66,4 +74,5 @@ function loadEmberDebug() {
     xhr.send();
     emberDebug = xhr.responseText;
   }
+  return emberDebug;
 }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -62,10 +62,16 @@ export default Ember.Route.extend({
       this.set('controller.isDragging', isDragging);
     },
     refreshPage: function() {
-      this.get('port').send('general:refresh');
-      // inject ember_debug as quickly as possible in chrome
-      // so that promises created on dom ready are caught
-      this.get('adapter').willReload();
+      // If the adapter defined a `reloadTab` method, it means
+      // they prefer to handle the reload themselves
+      if (typeof this.get('adapter').reloadTab === 'function') {
+        this.get('adapter').reloadTab();
+      } else {
+        // inject ember_debug as quickly as possible in chrome
+        // so that promises created on dom ready are caught
+        this.get('port').send('general:refresh');
+        this.get('adapter').willReload();
+      }
     }
   }
 });

--- a/app/templates/promise-tree-toolbar.handlebars
+++ b/app/templates/promise-tree-toolbar.handlebars
@@ -15,8 +15,17 @@
   <button data-label="filter" {{bind-attr class="isPendingFilter:active :toolbar__radio"}} {{action "setFilter" "pending"}} >Pending</button>
   <button data-label="filter" {{bind-attr class="isFulfilledFilter:active :toolbar__radio"}} {{action "setFilter" "fulfilled"}} >Fulfilled</button>
 
+  <div class="divider"></div>
 
   <div class="toolbar__checkbox" data-label="with-stack">
     {{input type="checkbox" checked=instrumentWithStack id="instrument-with-stack"}} <label for="instrument-with-stack">Trace promises</label>
   </div>
+
+
+  {{! if should refresh the refresh button will be in the middle of the of the tab }}
+  {{#unless shouldRefresh}}
+    <div class="divider"></div>
+    <button data-label="toolbar-page-refresh-btn" {{action "refreshPage"}}>Reload</button>
+  {{/unless}}
+
 </div>

--- a/app/templates/render-tree-toolbar.handlebars
+++ b/app/templates/render-tree-toolbar.handlebars
@@ -4,4 +4,10 @@
     {{input value=searchField placeholder="Search"}}
   </div>
   <div class="filter-bar__pills"></div>
+
+  {{#unless showEmpty}}
+    <div class="divider"></div>
+    <button data-label="toolbar-page-refresh-btn" {{action "refreshPage"}}>Reload</button>
+  {{/unless}}
+
 </div>

--- a/app/templates/render-tree.handlebars
+++ b/app/templates/render-tree.handlebars
@@ -21,7 +21,9 @@
 </div>
 {{else}}
   <div class="notice" data-label="render-tree-empty">
-    <p>No rendering metrics have been collected. Try navigating around your application.</p>
+    <p>No rendering metrics have been collected. Try reloading or navigating around your application.</p>
     <p><strong>Note:</strong> Very fast rendering times (&lt;1ms) are excluded.</p>
+    <button data-label="toolbar-page-refresh-btn" {{action "refreshPage"}}>Reload</button>
+
   </div>
 {{/unless}}

--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -1,11 +1,24 @@
 var Ember = window.Ember;
-var BasicAdapter = Ember.Object.extend({
+var computed = Ember.computed;
+var $ = Ember.$;
+var Promise = Ember.RSVP.Promise;
+
+export default Ember.Object.extend({
+  init: function() {
+    var self = this;
+    Promise.resolve(this.connect(), 'ember-inspector').then(function() {
+      self.onConnectionReady();
+    }, null, 'ember-inspector');
+  },
+
   debug: function() {
     console.debug.apply(console, arguments);
   },
+
   log: function() {
     console.log.apply(console, arguments);
   },
+
   /**
     Used to send messages to EmberExtension
 
@@ -42,7 +55,60 @@ var BasicAdapter = Ember.Object.extend({
     this.get('_messageCallbacks').forEach(function(callback) {
       callback.call(null, message);
     });
+  },
+
+  /**
+
+    A promise that resolves when the connection
+    with the inspector is set up and ready.
+
+    @return {Promise}
+  */
+  connect: function() {
+    var self = this;
+    return new Promise(function(resolve, reject) {
+      $(function() {
+        if (self.isDestroyed) { reject(); }
+        self.interval = setInterval(function() {
+          if (document.documentElement.dataset.emberExtension) {
+            clearInterval(self.interval);
+            resolve();
+          }
+        }, 10);
+      });
+    }, 'ember-inspector');
+  },
+
+  willDestroy: function() {
+    this._super();
+    clearInterval(this.interval);
+  },
+
+  _isReady: false,
+  _pendingMessages: computed(function() { return Ember.A(); }).property(),
+
+  send: function(options) {
+    if (this._isReady) {
+      this.sendMessage.apply(this, arguments);
+    } else {
+      this.get('_pendingMessages').push(options);
+    }
+  },
+
+  /**
+    Called when the connection is set up.
+    Flushes the pending messages.
+  */
+  onConnectionReady: function() {
+    // Flush pending messages
+    var self = this;
+    var messages = this.get('_pendingMessages');
+    messages.forEach(function(options) {
+      self.sendMessage(options);
+    });
+    messages.clear();
+    this._isReady = true;
   }
+
 });
 
-export default BasicAdapter;

--- a/ember_debug/adapters/bookmarklet.js
+++ b/ember_debug/adapters/bookmarklet.js
@@ -5,7 +5,7 @@ var $ = Ember.$;
 export default BasicAdapter.extend({
   init: function() {
     this._super();
-    this._connect();
+    this._listen();
   },
 
   sendMessage: function(options) {
@@ -13,7 +13,7 @@ export default BasicAdapter.extend({
     window.emberInspector.w.postMessage(options, window.emberInspector.url);
   },
 
-  _connect: function() {
+  _listen: function() {
     var self = this;
     window.addEventListener('message', function(e) {
       if (e.origin !== window.emberInspector.url) {

--- a/ember_debug/adapters/chrome.js
+++ b/ember_debug/adapters/chrome.js
@@ -2,9 +2,13 @@ import BasicAdapter from "./basic";
 var Ember = window.Ember;
 
 var ChromeAdapter = BasicAdapter.extend({
-  init: function() {
-    this._super();
-    this._connect();
+  connect: function() {
+    var channel = this.get('_channel');
+    var self = this;
+    return this._super.apply(this, arguments).then(function() {
+      window.postMessage('debugger-client', [channel.port2], '*');
+      self._listen();
+    }, null, 'ember-inspector');
   },
 
   sendMessage: function(options) {
@@ -19,18 +23,15 @@ var ChromeAdapter = BasicAdapter.extend({
 
   _channel: Ember.computed(function() {
     return new MessageChannel();
-  }).property(),
+  }).property().readOnly(),
 
   _chromePort: Ember.computed(function() {
     return this.get('_channel.port1');
-  }).property(),
+  }).property().readOnly(),
 
-  _connect: function() {
-    var channel = this.get('_channel'),
-        self = this,
+  _listen: function() {
+    var self = this,
         chromePort = this.get('_chromePort');
-
-    window.postMessage('debugger-client', [channel.port2], '*');
 
     chromePort.addEventListener('message', function(event) {
       var message = event.data;

--- a/ember_debug/adapters/firefox.js
+++ b/ember_debug/adapters/firefox.js
@@ -4,7 +4,7 @@ var Ember = window.Ember;
 var FirefoxAdapter = BasicAdapter.extend({
   init: function() {
     this._super();
-    this._connect();
+    this._listen();
   },
 
   debug: function() {
@@ -40,7 +40,7 @@ var FirefoxAdapter = BasicAdapter.extend({
     });
   },
 
-  _connect: function() {
+  _listen: function() {
     var self = this;
 
     window.addEventListener('ember-debug-receive', function(event) {

--- a/ember_debug/adapters/websocket.js
+++ b/ember_debug/adapters/websocket.js
@@ -1,12 +1,10 @@
 import BasicAdapter from "./basic";
 var Ember = window.Ember;
 var computed = Ember.computed;
+var Promise = Ember.RSVP.Promise;
+var $ = Ember.$;
 
 var WebsocketAdapter = BasicAdapter.extend({
-  init: function() {
-    this._super();
-    this._connect();
-  },
 
   sendMessage: function(options) {
     options = options || {};
@@ -17,7 +15,7 @@ var WebsocketAdapter = BasicAdapter.extend({
     return window.EMBER_INSPECTOR_CONFIG.remoteDebugSocket;
   }).property(),
 
-  _connect: function() {
+  _listen: function() {
     var self = this;
     this.get('socket').on('emberInspectorMessage', function(message) {
       Ember.run(function() {
@@ -28,6 +26,21 @@ var WebsocketAdapter = BasicAdapter.extend({
 
   _disconnect: function() {
     this.get('socket').removeAllListeners("emberInspectorMessage");
+  },
+
+  connect: function() {
+    var self = this;
+    return new Promise(function(resolve, reject) {
+      $(function() {
+        if (self.isDestroyed) { reject(); }
+        var EMBER_INSPECTOR_CONFIG = window.EMBER_INSPECTOR_CONFIG;
+        if (typeof EMBER_INSPECTOR_CONFIG === 'object' && EMBER_INSPECTOR_CONFIG.remoteDebugSocket) {
+          resolve();
+        }
+      });
+    }).then(function() {
+      self._listen();
+    });
   },
 
   willDestroy: function() {

--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -13,7 +13,7 @@ var GeneralDebug = Ember.Object.extend(PortMixin, {
 
   sendBooted: function() {
     this.sendMessage('applicationBooted', {
-      booted: Ember.BOOTED
+      booted: Ember.BOOTED || this.get('application.booted')
     });
   },
 
@@ -23,7 +23,7 @@ var GeneralDebug = Ember.Object.extend(PortMixin, {
     },
     getLibraries: function() {
       var libraries = Ember.libraries;
-      
+
       // Ember has changed where the array of libraries is located.
       // In older versions, `Ember.libraries` was the array itself,
       // but now it's found under _registry.

--- a/ember_debug/libs/promise-assembler.js
+++ b/ember_debug/libs/promise-assembler.js
@@ -7,7 +7,6 @@
 
 import Promise from '/ember-debug/models/promise';
 var Ember = window.Ember;
-var alias = Ember.computed.alias;
 
 var PromiseAssembler = Ember.Object.extend(Ember.Evented, {
   // RSVP lib to debug
@@ -19,9 +18,6 @@ var PromiseAssembler = Ember.Object.extend(Ember.Evented, {
 
   // injected on creation
   promiseDebug: null,
-
-  existingEvents: alias('promiseDebug.existingEvents'),
-  existingCallbacks: alias('promiseDebug.existingCallbacks'),
 
   start: function() {
     this.RSVP.configure('instrument', true);
@@ -40,22 +36,11 @@ var PromiseAssembler = Ember.Object.extend(Ember.Evented, {
       create.bind(self)(e);
     };
 
-
     this.RSVP.on('chained', this.promiseChained);
     this.RSVP.on('rejected', this.promiseRejected);
     this.RSVP.on('fulfilled', this.promiseFulfilled);
     this.RSVP.on('created',  this.promiseCreated);
 
-    if (this.get('existingEvents')) {
-      var callbacks = this.get('existingCallbacks');
-      for (var eventName in callbacks) {
-        this.RSVP.off(eventName, callbacks[eventName]);
-      }
-      var events = Ember.A(this.get('existingEvents'));
-      events.forEach(function(e) {
-        self['promise' + Ember.String.capitalize(e.eventName)].call(self, e.options);
-      });
-    }
   },
 
   stop: function() {

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -19,14 +19,6 @@ EmberDebug = Ember.Namespace.extend({
   Port: Port,
   Adapter: BasicAdapter,
 
-
-  // These two are used to make RSVP start instrumentation
-  // even before this object is created
-  // all events triggered before creation are injected
-  // to this object as `existingEvents`
-  existingEvents: Ember.computed(function() { return []; }).property(),
-  existingCallbacks: Ember.computed(function() { return {}; }).property(),
-
   start: function() {
     if (this.get('started')) {
       this.reset();

--- a/ember_debug/port.js
+++ b/ember_debug/port.js
@@ -23,6 +23,6 @@ export default Ember.Object.extend(Ember.Evented, {
     options.type = messageType;
     options.from = 'inspectedWindow';
     options.applicationId = this.get('uniqueId');
-    this.get('adapter').sendMessage(options);
+    this.get('adapter').send(options);
   }
 });

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -1,17 +1,14 @@
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import PromiseAssembler from 'ember-debug/libs/promise-assembler';
 var Ember = window.Ember;
+var readOnly = Ember.computed.readOnly;
 
 var PromiseDebug = Ember.Object.extend(PortMixin, {
   namespace: null,
-  port: Ember.computed.alias('namespace.port'),
-  objectInspector: Ember.computed.alias('namespace.objectInspector'),
-  adapter: Ember.computed.alias('namespace.adapter'),
+  port: readOnly('namespace.port'),
+  objectInspector: readOnly('namespace.objectInspector'),
+  adapter: readOnly('namespace.adapter'),
   portNamespace: 'promise',
-
-
-  existingEvents: Ember.computed.alias('namespace.existingEvents'),
-  existingCallbacks: Ember.computed.alias('namespace.existingCallbacks'),
 
   // created on init
   promiseAssembler: null,
@@ -112,6 +109,10 @@ var PromiseDebug = Ember.Object.extend(PortMixin, {
         uniquePromises.addObject(promise);
       });
     }
+    // Remove inspector-created promises
+    uniquePromises = uniquePromises.filter(function(promise) {
+      return promise.get('label') !== 'ember-inspector';
+    });
     var serialized = this.serializeArray(uniquePromises);
     this.sendMessage('promisesUpdated', {
       promises: serialized


### PR DESCRIPTION
Several tabs (Promise, Render Speed) need to start logging the moment the application is initialized.
Instead of waiting for domready, we start EmberDebug immediately when the application initializes.

Things that require domready such as setting up connections are moved
to the adapter.

Fixes part of #273.
