### PR TITLE
Fix errors when EXTEND_PROTOTYPES=false

### DIFF
--- a/ember_debug/libs/source-map.js
+++ b/ember_debug/libs/source-map.js
@@ -5,6 +5,7 @@
  */
 var Ember = window.Ember;
 var EmberObject = Ember.Object;
+var computed = Ember.computed;
 export default EmberObject.extend({
 
   map: function(stack) {
@@ -21,9 +22,9 @@ export default EmberObject.extend({
     });
   },
 
-  sourceMapCache: function() {
+  sourceMapCache: computed(function() {
     return {};
-  }.property(),
+  }),
 
   getSourceMap: function(url) {
     var sourceMaps = this.get('sourceMapCache');


### PR DESCRIPTION
Fixes #312.

This PR fixes an issue where `ember_debug/libs/source-map.js` assumes Ember's prototype extensions are enabled. If they aren't, then the inspector will crash upon loading.