### PR TITLE
Use an arrow function to preserve this value

### DIFF
--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -115,7 +115,7 @@ export default EmberObject.extend({
     return new Promise((resolve, reject) => {
       $(() => {
         if (this.isDestroyed) { reject(); }
-        this.interval = setInterval(function() {
+        this.interval = setInterval(() => {
           if (document.documentElement.dataset.emberExtension) {
             clearInterval(this.interval);
             resolve();


### PR DESCRIPTION
Using an arrow function here prevent this from being undefined and thus allowing the code to actually clear the interval