### PR TITLE
Update getState and getLocals for compatibility with canary

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -696,7 +696,11 @@ export default EmberObject.extend(PortMixin, {
    * @return {Boolean}
    */
   _nodeIsView(renderNode) {
-    return !!renderNode.state.manager;
+    if (renderNode.getState) {
+      return !!renderNode.getState().manager;
+    } else {
+      return !!renderNode.state.manager;
+    }
   },
 
   /**
@@ -731,7 +735,14 @@ export default EmberObject.extend(PortMixin, {
    * @return {Ember.Controller}
    */
   _controllerForNode(renderNode) {
-    return renderNode.lastResult && renderNode.lastResult.scope.locals.controller.value();
+    if (renderNode.lastResult) {
+      let scope = renderNode.lastResult.scope;
+      if (scope.getLocal) {
+        return scope.getLocal('controller');
+      } else {
+        return scope.locals.controller.value();
+      }
+    }
   },
 
   /**


### PR DESCRIPTION
This change is necessary but not sufficient to use ember-inspector with current canary.

(Still exploring what else is broken -- we apparently have a problem with Streams being sealed.)