### PR TITLE
Use ember-computed-new in ember-debug to avoid warnings

### DIFF
--- a/ember_debug/addons/ember-new-computed/index.js
+++ b/ember_debug/addons/ember-new-computed/index.js
@@ -1,0 +1,36 @@
+import canUseNewSyntax from './utils/can-use-new-syntax';
+
+var Ember = window.Ember;
+var computed = Ember.computed;
+
+export default function() {
+  var polyfillArguments = [];
+  var config = arguments[arguments.length - 1];
+
+  if (typeof config === 'function' || canUseNewSyntax) {
+    return computed.apply(this, arguments);
+  }
+
+  for (var i = 0, l = arguments.length - 1; i < l; i++) {
+    polyfillArguments.push(arguments[i]);
+  }
+
+  var func;
+  if (config.set) {
+    func = function(key, value) {
+      if (arguments.length > 1) {
+        return config.set.call(this, key, value);
+      } else {
+        return config.get.call(this, key);
+      }
+    };
+  } else {
+    func = function(key) {
+      return config.get.call(this, key);
+    };
+  }
+
+  polyfillArguments.push(func);
+
+  return computed.apply(this, polyfillArguments);
+}

--- a/ember_debug/addons/ember-new-computed/utils/can-use-new-syntax.js
+++ b/ember_debug/addons/ember-new-computed/utils/can-use-new-syntax.js
@@ -1,0 +1,14 @@
+var Ember = window.Ember;
+var supportsSetterGetter;
+
+try {
+  Ember.computed({
+    set: function() { },
+    get: function() { }
+  });
+  supportsSetterGetter = true;
+} catch(e) {
+  supportsSetterGetter = false;
+}
+
+export default supportsSetterGetter;

--- a/ember_debug/models/promise.js
+++ b/ember_debug/models/promise.js
@@ -1,18 +1,20 @@
+import computedPolyfill from '../addons/ember-new-computed/index';
 var Ember = window.Ember;
 
 var dateComputed = function() {
-  return Ember.computed(
-    function(key, date) {
-      if (date !== undefined) {
-        if (date instanceof Date) {
-          return date;
-        } else if (typeof date === 'number' || typeof date === 'string') {
-          return new Date(date);
-        }
+  return computedPolyfill({
+    get: function() {
+      return null;
+    },
+    set: function(key, date) {
+      if (Ember.typeOf(date) === 'date') {
+        return date;
+      } else if (typeof date === 'number' || typeof date === 'string') {
+        return new Date(date);
       }
       return null;
     }
-  ).property();
+  });
 };
 
 export default Ember.Object.extend({


### PR DESCRIPTION
I've been getting deprecation warnings in my app coming from `ember_debug/models/promise.js`.

Now it uses the `ember-computed-new` addon, that is already being used in other areas.