### PR TITLE
Clone Ember arrays before sending them in Chrome

### DIFF
--- a/ember_debug/adapters/chrome.js
+++ b/ember_debug/adapters/chrome.js
@@ -1,6 +1,8 @@
 import BasicAdapter from "./basic";
 const Ember = window.Ember;
-const { computed, run } = Ember;
+const { computed, run, $: { extend } } = Ember;
+const { isArray } = Array;
+const { keys } = Object;
 
 export default BasicAdapter.extend({
   connect() {
@@ -13,6 +15,13 @@ export default BasicAdapter.extend({
 
   sendMessage(options) {
     options = options || {};
+    // If prototype extensions are disabled, `Ember.A()` arrays
+    // would not be considered native arrays, so it's not possible to
+    // "clone" them through postMessage unless they are converted to a
+    // native array.
+    if (!Ember.EXTEND_PROTOTYPES || Ember.EXTEND_PROTOTYPES.Array === false) {
+      options = deepCloneArrays(extend(true, {}, options));
+    }
     this.get('_chromePort').postMessage(options);
   },
 
@@ -40,6 +49,29 @@ export default BasicAdapter.extend({
     });
 
     chromePort.start();
-
   }
 });
+
+/**
+ * Recursively clones all arrays. Needed because Chrome
+ * refuses to clone Ember Arrays when extend prototypes is disabled.
+ *
+ * If the item passed is an array, a clone of the array is returned.
+ * If the item is an object or an array, or array properties/items are cloned.
+ *
+ * @param {Mixed} item The item to clone
+ * @return {Mixed}
+ */
+function deepCloneArrays(item) {
+  if (isArray(item)) {
+    item = item.slice();
+    item.forEach((child, key) => {
+      item[key] = deepCloneArrays(child);
+    });
+  } else if (item && typeof item === 'object') {
+    keys(item).forEach(key => {
+      item[key] = deepCloneArrays(item[key]);
+    });
+  }
+  return item;
+}

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -124,7 +124,7 @@ export default EmberObject.extend(PortMixin, {
         deprecations.push(grouped[i]);
       }
       this.sendMessage('deprecationsAdded', {
-        deprecations: deprecations
+        deprecations
       });
       this.sendPending();
     },


### PR DESCRIPTION
If Ember prototype extensions are disabled Chrome refuses to clone Ember arrays. We need to turn them into native arrays before sending them.

Fixes https://github.com/emberjs/ember-inspector/issues/366