### PR TITLE
Handle case where container type no longer exists after reload

### DIFF
--- a/app/routes/container-type.js
+++ b/app/routes/container-type.js
@@ -14,15 +14,25 @@ export default TabRoute.extend({
   model: function(params) {
     var type = params.type_id;
     var port = this.get('port');
-    return new Promise(function(resolve) {
-      port.one('container:instances', function(message) {
-        resolve(message.instances);
+    return new Promise((resolve, reject) => {
+      port.one('container:instances', message => {
+        if (message.status === 200) {
+          resolve(message.instances);
+        } else {
+          reject(message);
+        }
       });
       port.send('container:getInstances', { containerType: type });
     });
   },
 
+
   actions: {
+    error(err) {
+      if (err && err.status === 404) {
+        this.transitionTo('container-types.index');
+      }
+    },
     inspectInstance: function(obj) {
       if (!get(obj, 'inspectable')) {
         return;

--- a/ember_debug/container-debug.js
+++ b/ember_debug/container-debug.js
@@ -69,8 +69,11 @@ export default EmberObject.extend(PortMixin, {
   },
 
   getInstances: function(type) {
-    var instancesByType = this.instancesByType();
-    return instancesByType[type].map(function(item) {
+    var instances = this.instancesByType()[type];
+    if (!instances) {
+      return null;
+    }
+    return instances.map(function(item) {
       return {
         name: this.nameFromKey(item.fullName),
         fullName: item.fullName,
@@ -86,9 +89,17 @@ export default EmberObject.extend(PortMixin, {
       });
     },
     getInstances: function(message) {
-      this.sendMessage('instances', {
-        instances: this.getInstances(message.containerType)
-      });
+      var instances = this.getInstances(message.containerType);
+      if (instances) {
+        this.sendMessage('instances', {
+          instances: instances,
+          status: 200
+        });
+      } else {
+        this.sendMessage('instances', {
+          status: 404
+        });
+      }
     },
     sendInstanceToConsole: function(message) {
       var instance = this.get('container').lookup(message.name);

--- a/tests/ember_debug/container_debug_test.js
+++ b/tests/ember_debug/container_debug_test.js
@@ -74,5 +74,20 @@ test("#getInstances", function(assert) {
     assert.equal(name, 'container:instances');
     var instances = emberA(message.instances);
     assert.ok(instances.findBy('name', 'simple'));
+    assert.equal(message.status, 200);
+  });
+});
+
+test("#getInstances on a non existing type", function(assert) {
+  visit('/simple');
+
+  andThen(function() {
+    port.trigger('container:getInstances', { containerType: 'not-here' });
+    return wait();
+  });
+
+  andThen(function() {
+    assert.equal(name, 'container:instances');
+    assert.equal(message.status, 404);
   });
 });

--- a/tests/integration/container_test.js
+++ b/tests/integration/container_test.js
@@ -84,7 +84,7 @@ test("Container instances are successfully listed", function(assert) {
       }
 
       if (name === 'container:getInstances' && message.containerType === 'controller') {
-        this.trigger('container:instances', { instances: instances });
+        this.trigger('container:instances', { instances, status: 200 });
       }
     }
   });
@@ -123,6 +123,30 @@ test("Container instances are successfully listed", function(assert) {
 
 });
 
+test("Successfully redirects if the container type is not found", function(assert) {
+
+  port.reopen({
+    send(n, m) {
+      name = n;
+      message = m;
+      if (name === 'container:getTypes') {
+        this.trigger('container:types', { types: getTypes() });
+      }
+
+      if (name === 'container:getInstances' && message.containerType === 'random-type') {
+        this.trigger('container:instances', { status: 404 });
+      }
+    }
+  });
+
+  visit('/container-types/random-type');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/container-types');
+  });
+
+});
+
 test("Reload", function(assert) {
   var types = [], instances = [];
 
@@ -132,7 +156,7 @@ test("Reload", function(assert) {
         this.trigger('container:types', { types: types });
       }
       if (n === 'container:getInstances' && m.containerType === 'controller') {
-        this.trigger('container:instances', { instances: instances });
+        this.trigger('container:instances', { instances, status: 200 });
       }
     }
   });


### PR DESCRIPTION
If the container type does not exist we redirect back to the list of
container types.

Fixes https://github.com/emberjs/ember-inspector/issues/314