### PR TITLE
Don't assume Ember.View exists

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -394,7 +394,7 @@ export default EmberObject.extend(PortMixin, {
     if (!element) { return; }
 
 
-    if (element instanceof View) {
+    if ((View && element instanceof View) || element instanceof Component) {
       view = element;
     } else {
       view = this.get('viewRegistry')[element.id];


### PR DESCRIPTION
No `Ember.View` in Ember >= 2.0.

cc @wagenet 