### PR TITLE
Catch errors triggered by the inspector.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -130,7 +130,7 @@ emberDebug = concatFiles(emberDebug, {
 });
 
 emberDebug = wrapFiles(emberDebug, {
-  wrapper: ["(function(adapter) {\n", "\n}('" + (dist || 'basic') + "'));"]
+  wrapper: ["(function(adapter, env) {\n", "\n}('" + (dist || 'basic') + "', '" + env + "'));"]
 });
 
 var tree = app.toTree();

--- a/ember_debug/port.js
+++ b/ember_debug/port.js
@@ -1,6 +1,7 @@
 var Ember = window.Ember;
 var oneWay = Ember.computed.oneWay;
 var guidFor = Ember.guidFor;
+var run = Ember.run;
 
 export default Ember.Object.extend(Ember.Evented, {
   adapter: oneWay('namespace.adapter').readOnly(),
@@ -15,14 +16,49 @@ export default Ember.Object.extend(Ember.Evented, {
     var self = this;
     this.get('adapter').onMessageReceived(function(message) {
       if (self.get('uniqueId') === message.applicationId || !message.applicationId) {
-        self.trigger(message.type, message);
+        self.messageReceived(message.type, message);
       }
     });
   },
+
+  messageReceived: function(name, message) {
+    var self = this;
+    this.wrap(function() {
+      self.trigger(name, message);
+    });
+  },
+
   send: function(messageType, options) {
     options.type = messageType;
     options.from = 'inspectedWindow';
     options.applicationId = this.get('uniqueId');
     this.get('adapter').send(options);
+  },
+
+  /**
+   * Wrap all code triggered from outside of
+   * EmberDebug with this method.
+   *
+   * `wrap` is called by default
+   * on all callbacks triggered by `port`,
+   * so no need to call it in this case.
+   *
+   * - Wraps a callback in `Ember.run`.
+   * - Catches all errors during production
+   * and displays them in a user friendly manner.
+   *
+   * @method wrap
+   * @param {Function} fn
+   * @return {Mixed} The return value of the passed function
+   */
+  wrap: function(fn) {
+    return run(this, function() {
+      try {
+        return fn();
+      } catch (error) {
+        this.get('adapter').handleError(error);
+      }
+    });
   }
 });
+

--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -68,12 +68,21 @@ export default Ember.Object.extend(PortMixin, {
   profileManager: profileManager,
 
   init: function() {
+    var self = this;
     this._super();
+    this.profileManager.wrapForErrors = function(context, callback) {
+      return self.get('port').wrap(function() {
+        return callback.call(context);
+      });
+    };
     this._subscribeForViewTrees();
   },
 
   willDestroy: function() {
     this._super();
+    this.profileManager.wrapForErrors = function(context, callback) {
+      return callback.call(context);
+    };
     this.profileManager.offProfilesAdded(this, this.sendAdded);
     this.profileManager.offProfilesAdded(this, this._updateViewTree);
   },

--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -9,11 +9,15 @@
   Also responsible for sending the first tree.
 **/
 
-/* globals Ember, adapter, requireModule */
+/* globals Ember, adapter, env, requireModule */
 
 var currentAdapter = 'basic';
 if (typeof adapter !== 'undefined') {
   currentAdapter = adapter;
+}
+var currentEnv = 'production';
+if (typeof env !== 'undefined') {
+  currentEnv = env;
 }
 
 (function(adapter) {
@@ -24,6 +28,13 @@ if (typeof adapter !== 'undefined') {
     }
     // prevent from injecting twice
     if (!Ember.Debug) {
+      define('ember-debug/config', function() {
+        return {
+          default: {
+            environment: currentEnv
+          }
+        };
+      });
       window.EmberInspector = Ember.Debug = requireModule('ember-debug/main')['default'];
       Ember.Debug.Adapter = requireModule('ember-debug/adapters/' + adapter)['default'];
 


### PR DESCRIPTION
Ember Inspector caused errors are now caught in production and logged as warnings instead of being thrown.

![screen shot 2015-04-12 at 8 45 01 pm](https://cloud.githubusercontent.com/assets/1061742/7106808/5ffed9a8-e157-11e4-9024-1034ba001376.png)