### PR TITLE
Handle and display errors caused by CP calculation in the object inspector

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -20,36 +20,37 @@ export default Ember.Controller.extend({
 
   inspectorExpanded: false,
 
-  pushMixinDetails: function(name, property, objectId, details) {
+  pushMixinDetails(name, property, objectId, details, errors) {
     details = {
-      name: name,
-      property: property,
-      objectId: objectId,
-      mixins: details
+      name,
+      property,
+      objectId,
+      mixins: details,
+      errors
     };
 
     this.get('mixinStack').pushObject(details);
     this.set('mixinDetails.model', details);
   },
 
-  popMixinDetails: function() {
+  popMixinDetails() {
     var mixinStack = this.get('controllers.mixin-stack');
     var item = mixinStack.popObject();
     this.set('mixinDetails.model', mixinStack.get('lastObject'));
     this.get('port').send('objectInspector:releaseObject', { objectId: item.objectId });
   },
 
-  activateMixinDetails: function(name, details, objectId) {
+  activateMixinDetails(name, objectId, details, errors) {
     var self = this;
     this.get('mixinStack').forEach(function(item) {
       self.get('port').send('objectInspector:releaseObject', { objectId: item.objectId });
     });
 
     this.set('mixinStack.model', []);
-    this.pushMixinDetails(name, undefined, objectId, details);
+    this.pushMixinDetails(name, undefined, objectId, details, errors);
   },
 
-  droppedObject: function(objectId) {
+  droppedObject(objectId) {
     var mixinStack = this.get('mixinStack.model');
     var obj = mixinStack.findProperty('objectId', objectId);
     if (obj) {

--- a/app/controllers/mixin-detail.js
+++ b/app/controllers/mixin-detail.js
@@ -5,7 +5,7 @@ export default Ember.ObjectController.extend({
   needs: ['mixin-details'],
 
   mixinDetails: oneWay('controllers.mixin-details').readOnly(),
-  objectId: oneWay('mixinDetails.objectId').readOnly(),
+  objectId: oneWay('mixinDetails.model.objectId').readOnly(),
 
   isExpanded: function() {
     return this.get('model.expand') && this.get('model.properties.length') > 0;
@@ -14,7 +14,7 @@ export default Ember.ObjectController.extend({
   actions: {
     calculate: function(property) {
       var objectId = this.get('objectId');
-      var mixinIndex = this.get('mixinDetails.mixins').indexOf(this.get('model'));
+      var mixinIndex = this.get('mixinDetails.model.mixins').indexOf(this.get('model'));
 
       this.get('port').send('objectInspector:calculate', {
         objectId: objectId,
@@ -46,7 +46,7 @@ export default Ember.ObjectController.extend({
     },
 
     saveProperty: function(prop, val, type) {
-      var mixinIndex = this.get('mixinDetails.mixins').indexOf(this.get('model'));
+      var mixinIndex = this.get('mixinDetails.model.mixins').indexOf(this.get('model'));
 
       this.get('port').send('objectInspector:saveProperty', {
         objectId: this.get('objectId'),

--- a/app/controllers/mixin-details.js
+++ b/app/controllers/mixin-details.js
@@ -1,2 +1,11 @@
 import Ember from "ember";
-export default Ember.ObjectController.extend();
+const { Controller } = Ember;
+export default Controller.extend({
+  actions: {
+    traceErrors() {
+      this.get('port').send('objectInspector:traceErrors', {
+        objectId: this.get('model.objectId')
+      });
+    }
+  }
+});

--- a/app/styles/mixin.scss
+++ b/app/styles/mixin.scss
@@ -53,6 +53,15 @@
     color: #aaa;
   }
 
+.mixin__name_errors {
+  background-color: #fff;
+
+  &:active{
+    background-color: #fff;
+  }
+}
+
+
 .mixin__properties {
   margin: 5px;
   list-style-type: none;
@@ -70,6 +79,12 @@
   flex-direction: row;
   -webkit-align-items: center;
   align-items: center;
+}
+
+.mixin__error {
+  margin-right: 3px;
+  padding: 0px 20px;
+  color: red;
 }
 
 .mixin__property button {

--- a/app/templates/mixin-details.hbs
+++ b/app/templates/mixin-details.hbs
@@ -1,4 +1,21 @@
-{{#each mixin in mixins itemController="mixinDetail"}}
+{{#if model.errors.length}}
+<div class="mixin mixin_props_no" data-label="object-inspector-errors">
+  <h2 class="mixin__name mixin__name_errors">
+    Errors
+    <span {{action "traceErrors"}} class="send-trace-to-console" data-label="send-errors-to-console">
+      Trace in the console
+    </span>
+  </h2>
+  <div class="mixin__properties">
+  {{#each model.errors as |error|}}
+    <div class="mixin__error" data-label="object-inspector-error">
+      Error while computing: {{error.property}}
+    </div>
+  {{/each}}
+  </div>
+</div>
+{{/if}}
+{{#each model.mixins itemController="mixinDetail" as |mixin|}}
 <div {{bind-attr class=":mixin mixin.type mixin.isExpanded:mixin_state_expanded mixin.properties.length:mixin_props_yes:mixin_props_no"}} data-label="object-detail" >
   {{#if mixin.properties.length}}
     <h2 class="mixin__name" {{action "toggleExpanded" target="mixin"}} data-label="object-detail-name">{{mixin.name}}</h2>


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember-inspector/issues/222

Opening an object in the inspector means we eagerly calculate all of that object's CPs. Sometimes CPs that don't expect to be calculated yet may throw an error (for example CPs that depend on another property that hasn't been set yet). 

Previously, the object inspector just wouldn't open, and the thrown errors were displayed in the app's console.

After this PR these errors are caught by the inspector and displayed above the object's properties.

![screen shot 2015-04-12 at 6 16 15 pm](https://cloud.githubusercontent.com/assets/1061742/7106120/1d06d1d0-e140-11e4-80c3-bb6f2f1ed3c9.png)

