### PR TITLE
Switch computed property with get/set to polyfill

### DIFF
--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -96,6 +96,7 @@ export default EmberObject.extend(PortMixin, {
     },
     set: function(key, value) {
       this.get('session').setItem('promise:stack', value);
+      return value;
     }
   }).property(),
 

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -1,6 +1,6 @@
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import PromiseAssembler from 'ember-debug/libs/promise-assembler';
-import computedPolyfill from '../addons/ember-new-computed/index';
+import computedPolyfill from './addons/ember-new-computed/index';
 var Ember = window.Ember;
 var computed = Ember.computed;
 var oneWay = computed.oneWay;

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -1,5 +1,6 @@
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import PromiseAssembler from 'ember-debug/libs/promise-assembler';
+import computedPolyfill from '../addons/ember-new-computed/index';
 var Ember = window.Ember;
 var computed = Ember.computed;
 var oneWay = computed.oneWay;
@@ -88,13 +89,14 @@ export default EmberObject.extend(PortMixin, {
       this.sendInstrumentWithStack();
     }
   },
-
-  instrumentWithStack: computed(function(key, val) {
-    if (arguments.length > 1) {
+  
+  instrumentWithStack: computedPolyfill({
+    get: function(key) {
+      return !!this.get('session').getItem('promise:stack');
+    },
+    set: function(key, value) {
       this.get('session').setItem('promise:stack', val);
-      return val;
     }
-    return !!this.get('session').getItem('promise:stack');
   }).property(),
 
   sendInstrumentWithStack: function() {

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -89,13 +89,13 @@ export default EmberObject.extend(PortMixin, {
       this.sendInstrumentWithStack();
     }
   },
-  
+
   instrumentWithStack: computedPolyfill({
-    get: function(key) {
+    get: function() {
       return !!this.get('session').getItem('promise:stack');
     },
     set: function(key, value) {
-      this.get('session').setItem('promise:stack', val);
+      this.get('session').setItem('promise:stack', value);
     }
   }).property(),
 


### PR DESCRIPTION
Fixes deprecation warning with Ember 1.12.0. Fixes #361. Note this is untested (dry-coded on Github).