### PR TITLE
`run` is missing from a couple of build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OR:
 - cd into the repo directory
 - run `npm install && bower install`
 - run `npm install -g ember-cli`
-- run `npm build` to build the `dist` directory
+- run `npm run build` to build the `dist` directory
 - Visit chrome://extensions in chrome
 - Make sure `Developer mode` is checked
 - Click on 'Load unpacked extension...'
@@ -43,7 +43,7 @@ OR:
 - cd into the repo directory
 - run `npm install`
 - run `npm install -g ember-cli`
-- run `npm build` to build the `dist` directory
+- run `npm run build` to build the `dist` directory
 - Visit chrome://extensions in chrome
 - Make sure `Developer mode` is checked
 - Click on 'Load unpacked extension...'
@@ -75,7 +75,7 @@ Building and Testing:
 
 Run `npm install && npm install -g ember-cli && && npm install -g bower && bower install && npm install -g grunt-cli` to install the required modules.
 
-- `npm build` to build the files in the `dist` directory
+- `npm run build` to build the files in the `dist` directory
 - `npm run watch` To watch the files and re-build in `dist` when anything changes (useful during development).
 - `npm test` To run the tests in the terminal
 - `npm run build:xpi` to download and build Firefox Addon XPI into `tmp/xpi/ember-inspector.xpi`

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
     "watch": "ember build --watch",
     "serve:bookmarklet": "ember serve --port 9191",
     "build:production": "ember build --environment production",
-    "upload": "npm build:production && grunt s3:bookmarklet",
-    "run-xpi": "npm build && grunt run-xpi",
-    "build:xpi": "npm build && grunt build-xpi",
+    "upload": "npm run build:production && grunt s3:bookmarklet",
+    "run-xpi": "npm run build && grunt run-xpi",
+    "build:xpi": "npm run build && grunt build-xpi",
     "build:xpi:production": "npm run build:production && grunt clean-tmp build-xpi"
   },
   "repository": "https://github.com/emberjs/ember-inspector",


### PR DESCRIPTION
First I want to thank everyone working on this for an amazing tool.

While setting up the project on my machine I noticed that `run` was missing from a couple of commands in the README.md.

Figured I would create a PR instead of just opening an issue, hope that is ok. 

Cheers,
Björn