### PR TITLE
Update Firefox skeleton for path change in Firefox 44 and later

### DIFF
--- a/skeleton_firefox/lib/devtools-utils.js
+++ b/skeleton_firefox/lib/devtools-utils.js
@@ -4,10 +4,25 @@ const self = require("sdk/self");
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-XPCOMUtils.defineLazyModuleGetter(this, "gDevTools",
-                                  "resource:///modules/devtools/gDevTools.jsm");
-XPCOMUtils.defineLazyModuleGetter(this, "gDevToolsBrowser",
-                                  "resource:///modules/devtools/gDevTools.jsm");
+function importDevTools(name) {
+  // The path to this file was moved in Firefox 44 and later.
+  // See https://bugzil.la/912121 for more details.
+  let value;
+  try {
+    value = Cu.import("resource:///modules/devtools/client/framework/" +
+                      "gDevTools.jsm", {})[name];
+  } catch (e) {
+    value = Cu.import("resource:///modules/devtools/gDevTools.jsm", {})[name];
+  }
+  return value;
+}
+
+XPCOMUtils.defineLazyGetter(this, "gDevTools", () => {
+  return importDevTools("gDevTools");
+});
+XPCOMUtils.defineLazyGetter(this, "gDevToolsBrowser", () => {
+  return importDevTools("gDevToolsBrowser");
+});
 
 var Promise = require("sdk/core/promise.js");
 


### PR DESCRIPTION
In Firefox 44, we are [moving DevTools files][1] to a new location. This impacts some add-ons that import those files at their old paths.

For Ember, there's only two imports to clean up.

I've updated the add-on to use the new path when available (Firefox 44 and later) and fallback to the old one if not.

I tested this add-on build in Firefox 43 and 44.

At the moment, the old path also works in 44, but we'll soon start logging deprecation warnings for the old paths, so now you'll already be updated to avoid such warnings.

[1]: https://bugzil.la/912121