### PR TITLE
[Glimmer] The view tree now supports glimmer

### DIFF
--- a/app/components/view-item.js
+++ b/app/components/view-item.js
@@ -51,4 +51,3 @@ export default Component.extend({
   }
 
 });
-

--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -20,20 +20,21 @@ export default Controller.extend({
 
   actions: {
     previewLayer: function(node) {
-      this.get('port').send('view:previewLayer', { objectId: node.value.objectId });
+      // We are passing both objectId and renderNodeId to support both pre-glimmer and post-glimmer
+      this.get('port').send('view:previewLayer', { objectId: node.value.objectId, renderNodeId: node.value.renderNodeId });
     },
 
-    hidePreview: function(node) {
-      this.get('port').send('view:hidePreview', { objectId: node.value.objectId });
+    hidePreview: function() {
+      this.get('port').send('view:hidePreview');
     },
 
     toggleViewInspection: function() {
       this.get('port').send('view:inspectViews', { inspect: !this.get('inspectingViews') });
     },
 
-    sendModelToConsole: function(viewId) {
+    sendModelToConsole: function(value) {
       // do not use `sendObjectToConsole` because models don't have to be ember objects
-      this.get('port').send('view:sendModelToConsole', { viewId: viewId });
+      this.get('port').send('view:sendModelToConsole', { viewId: value.objectId, renderNodeId: value.renderNod });
     },
 
     sendObjectToConsole: function(objectId) {

--- a/app/templates/view-item.hbs
+++ b/app/templates/view-item.hbs
@@ -14,7 +14,7 @@
         <span title="{{unbound value.model.completeName}}">{{unbound value.model.name}}</span>
       </div>
       <div class="list-tree__right-helper">
-        {{send-to-console action="sendModelToConsole" param=value.objectId}}
+        {{send-to-console action="sendModelToConsole" param=value}}
       </div>
     {{else}}
       --

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -153,7 +153,7 @@ export default EmberObject.extend(PortMixin, {
 
   replaceDeprecate: function() {
     var self = this;
-    var originalDeprecate = this.originalDeprecate = Ember.deprecate;
+    this.originalDeprecate = Ember.deprecate;
 
     Ember.deprecate = function(message, test, options) {
       /* global __fail__*/

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -464,7 +464,7 @@ function addProperties(properties, hash) {
 }
 
 function replaceProperty(properties, name, value, options) {
-  var found, type;
+  var found;
 
   for (var i = 0, l = properties.length; i < l; i++) {
     if (properties[i].name === name) {
@@ -475,9 +475,6 @@ function replaceProperty(properties, name, value, options) {
 
   if (found) { properties.splice(i, 1); }
 
-  if (name) {
-    type = name.PrototypeMixin ? 'ember-class' : 'ember-mixin';
-  }
   var prop = { name: name, value: inspectValue(value) };
   prop.isMandatorySetter = options.isMandatorySetter;
   prop.readOnly = options.readOnly;

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -2,11 +2,11 @@
 import PortMixin from "ember-debug/mixins/port-mixin";
 
 var Ember = window.Ember;
+var guidFor = Ember.guidFor;
 
 var layerDiv,
     previewDiv,
     highlightedElement,
-    previewedElement,
     $ = Ember.$,
     later = Ember.run.later,
     computed = Ember.computed,
@@ -37,13 +37,26 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       this.hideLayer();
     },
     showLayer: function(message) {
-      this.showLayer(message.objectId);
+      // >= Ember 1.13
+      if (message.renderNodeId !== undefined) {
+        this._highlightNode(this.get('_lastNodes').objectAt(message.renderNodeId), false);
+      } else {
+        // < Ember 1.13
+        this.showLayer(message.objectId);
+      }
     },
     previewLayer: function(message) {
-      this.previewLayer(message.objectId);
+      // >= Ember 1.13
+      if (message.renderNodeId !== undefined) {
+        this._highlightNode(this.get('_lastNodes').objectAt(message.renderNodeId), true);
+      } else {
+        // < Ember 1.13
+        this.previewLayer(message.objectId);
+      }
+
     },
-    hidePreview: function(message) {
-      this.hidePreview(message.objectId);
+    hidePreview: function() {
+      this.hidePreview();
     },
     inspectViews: function(message) {
       if (message.inspect) {
@@ -60,8 +73,16 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       this.sendTree();
     },
     sendModelToConsole: function(message) {
-      var view = this.get('objectInspector').sentObjects[message.viewId];
-      var model = this.modelForView(view);
+      var model;
+      if (message.renderNodeId) {
+        // >= Ember 1.13
+        var renderNode = this.get('_lastNodes').objectAt(message.renderNodeId);
+        model = this._modelForNode(renderNode);
+      } else {
+        // < Ember 1.13
+        var view = this.get('objectInspector').sentObjects[message.viewId];
+        model = this.modelForView(view);
+      }
       if (model) {
         this.get('objectInspector').sendValueToConsole(model);
       }
@@ -91,7 +112,6 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     });
   },
 
-
   updateDurations: function(durations) {
     for (var guid in durations) {
       if (!durations.hasOwnProperty(guid)) {
@@ -110,13 +130,13 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
   releaseCurrentObjects: function() {
     var self = this;
     this.retainedObjects.forEach(function(item) {
-      self.get('objectInspector').releaseObject(Ember.guidFor(item));
+      self.get('objectInspector').releaseObject(guidFor(item));
     });
     this.retainedObjects = [];
   },
 
   eventNamespace: Ember.computed(function() {
-    return 'view_debug_' + Ember.guidFor(this);
+    return 'view_debug_' + guidFor(this);
   }).property(),
 
   willDestroy: function() {
@@ -124,6 +144,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     $(window).off(this.get('eventNamespace'));
     $(layerDiv).remove();
     $(previewDiv).remove();
+    this.get('_lastNodes').clear();
     Ember.View.removeMutationListener(this.viewTreeChanged);
     this.releaseCurrentObjects();
     this.stopInspecting();
@@ -235,6 +256,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
   },
 
   viewTree: function() {
+    var tree;
     var emberApp = this.get('application');
     if (!emberApp) {
       return false;
@@ -246,14 +268,21 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     if (!rootView) {
       return false;
     }
-    var retained = [];
 
     var children = [];
-    var treeId = this.retainObject(retained);
 
-    var tree = { value: this.inspectView(rootView, retained), children: children, treeId: treeId };
-
-    this.appendChildren(rootView, children, retained);
+    if (!this._isGlimmer()) {
+      // before Glimmer
+      var retained = [];
+      var treeId = this.retainObject(retained);
+      tree = { value: this.inspectView(rootView, retained), children: children, treeId: treeId };
+      this.appendChildren(rootView, children, retained);
+    } else {
+      this.get('_lastNodes').clear();
+      var renderNode = rootView._renderNode;
+      tree = { value: this._inspectNode(renderNode), children: children };
+      this._appendNodeChildren(renderNode, children);
+    }
 
     return tree;
   },
@@ -266,6 +295,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     }
     return model;
   },
+
 
   inspectView: function(view, retained) {
     var templateName = view.get('templateName') || view.get('_debugTemplateName'),
@@ -281,7 +311,6 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     var controller = view.get('controller');
 
     name = viewDescription(view);
-
 
     var viewId = this.retainObject(view);
     retained.push(viewId);
@@ -312,7 +341,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
         if (Ember.Object.detectInstance(model) || Ember.typeOf(model) === 'array') {
           value.model = {
             name: shortModelName(model),
-            completeName: modelName(model),
+            completeName: getModelName(model),
             objectId: this.retainObject(model),
             type: 'type-ember-object'
           };
@@ -363,21 +392,15 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       !(view.get('_parentView.context') instanceof Ember.Component);
   },
 
-  highlightView: function(element, preview) {
-    var self = this;
-    var range, view, rect, div;
+  highlightView: function(element, isPreview) {
+    var range, view, rect;
+
+    if (!isPreview) {
+      highlightedElement = element;
+    }
 
     if (!element) { return; }
 
-    if (preview) {
-      previewedElement = element;
-      div = previewDiv;
-    } else {
-      this.hideLayer();
-      highlightedElement = element;
-      div = layerDiv;
-      this.hidePreview();
-    }
 
     if (element instanceof Ember.View) {
       view = element;
@@ -401,15 +424,64 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
       }
     }
 
-    // take into account the scrolling position as mentioned in docs
-    // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
-    rect = $().extend({}, rect);
-    rect.top = rect.top + window.scrollY;
-    rect.left = rect.left + window.scrollX;
 
     var templateName = view.get('templateName') || view.get('_debugTemplateName'),
         controller = view.get('controller'),
-        model = controller && controller.get('model');
+        model = controller && controller.get('model'),
+        modelName;
+
+
+    var options = {
+      isPreview: isPreview,
+      view: {
+        name: viewName(view),
+        object: view
+      }
+    };
+
+    if (controller) {
+      options.controller = {
+        name: controllerName(controller),
+        object: controller
+      };
+    }
+
+    if (templateName) {
+      options.template = {
+        name: templateName
+      };
+    }
+
+    if (model) {
+      modelName = this.get('objectInspector').inspect(model);
+      options.model = {
+        name: modelName,
+        object: model
+      };
+    }
+
+    this._highlightRange(rect, options);
+  },
+
+  // TODO: This method needs a serious refactor/cleanup
+  _highlightRange: function(rect, options) {
+    var div;
+    var isPreview = options.isPreview;
+    var self = this;
+
+    // take into account the scrolling position as mentioned in docs
+    // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
+    rect = $.extend({}, rect);
+    rect.top = rect.top + window.scrollY;
+    rect.left = rect.left + window.scrollX;
+
+    if (isPreview) {
+      div = previewDiv;
+    } else {
+      this.hideLayer();
+      div = layerDiv;
+      this.hidePreview();
+    }
 
     $(div).css(rect);
     $(div).css({
@@ -429,26 +501,31 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
 
     var output = "";
 
-    if (!preview) {
+    if (!isPreview) {
       output = "<span class='close' data-label='layer-close'>&times;</span>";
     }
 
-    if (templateName) {
-      output += "<p class='template'><span>template</span>=<span data-label='layer-template'>" + escapeHTML(templateName) + "</span></p>";
-    }
+    var template = options.template;
 
-    if (!(view instanceof Ember.Component)) {
+    if (template) {
+      output += "<p class='template'><span>template</span>=<span data-label='layer-template'>" + escapeHTML(template.name) + "</span></p>";
+    }
+    var view = options.view;
+    var controller = options.controller;
+    if (!view ||!(view.object instanceof Ember.Component)) {
       if (controller) {
-        output += "<p class='controller'><span>controller</span>=<span data-label='layer-controller'>" + escapeHTML(controllerName(controller)) + "</span></p>";
+        output += "<p class='controller'><span>controller</span>=<span data-label='layer-controller'>" + escapeHTML(controller.name) + "</span></p>";
       }
-      output += "<p class='view'><span>view</span>=<span data-label='layer-view'>" + escapeHTML(viewName(view)) + "</span></p>";
+      if (view) {
+        output += "<p class='view'><span>view</span>=<span data-label='layer-view'>" + escapeHTML(view.name) + "</span></p>";
+      }
     } else {
-      output += "<p class='component'><span>component</span>=<span data-label='layer-component'>" + escapeHTML(viewName(view)) + "</span></p>";
+      output += "<p class='component'><span>component</span>=<span data-label='layer-component'>" + escapeHTML(view.name) + "</span></p>";
     }
 
+    var model = options.model;
     if (model) {
-      var modelName = this.get('objectInspector').inspect(model);
-      output += "<p class='model'><span>model</span>=<span data-label='layer-model'>" + escapeHTML(modelName) + "</span></p>";
+      output += "<p class='model'><span>model</span>=<span data-label='layer-model'>" + escapeHTML(model.name) + "</span></p>";
     }
 
     $(div).html(output);
@@ -458,7 +535,7 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     $('p span:first-child', div).css({ color: 'rgb(153, 153, 0)' });
     $('p span:last-child', div).css({ color: 'rgb(153, 0, 153)' });
 
-    if (!preview) {
+    if (!isPreview) {
       $('span.close', div).css({
         float: 'right',
         margin: '5px',
@@ -482,29 +559,25 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
     }
 
     $('p.view span:last-child', div).css({ cursor: 'pointer' }).click(function() {
-      self.get('objectInspector').sendObject(view);
+      self.get('objectInspector').sendObject(view.object);
     });
 
     $('p.controller span:last-child', div).css({ cursor: 'pointer' }).click(function() {
-      self.get('objectInspector').sendObject(controller);
+      self.get('objectInspector').sendObject(controller.object);
     });
 
     $('p.component span:last-child', div).css({ cursor: 'pointer' }).click(function() {
-      self.get('objectInspector').sendObject(view);
+      self.get('objectInspector').sendObject(view.object);
     });
 
     $('p.template span:last-child', div).css({ cursor: 'pointer' }).click(function() {
-      self.inspectElement(Ember.guidFor(view));
+      self.inspectElement(guidFor(view.object));
     });
 
-    if (model && ((model instanceof Ember.Object) || Ember.typeOf(model) === 'array')) {
+    if (model && model.object && ((model.object instanceof Ember.Object) || Ember.typeOf(model.object) === 'array')) {
       $('p.model span:last-child', div).css({ cursor: 'pointer' }).click(function() {
-        self.get('objectInspector').sendObject(controller.get('model'));
+        self.get('objectInspector').sendObject(model.object);
       });
-    }
-
-    if (!preview) {
-      this.sendMessage('pinView', { objectId: Ember.guidFor(view) });
     }
   },
 
@@ -517,14 +590,335 @@ var ViewDebug = Ember.Object.extend(PortMixin, {
   },
 
   hideLayer: function() {
-    this.sendMessage('unpinView', {});
     layerDiv.style.display = 'none';
     highlightedElement = null;
   },
 
   hidePreview: function() {
     previewDiv.style.display = 'none';
-    previewedElement = null;
+  },
+
+  /**
+   * List of render nodes from the last
+   * sent view tree.
+   *
+   * @property lastNodes
+   * @type {Array}
+   */
+  _lastNodes: computed(function() {
+    return Ember.A([]);
+  }),
+
+  /**
+   * @method isGlimmer
+   * @return {Boolean}
+   */
+  _isGlimmer: function() {
+    var id = Ember.keys(Ember.View.views)[0];
+    return id && !Ember.View.views[id].get('_childViews');
+  },
+
+  /**
+   * Walk the render node hierarchy and build the tree.
+   *
+   * @param  {Object} renderNode
+   * @param  {Array} children
+   */
+  _appendNodeChildren: function(renderNode, children) {
+    var self = this;
+    var childNodes = renderNode.childNodes;
+    if (!childNodes) { return; }
+    childNodes.forEach(function(childNode) {
+      if (self._shouldShowNode(childNode, renderNode)) {
+        var grandChildren = [];
+        children.push({ value: self._inspectNode(childNode), children: grandChildren});
+        self._appendNodeChildren(childNode, grandChildren);
+      } else {
+        self._appendNodeChildren(childNode, children);
+      }
+    });
+  },
+
+  /**
+   * Whether a render node is elligible to be included
+   * in the tree.
+   * Depends on whether the node is actually a view node
+   * (as opposed to an attribute node for example),
+   * and also checks the filtering options. For example,
+   * showing Ember component nodes can be toggled.
+   *
+   * @param  {Object} renderNode
+   * @param  {Object} parentNode
+   * @return {Boolean} `true` for show and `false` to skip the node
+   */
+  _shouldShowNode: function(renderNode, parentNode) {
+
+    // Filter out non-(view/components)
+    if (!this._nodeIsView(renderNode)) {
+      return false;
+    }
+    // Has either a template or a view/component instance
+    if (!this._nodeTemplateName(renderNode) && !this._nodeHasViewInstance(renderNode)) {
+      return false;
+    }
+    return (this.options.allViews || this._nodeHasOwnController(renderNode, parentNode)) &&
+        (this.options.components || !(this._nodeIsEmberComponent(renderNode))) &&
+        (this._nodeHasViewInstance(renderNode) || this._nodeHasOwnController(renderNode, parentNode));
+  },
+
+  /**
+   * The node's model. If the view has a controller,
+   * it will be the controller's `model` property.s
+   *
+   * @param  {Object} renderNode
+   * @return {Object} the model
+   */
+  _modelForNode: function(renderNode) {
+    var controller = this._controllerForNode(renderNode);
+    if (controller) {
+      return controller.get('model');
+    }
+  },
+
+  /**
+   * Not all nodes are actually views/components.
+   * Nodes can be attributes for example.
+   *
+   * @param  {Object} renderNode
+   * @return {Boolean}
+   */
+  _nodeIsView: function(renderNode) {
+    return !!renderNode.state.manager;
+  },
+
+  /**
+   * Check if a node has its own controller (as opposed to sharing
+   * its parent's controller).
+   * Useful to identify route views from other views.
+   *
+   * @param  {Object} renderNode
+   * @param  {Object} parentNode
+   * @return {Boolean}
+   */
+  _nodeHasOwnController: function(renderNode, parentNode) {
+    return this._controllerForNode(renderNode) !== this._controllerForNode(parentNode);
+  },
+
+  /**
+   * Check if the node has a view instance.
+   * Virtual nodes don't have a view/component instance.
+   *
+   * @param  {Object} renderNode
+   * @return {Boolean}
+   */
+  _nodeHasViewInstance: function(renderNode) {
+    return !!this._viewInstanceForNode(renderNode);
+  },
+
+
+  /**
+   * Returns the nodes' controller.
+   *
+   * @param  {Object} renderNode
+   * @return {Ember.Controller}
+   */
+  _controllerForNode: function(renderNode) {
+    return renderNode.lastResult.scope.locals.controller.value();
+  },
+
+  /**
+   * Inspect a node. This will return an object with all
+   * the required properties to be added to the view tree
+   * to be sent.
+   *
+   * @param  {Object} renderNode
+   * @return {Object} the object containing the required values
+   */
+  _inspectNode: function(renderNode) {
+    var name, viewClassName, completeViewClassName, tagName, viewId, timeToRender;
+
+    var viewClass = this._viewInstanceForNode(renderNode);
+
+    if (viewClass) {
+      viewClassName = shortViewName(viewClass);
+      completeViewClassName = viewName(viewClass);
+      tagName = viewClass.get('tagName') || 'div';
+      viewId = this.retainObject(viewClass);
+      timeToRender = this._durations[viewId];
+    }
+
+    name = this._nodeDescription(renderNode);
+
+    var value = {
+      template: this._nodeTemplateName(renderNode) || '(inline)',
+      name: name,
+      objectId: viewId,
+      viewClass: viewClassName,
+      duration: timeToRender,
+      completeViewClass: completeViewClassName,
+      isComponent: this._nodeIsEmberComponent(renderNode),
+      tagName: tagName,
+      isVirtual: !viewClass
+    };
+
+
+    var controller = this._controllerForNode(renderNode);
+    if (controller && !(this._nodeIsEmberComponent(renderNode))) {
+      value.controller = {
+        name: shortControllerName(controller),
+        completeName: controllerName(controller),
+        objectId: this.retainObject(controller)
+      };
+
+      var model = this._modelForNode(renderNode);
+      if (model) {
+        if (Ember.Object.detectInstance(model) || Ember.typeOf(model) === 'array') {
+          value.model = {
+            name: shortModelName(model),
+            completeName: getModelName(model),
+            objectId: this.retainObject(model),
+            type: 'type-ember-object'
+          };
+        } else {
+          value.model = {
+            name: this.get('objectInspector').inspect(model),
+            type: 'type-' + Ember.typeOf(model)
+          };
+        }
+      }
+    }
+
+    value.renderNodeId = this.get('_lastNodes').push(renderNode) - 1;
+
+    return value;
+  },
+
+  /**
+   * Get the node's template name. Relies on an htmlbars
+   * feature that adds the module name as a meta property
+   * to compiled templates.
+   *
+   * @param  {Object} renderNode
+   * @return {String} the template name
+   */
+  _nodeTemplateName: function(renderNode) {
+    var template = renderNode.lastResult.template;
+    if (template && template.meta && template.meta.moduleName) {
+      return template.meta.moduleName.replace(/\.hbs$/, '');
+    }
+  },
+
+  /**
+   * The node's name. Should be anything that the user
+   * can use to identity what node we are talking about.
+   *
+   * Usually either the view instance name, or the template name.
+   *
+   * @param  {Object} renderNode
+   * @return {String}
+   */
+  _nodeDescription: function(renderNode) {
+    var name;
+
+    var viewClass = this._viewInstanceForNode(renderNode);
+
+    if (viewClass) {
+      //. Has a view instance - take the view's name
+      name = viewClass.get('_debugContainerKey');
+      if (name) {
+        name = name.replace(/.*(view|component):/, '').replace(/:$/, '');
+      }
+    } else {
+      // Virtual - no view instance
+      var templateName = this._nodeTemplateName(renderNode);
+      if (templateName) {
+        return templateName.replace(/^.*templates\//, '').replace(/\//g, '.');
+      }
+    }
+
+    // If application view was not defined, it uses a `toplevel` view
+    if (name === 'toplevel') {
+      name = 'application';
+    }
+    return name;
+  },
+
+  /**
+   * Return a node's view instance.
+   *
+   * @param  {Object} renderNode
+   * @return {Ember.View|Ember.Component} The view or component instance
+   */
+  _viewInstanceForNode: function(renderNode) {
+    return renderNode.emberView;
+  },
+
+  /**
+   * Returns whether the node is an Ember Component or not.
+   *
+   * @param  {Object} renderNode
+   * @return {Boolean}
+   */
+  _nodeIsEmberComponent: function(renderNode) {
+    var viewInstance = this._viewInstanceForNode(renderNode);
+    return !!(viewInstance && (viewInstance instanceof Ember.Component));
+  },
+
+  /**
+   * Highlight a render node on the screen.
+   *
+   * @param  {Object} renderNode
+   * @param  {Boolean} isPreview (whether to pin the layer or not)
+   */
+  _highlightNode: function(renderNode, isPreview) {
+    var modelName;
+    // Todo: should be in Ember core
+    var range = document.createRange();
+    range.setStartBefore(renderNode.firstNode);
+    range.setEndAfter(renderNode.lastNode);
+    var rect = range.getBoundingClientRect();
+
+    var options = {
+      isPreview: isPreview
+    };
+
+    var controller = this._controllerForNode(renderNode);
+    if (controller) {
+      options.controller = {
+        name: controllerName(controller),
+        object: controller
+      };
+    }
+
+    var templateName = this._nodeTemplateName(renderNode);
+    if (templateName) {
+      options.template = {
+        name: templateName
+      };
+    }
+
+    var model;
+    if (controller) {
+      model = controller.get('model');
+    }
+    if (model) {
+      modelName = this.get('objectInspector').inspect(model);
+      options.model = {
+        name: modelName,
+        object: model
+      };
+    }
+
+    var view = this._viewInstanceForNode(renderNode);
+
+    if (view) {
+      options.view = {
+        name: viewName(view),
+        object: view
+      };
+    }
+
+    this._highlightRange(rect, options);
   }
 });
 
@@ -541,10 +935,11 @@ function viewName(view) {
 function shortViewName(view) {
   var name = viewName(view);
   // jj-abrams-resolver adds `app@view:` and `app@component:`
-  return name.replace(/.+(view|component):/, '').replace(/:$/, '');
+  // Also `_debugContainerKey` has the format `type-key:factory-name`
+  return name.replace(/.*(view|component):(?!$)/, '').replace(/:$/, '');
 }
 
-function modelName(model) {
+function getModelName(model) {
   var name = '<Unknown model>';
   if (model.toString) {
     name = model.toString();
@@ -558,7 +953,7 @@ function modelName(model) {
 }
 
 function shortModelName(model) {
-  var name = modelName(model);
+  var name = getModelName(model);
   // jj-abrams-resolver adds `app@model:`
   return name.replace(/<[^>]+@model:/g, '<');
 }

--- a/eslint.json
+++ b/eslint.json
@@ -102,7 +102,7 @@
     "no-underscore-dangle": 0,
     "no-unreachable": 2,
     "no-unused-expressions": 2,
-    "no-unused-vars": [0, "local"],
+    "no-unused-vars": [2, "local"],
     "no-use-before-define": 0,
     "no-with": 2,
     "no-void": 2,

--- a/tests/ember_debug/deprecation_debug_test.js
+++ b/tests/ember_debug/deprecation_debug_test.js
@@ -3,7 +3,7 @@ import { module, test } from 'qunit';
 /*globals require */
 var EmberDebug = require("ember-debug/main")["default"];
 
-var port, name, message;
+var port;
 /* jshint ignore:start */
 var EmberDebug;
 var run = Ember.run;
@@ -19,10 +19,7 @@ module("Deprecation Debug", {
   beforeEach() {
     EmberDebug.Port = EmberDebug.Port.extend({
       init: function() {},
-      send: function(n, m) {
-        name = n;
-        message = m;
-      }
+      send: function(/*n, m*/) {}
     });
     run(function() {
       setupApp();
@@ -36,8 +33,6 @@ module("Deprecation Debug", {
     });
   },
   afterEach() {
-    name = null;
-    message = null;
     EmberDebug.destroyContainer();
     Ember.run(App, 'destroy');
   }

--- a/tests/ember_debug/ember_debug_test.js
+++ b/tests/ember_debug/ember_debug_test.js
@@ -4,7 +4,7 @@ import Ember from "ember";
 import { module, test } from 'qunit';
 
 var EmberDebug;
-var port, name, message;
+var name;
 /* jshint ignore:start */
 var run = Ember.run;
 var App;
@@ -20,9 +20,8 @@ module("Ember Debug", {
     EmberDebug = require('ember-debug/main')["default"];
     EmberDebug.Port = EmberDebug.Port.extend({
       init: function() {},
-      send: function(n, m) {
+      send: function(n/*, m*/) {
         name = n;
-        message = m;
       }
     });
     run(function() {
@@ -32,11 +31,9 @@ module("Ember Debug", {
     run(EmberDebug, 'start');
     EmberDebug.start();
     EmberInspector = EmberDebug;
-    port = EmberDebug.port;
   },
   afterEach() {
     name = null;
-    message = null;
     EmberDebug.destroyContainer();
     run(App, 'destroy');
   }

--- a/tests/ember_debug/promise_debug_test.js
+++ b/tests/ember_debug/promise_debug_test.js
@@ -58,7 +58,7 @@ test("Existing promises sent when requested", async function t(assert) {
   let promise1, child1, promise2;
 
   run(function() {
-    let p = RSVP.resolve('value', "Promise1")
+    RSVP.resolve('value', "Promise1")
     .then(function() {}, null, "Child1");
 
     // catch so we don't get a promise failure
@@ -124,10 +124,9 @@ test("Updates are published when they happen", function(assert) {
 
 test("Instrumentation with stack is persisted to session storage", function(assert) {
   var withStack = false;
-  var persisted = false;
   EmberDebug.get('promiseDebug').reopen({
     session: {
-      getItem: function(key) {
+      getItem: function(/*key*/) {
         return withStack;
       },
       setItem: function(key, val) {

--- a/tests/ember_debug/route_debug_test.js
+++ b/tests/ember_debug/route_debug_test.js
@@ -51,7 +51,7 @@ module("Route Tree Debug", {
 });
 
 test("Route tree", async function t(assert) {
-  var name = null, message = null, route, children;
+  var name = null, message = null, route;
   port.reopen({
     send(n, m) {
       name = n;

--- a/tests/ember_debug/view_debug_test.js
+++ b/tests/ember_debug/view_debug_test.js
@@ -16,7 +16,7 @@ var OLD_TEMPLATES = {};
 
 function setTemplate(name, template) {
   OLD_TEMPLATES = Ember.TEMPLATES[name];
-  Ember.TEMPLATES[name] = compile(template);
+  Ember.TEMPLATES[name] = compile(template, { moduleName: name });
 }
 
 function destroyTemplates() {
@@ -135,10 +135,9 @@ test("Simple View Tree", async function t(assert) {
 
 
 test("Views created by context switching {{each}} helper are shown", async function t(assert) {
-  let name = null, message = null;
+  let message = null;
   port.reopen({
     send(n, m) {
-      name = n;
       message = m;
     }
   });
@@ -173,7 +172,6 @@ test("Highlight a view", async function t(assert) {
     objectId: tree.children[0].value.objectId
   });
   await wait();
-
   layerDiv = findByLabel('layer-div');
   assert.ok(layerDiv.is(':visible'));
   assert.equal(findByLabel('layer-template', layerDiv).text(), 'simple');
@@ -200,10 +198,9 @@ test("Highlight a view", async function t(assert) {
 });
 
 test("Components in view tree", async function t(assert) {
-  let name, message;
+  let message;
   port.reopen({
     send(n, m) {
-      name = n;
       message = m;
     }
   });
@@ -228,17 +225,12 @@ test("Components in view tree", async function t(assert) {
 });
 
 test("Highlighting Views on hover", async function t(assert) {
-  let name, message, layerDiv;
   port.reopen({
-    send(n, m) {
-      name = n;
-      message = m;
-    }
+    send(/*n, m*/) {}
   });
 
   await visit('/simple');
 
-  let tree = message.tree;
   run(() => port.trigger('view:inspectViews', { inspect: true }));
   await wait();
 
@@ -288,10 +280,9 @@ test("Highlighting Views on hover", async function t(assert) {
 });
 
 test("Highlighting a view without an element should not throw an error", async function t(assert) {
-  let name = null, message = null;
+  let message = null;
   port.reopen({
     send(n, m) {
-      name = n;
       message = m;
     }
   });
@@ -307,10 +298,9 @@ test("Highlighting a view without an element should not throw an error", async f
 });
 
 test("Supports a view with a string as model", async function t(assert) {
-  let name = null, message = null;
+  let message = null;
   port.reopen({
     send(n, m) {
-      name = n;
       message = m;
     }
   });
@@ -322,7 +312,7 @@ test("Supports a view with a string as model", async function t(assert) {
 });
 
 test("Supports applications that don't have the ember-application CSS class", async function t(assert) {
-  let name = null, message = null,
+  let name = null,
       $rootElement = $('body');
 
   await visit('/simple');
@@ -335,9 +325,8 @@ test("Supports applications that don't have the ember-application CSS class", as
   port = EmberDebug.port;
 
   port.reopen({
-    send(n, m) {
+    send(n/*, m*/) {
       name = n;
-      message = m;
     }
   });
 

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -13,7 +13,7 @@ export default function startApp(attrs) {
 
   Application.initializer({
     name: generateGuid() + "-detectEmberApplication",
-    initialize: function(container, application) {
+    initialize: function(container) {
       container.lookup('route:app-detected').reopen({
         model: Ember.K
       });

--- a/tests/integration/container_test.js
+++ b/tests/integration/container_test.js
@@ -50,7 +50,7 @@ function getInstances() {
 
 test("Container types are successfully listed", async function t(assert) {
   port.reopen({
-    send: function(name, message) {
+    send: function(name) {
       if (name === 'container:getTypes') {
         this.trigger('container:types', { types: getTypes() });
       }
@@ -69,8 +69,6 @@ test("Container types are successfully listed", async function t(assert) {
 
 
 test("Container instances are successfully listed", async function t(assert) {
-  let types = [{ name: 'controller', count: 2 }];
-
   let instances = getInstances();
 
   port.reopen({

--- a/tests/integration/data_test.js
+++ b/tests/integration/data_test.js
@@ -6,7 +6,7 @@ import startApp from '../helpers/start-app';
 const { run } = Ember;
 let App;
 
-let port, message, name;
+let port, name;
 
 module('Data Tab', {
   beforeEach() {
@@ -18,7 +18,6 @@ module('Data Tab', {
       init() {},
       send(n, m) {
         name = n;
-        message = m;
         if (name === 'data:getModelTypes') {
           this.trigger('data:modelTypesAdded', { modelTypes: modelTypes() });
         }
@@ -33,8 +32,7 @@ module('Data Tab', {
   },
   afterEach() {
     name = null;
-    message = null;
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/integration/info_test.js
+++ b/tests/integration/info_test.js
@@ -5,7 +5,7 @@ import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 let App;
 
-let port, message, name;
+let port;
 
 module('Info Tab', {
   beforeEach() {
@@ -27,8 +27,6 @@ module('Info Tab', {
     });
   },
   afterEach() {
-    name = null;
-    message = null;
     Ember.run(App, App.destroy);
   }
 });

--- a/tests/integration/promise_test.js
+++ b/tests/integration/promise_test.js
@@ -55,7 +55,7 @@ function generatePromise(props) {
 
 test("Backwards compatibility - no promise support", async function t(assert) {
   port.reopen({
-    send(n, m) {
+    send(n/*, m*/) {
       if (n === 'promise:supported') {
         this.trigger('promise:supported', {
           supported: false

--- a/tests/integration/render_tree_test.js
+++ b/tests/integration/render_tree_test.js
@@ -5,7 +5,7 @@ import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 let App;
 
-let port, message, name;
+let port;
 
 module('Render Tree Tab', {
   beforeEach() {
@@ -14,16 +14,11 @@ module('Render Tree Tab', {
     });
     port = App.__container__.lookup('port:main');
     port.reopen({
-      send: function(n, m) {
-        name = n;
-        message = m;
-      }
+      send: function(/*n, m*/) {}
     });
   },
   afterEach() {
     Ember.run(App, App.destroy);
-    name = null;
-    message = null;
   }
 });
 
@@ -52,7 +47,7 @@ function generateProfiles() {
 
 test("No profiles collected", async function t(assert) {
   port.reopen({
-    send(n, m) {
+    send(n/*, m*/) {
       if (n === 'render:watchProfiles') {
         this.trigger('render:profilesAdded', {
           profiles: []
@@ -69,7 +64,7 @@ test("No profiles collected", async function t(assert) {
 
 test("Renders the list correctly", async function t(assert) {
   port.reopen({
-    send(n, m) {
+    send(n/*, m*/) {
       if (n === 'render:watchProfiles') {
         this.trigger('render:profilesAdded', {
           profiles: generateProfiles()
@@ -110,7 +105,7 @@ test("Renders the list correctly", async function t(assert) {
 
 test("Searching the profiles", async function t(assert) {
   port.reopen({
-    send(n, m) {
+    send(n/*, m*/) {
       if (n === 'render:watchProfiles') {
         this.trigger('render:profilesAdded', {
           profiles: generateProfiles()

--- a/tests/integration/route_tree_test.js
+++ b/tests/integration/route_tree_test.js
@@ -4,7 +4,7 @@ import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 var App;
-var run = Ember.run;
+const { run } = Ember;
 
 var port;
 
@@ -16,7 +16,7 @@ module('Route Tree Tab', {
     port = App.__container__.lookup('port:main');
   },
   afterEach() {
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 
@@ -56,7 +56,7 @@ var routeTree = {
 
 test("Route tree is successfully displayed", function(assert) {
   port.reopen({
-    send: function(name, message) {
+    send: function(name/*, message*/) {
       if (name === 'route:getTree') {
         this.trigger('route:routeTree', { tree: routeTree });
       }
@@ -167,7 +167,7 @@ test("Clicking on route handlers and controller sends an inspection message", fu
 
 test("Current Route is highlighted", function(assert) {
   port.reopen({
-    send: function(name, message) {
+    send: function(name/*, message*/) {
       if (name === 'route:getTree') {
         this.trigger('route:routeTree', { tree: routeTree });
       } else if (name === 'route:getCurrentRoute') {
@@ -201,7 +201,7 @@ test("Current Route is highlighted", function(assert) {
 
 test("Hiding non current route", function(assert) {
   port.reopen({
-    send: function(name, message) {
+    send: function(name/*, message*/) {
       if (name === 'route:getTree') {
         this.trigger('route:routeTree', { tree: routeTree });
       } else if (name === 'route:getCurrentRoute') {

--- a/tests/integration/view_tree_test.js
+++ b/tests/integration/view_tree_test.js
@@ -25,7 +25,6 @@ function viewNodeFactory(props) {
   if (!props.template) {
     props.template = props.name;
   }
-  var value = props;
   var obj = {
     value: props,
     children: [],
@@ -123,7 +122,6 @@ test("It should correctly display the view tree", function(assert) {
 
     var $treeNodes = findByLabel('tree-node');
     assert.equal($treeNodes.length, 3, 'expected some tree nodes');
-    var $treeView = $treeNodes.filter(':first');
     var controllerNames = [],
         templateNames = [],
         modelNames = [],
@@ -243,11 +241,12 @@ test("Previewing / showing a view on the client", function(assert) {
   })
   .mouseEnterByLabel('tree-node')
   .then(function() {
-    assert.deepEqual(messageSent, { name: 'view:previewLayer', message: { objectId: 'applicationView' } }, "Client asked to preview layer");
+    assert.equal(messageSent.name, 'view:previewLayer', "Client asked to preview layer");
+    assert.equal(messageSent.message.objectId, 'applicationView', "Client sent correct id to preview layer");
   })
   .mouseLeaveByLabel('tree-node')
   .then(function() {
-    assert.deepEqual(messageSent, { name: 'view:hidePreview', message: { objectId: 'applicationView' } }, "Client asked to hide preview");
+    assert.equal(messageSent.name, 'view:hidePreview', "Client asked to hide preview");
   });
 });
 


### PR DESCRIPTION
Fixes #351 
Fixes https://github.com/emberjs/ember.js/issues/11027 
Fixes #356

There was a shift in concept from a view tree to a render node tree.
Previously, the template tree was made of a hierarchy of view instances.
After the Glimmer rewrite, view instances are optional and secondary, and the main template representation is a render node tree.

This required a re-write of all of view-debug.js. Old code was left untouched, so the current version supports both pre-glimmer and post-glimmer. We detect glimmer by checking for the absence of `_childViews` on the top level view.

All code that touches private api (anything that has to do with render nodes) needs to be moved to Ember core and tested.