### PR TITLE
Only destroy the promise assembler if it exists

### DIFF
--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -34,7 +34,9 @@ export default EmberObject.extend(PortMixin, {
 
   willDestroy: function() {
     this.releaseAll();
-    this.get('promiseAssembler').destroy();
+    if (this.get('promiseAssembler')) {
+      this.get('promiseAssembler').destroy();
+    }
     this.set('promiseAssembler', null);
     this._super();
   },


### PR DESCRIPTION
Fixes #301