### PR TITLE
Fix naming to account for module based names

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -26,10 +26,10 @@ module.exports = function(environment) {
 
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
-    ENV.APP.LOG_ACTIVE_GENERATION = true;
+    //ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
-    ENV.APP.LOG_VIEW_LOOKUPS = true;
+    //ENV.APP.LOG_VIEW_LOOKUPS = true;
   }
 
   if (environment === 'test') {

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -5,7 +5,6 @@ var EmberObject = Ember.Object;
 var computed = Ember.computed;
 var readOnly = computed.readOnly;
 var run = Ember.run;
-var $ = Ember.$;
 var guidFor = Ember.guidFor;
 
 export default EmberObject.extend(PortMixin, {
@@ -31,22 +30,7 @@ export default EmberObject.extend(PortMixin, {
     return SourceMap.create();
   }).property(),
 
-  // Keep an eye on https://github.com/ember-cli/ember-cli/issues/3045
-  emberCliConfig: computed(function() {
-    var config;
-    $('meta[name]').each(function() {
-      var meta = $(this);
-      var match = meta.attr('name').match(/environment$/);
-      if (match) {
-        try {
-          /* global unescape */
-          config = JSON.parse(unescape(meta.attr('content')));
-          return false;
-        } catch (e) {}
-      }
-    });
-    return config;
-  }).property(),
+  emberCliConfig: readOnly('namespace.generalDebug.emberCliConfig'),
 
   init: function() {
     this._super();

--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -1,15 +1,37 @@
 import PortMixin from "ember-debug/mixins/port-mixin";
 var Ember = window.Ember;
+var computed = Ember.computed;
+var readOnly = computed.readOnly;
+
 var GeneralDebug = Ember.Object.extend(PortMixin, {
   namespace: null,
 
-  port: Ember.computed.alias('namespace.port'),
+  port: readOnly('namespace.port'),
 
-  application: Ember.computed.alias('namespace.application'),
+  application: readOnly('namespace.application'),
 
-  promiseDebug: Ember.computed.alias('namespace.promiseDebug'),
+  promiseDebug: readOnly('namespace.promiseDebug'),
 
   portNamespace: 'general',
+
+  // Keep an eye on https://github.com/ember-cli/ember-cli/issues/3045
+  emberCliConfig: computed(function() {
+    var config;
+    var $ = Ember.$;
+    $('meta[name]').each(function() {
+      var meta = $(this);
+      var match = meta.attr('name').match(/environment$/);
+      if (match) {
+        try {
+          /* global unescape */
+          config = JSON.parse(unescape(meta.attr('content')));
+          return false;
+        } catch (e) {}
+      }
+    });
+    return config;
+  }).property(),
+
 
   sendBooted: function() {
     this.sendMessage('applicationBooted', {

--- a/tests/ember_debug/route_debug_test.js
+++ b/tests/ember_debug/route_debug_test.js
@@ -7,6 +7,7 @@ var App, run = Ember.run;
 
 function setupApp(){
   App = Ember.Application.create();
+  App.toString = function() { return 'App'; };
   App.setupForTesting();
   App.injectTestHelpers();
 
@@ -35,6 +36,9 @@ module("Route Tree Debug", {
       EmberDebug.set('application', App);
     });
     run(EmberDebug, 'start');
+    EmberDebug.get('generalDebug').reopen({
+      emberCliConfig: null
+    });
     port = EmberDebug.port;
   },
   teardown: function() {


### PR DESCRIPTION
The route tab class names now take into account: globals and modules and pod-modules.

Fixes #196