### PR TITLE
Don't clear tomster in iframe content scripts.

### DIFF
--- a/skeleton_chrome/content-script.js
+++ b/skeleton_chrome/content-script.js
@@ -29,8 +29,14 @@
   document.documentElement.dataset.emberExtension = 1;
 
 
-  // clear a possible previous Ember icon
-  chrome.extension.sendMessage({ type: 'resetEmberIcon' });
+
+  // Iframes should not reset the icon so we make sure
+  // it's the parent window before resetting.
+  if (window.top === window) {
+    // Clear a possible previous Ember icon
+    chrome.extension.sendMessage({ type: 'resetEmberIcon' });
+  }
+
 
   // inject JS into the page to check for an app on domready
   var script = document.createElement('script');


### PR DESCRIPTION
If a content script is injected into an iframe, it shouldn't reset the Tomster because the parent window may be an Ember app.

Fixes https://github.com/emberjs/ember-inspector/issues/418