### PR TITLE
Prevent deprecation for initializer arguments.

### DIFF
--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -111,7 +111,11 @@ if (typeof env !== 'undefined') {
     }
     Ember.Application.initializer({
       name: 'ember-inspector-booted',
-      initialize: function(container, app) {
+      initialize: function() {
+        // If 2 arguments are passed, we are on Ember < 2.1 (app is second arg)
+        // If 1 argument is passed, we are on Ember 2.1+ (app is only arg)
+        var app = arguments[1] || arguments[0];
+
         app.reopen({
           didBecomeReady: function() {
             callback(app);


### PR DESCRIPTION
Ember 2.1+ issue a deprecation when using 2 arguments with initializers.

This tweak ensures that our initializer works without deprecation for  all Ember versions.