### PR TITLE
Ignore promises created by deprecation debug

### DIFF
--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -59,7 +59,7 @@ export default EmberObject.extend(PortMixin, {
         }
       });
     } else {
-      return RSVP.resolve(null);
+      return RSVP.resolve(null, 'ember-inspector');
     }
 
   },
@@ -70,7 +70,7 @@ export default EmberObject.extend(PortMixin, {
 
     var promises = RSVP.all(this.get('deprecationsToSend').map(function(deprecation) {
       var obj;
-      var promise = RSVP.resolve();
+      var promise = RSVP.resolve(undefined, 'ember-inspector');
       self.get('deprecations').pushObject(deprecation);
       var grouped = self.get('groupedDeprecations');
       var id = guidFor(deprecation.message);
@@ -96,7 +96,7 @@ export default EmberObject.extend(PortMixin, {
           if (map) {
             obj.hasSourceMap = true;
           }
-        });
+        }, null, 'ember-inspector');
       }
       return promise.then(function() {
         delete obj.stackStr;
@@ -111,7 +111,7 @@ export default EmberObject.extend(PortMixin, {
 
       self.get('deprecationsToSend').clear();
       self.sendCount();
-    });
+    }, null, 'ember-inspector');
   },
 
   sendCount: function() {

--- a/ember_debug/libs/source-map.js
+++ b/ember_debug/libs/source-map.js
@@ -14,7 +14,7 @@ var notFoundError = new Error('Source map url not found');
 export default EmberObject.extend({
 
   _lastPromise: computed(function() {
-    return resolve();
+    return resolve(undefined, 'ember-inspector');
   }),
 
   /**
@@ -32,7 +32,7 @@ export default EmberObject.extend({
     parsed.forEach(function(item) {
       lastPromise = self.get('_lastPromise').then(function() {
         return self.getSourceMap(item.url);
-      }).then(function(smc) {
+      }, null, 'ember-inspector').then(function(smc) {
         if (smc) {
           var source = smc.originalPositionFor({
             line: item.line,
@@ -42,15 +42,15 @@ export default EmberObject.extend({
           array.push(source);
           return array;
         }
-      });
+      }, null, 'ember-inspector');
       self.set('_lastPromise', lastPromise);
     });
-    return resolve(lastPromise).catch(function(e) {
+    return resolve(lastPromise, 'ember-inspector').catch(function(e) {
       if (e === notFoundError) {
         return null;
       }
       throw e;
-    });
+    }, 'ember-inspector');
   },
 
   sourceMapCache: computed(function() {
@@ -59,7 +59,7 @@ export default EmberObject.extend({
 
   getSourceMap: function(url) {
     var sourceMaps = this.get('sourceMapCache');
-    if (sourceMaps[url] !== undefined) { return resolve(sourceMaps[url]); }
+    if (sourceMaps[url] !== undefined) { return resolve(sourceMaps[url], 'ember-inspector'); }
     return retrieveSourceMap(url).then(function(response) {
       if (response) {
         var map = JSON.parse(response.map);
@@ -109,11 +109,11 @@ function retrieveFile(source) {
   return new RSVP.Promise(function(resolve) {
     var xhr = new XMLHttpRequest();
     xhr.onload = function() {
-      resolve(this.responseText);
+      resolve(this.responseText, 'ember-inspector');
     };
     xhr.open('GET', source, true);
     xhr.send();
-  });
+  }, 'ember-inspector');
 }
 
 function retrieveSourceMapURL(source) {


### PR DESCRIPTION
Passing `ember-inspector` label to promises will tell the Promise Tab to ignore them.