### PR TITLE
Prevent errors when document.documentElement.dataset is not present.

### DIFF
--- a/skeleton_chrome/content-script.js
+++ b/skeleton_chrome/content-script.js
@@ -25,8 +25,12 @@
     port.start();
   }
 
-  // let ember-debug know that content script has executed
-  document.documentElement.dataset.emberExtension = 1;
+  // document.documentElement.dataset is not present for SVG elements
+  // this guard prevents that condition from triggering an error
+  if (document.documentElement && document.documentElement.dataset) {
+    // let ember-debug know that content script has executed
+    document.documentElement.dataset.emberExtension = 1;
+  }
 
 
 


### PR DESCRIPTION
If `document.documentElement` does not have a `dataset` property we will never mark the content script as loaded (and it cannot be an Ember app) this happens in some scenarios with Chrome 45+ and SVG elements.

Fixes #463
Closes #473