### PR TITLE
Fix routes pane for Ember >= 1.13

### DIFF
--- a/app/routes/route-tree.js
+++ b/app/routes/route-tree.js
@@ -49,13 +49,16 @@ export default TabRoute.extend({
 
 function topSort(tree, list) {
   list = list || [];
-  let view = $.extend({}, tree);
-  view.parentCount = view.parentCount || 0;
-  delete view.children;
-  list.push(view);
+  let route = $.extend({}, tree);
+  delete route.children;
+  // Firt node in the tree doesn't have a value
+  if (route.value) {
+    route.parentCount = route.parentCount || 0;
+    list.push(route);
+  }
   tree.children = tree.children || [];
   tree.children.forEach(child => {
-    child.parentCount = view.parentCount + 1;
+    child.parentCount = route.parentCount + 1;
     topSort(child, list);
   });
   return list;

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -56,7 +56,7 @@ export default Ember.Object.extend(PortMixin, {
       var route = routeNames[routeName];
       buildSubTree.call(this, routeTree, route);
     }
-    return arrayizeChildren({ children: routeTree }).children[0];
+    return arrayizeChildren({ children: routeTree });
   }).property('router'),
 
   sendTree: function() {
@@ -163,7 +163,11 @@ var buildSubTree = function(routeTree, route) {
 };
 
 function arrayizeChildren(routeTree) {
-  var obj = { value: routeTree.value };
+  var obj = {};
+  // Top node doesn't have a value
+  if (routeTree.value) {
+    obj.value = routeTree.value;
+  }
 
   if (routeTree.children) {
     var childrenArray = [];

--- a/tests/ember_debug/route_debug_test.js
+++ b/tests/ember_debug/route_debug_test.js
@@ -66,7 +66,7 @@ test("Route tree", async function t(assert) {
 
   assert.equal(name, 'route:routeTree');
 
-  route = message.tree;
+  route = message.tree.children[0];
   assert.equal(route.value.name, 'application');
   assert.equal(route.value.type, 'resource');
   assert.equal(route.value.controller.name, 'application');


### PR DESCRIPTION
Having more than one top route (application, application_loading, application_error) broke the routes pane.

Fixes https://github.com/emberjs/ember-inspector/issues/396