### PR TITLE
Adding documentation for extension-level files

### DIFF
--- a/shared/in-page-script.js
+++ b/shared/in-page-script.js
@@ -1,3 +1,13 @@
+/**
+ * The Chrome and Firefox extensions inject the in-page-script into the
+ * page to deteremine the version of Ember the ClientApp is running.
+ *
+ * An iife runs to gather the data and uses postMessage to send the data back
+ * to the extension.
+ *
+ * @namespace EmberInspector/Shared
+ * @class InPageScript
+ */
 (function($) {
   "use strict";
   if (!$) { return; }

--- a/skeleton_chrome/background-script.js
+++ b/skeleton_chrome/background-script.js
@@ -1,16 +1,38 @@
 /*global chrome*/
+
+/**
+ * Long lived background script running in the browser, works in tandem with the
+ * client-script to coordinate messaging between EmberDebug, EmberInspector and the
+ * ClientApp.  The background-script serves as a proxy between the EmberInspector
+ * and the content-script.
+ *
+ * It is also responsible for showing the Tomster icon and tooltip in the url bar.
+ *
+ * See:
+ *     https://developer.chrome.com/extensions/background_pages
+ *     https://developer.chrome.com/extensions/messaging
+ */
 (function() {
   "use strict";
 
   var activeTabs = {},
-      ports = {};
+      emberInspectorChromePorts = {};
 
+  /**
+   * Creates the tooltip string to show the version of libraries used in the ClientApp
+   * @param  {Array} versions - array of library objects
+   * @return {String} - string of library names and versions
+   */
   function generateVersionsTooltip(versions) {
     return versions.map(function(lib) {
       return lib.name + " " + lib.version;
     }).join("\n");
   }
 
+  /**
+   * Creates the title for the pageAction for the current ClientApp
+   * @param {Number} tabId - the current tab
+   */
   function setActionTitle(tabId){
     chrome.pageAction.setTitle({
       tabId: tabId,
@@ -18,6 +40,12 @@
     });
   }
 
+  /**
+   * Update the tab's pageAction: https://developer.chrome.com/extensions/pageAction
+   * If the user has choosen to display it, the icon is shown and the title
+   * is updated to display the ClientApp's information in the tooltip.
+   * @param {Number} tabId - the current tab
+   */
   function updateTabAction(tabId){
     chrome.storage.sync.get("options", function(data) {
       if (!data.options.showTomster) { return; }
@@ -26,49 +54,88 @@
     });
   }
 
+  /**
+   * Remove the curent tab's Tomster.
+   * Typically used to clearout the icon after reload.
+   * @param {Number} tabId - the current tab
+   */
   function hideAction(tabId){
     delete activeTabs[tabId];
     chrome.pageAction.hide(tabId);
   }
 
-  chrome.extension.onMessage.addListener(function(request, sender) {
-    if (!sender.tab) {
-      // noop
-    } else if (request && request.type === 'emberVersion') {
-      activeTabs[sender.tab.id] = request.versions;
-      updateTabAction(sender.tab.id);
-    } else if (request && request.type === 'resetEmberIcon') {
-      hideAction(sender.tab.id);
-    } else {
-      var port = ports[sender.tab.id];
-      if (port) { port.postMessage(request); }
-    }
-  });
-
-  chrome.extension.onConnect.addListener(function(port) {
+  /**
+   * Listen for a connection request from the EmberInspector.
+   * When the EmberInspector connects to the extension a messageListener
+   * is added for the specific EmberInspector instance, and saved into
+   * an array, keyed by appId.
+   *
+   * @param {Port} emberInspectorChromePort
+   */
+  chrome.extension.onConnect.addListener(function(emberInspectorChromePort) {
     var appId;
 
-    port.onMessage.addListener(function(message) {
+    /**
+     * Listen for messages from the EmberInspector.
+     * The first message is used to save the port, all others are forwarded
+     * to the content-script.
+     * @param {Message} message
+     */
+    emberInspectorChromePort.onMessage.addListener(function(message) {
+      // if the message contains the appId, this is the first
+      // message and the appId is used to map the port for this app.
       if (message.appId) {
         appId = message.appId;
 
-        ports[appId] = port;
+        emberInspectorChromePorts[appId] = emberInspectorChromePort;
 
-        port.onDisconnect.addListener(function() {
-          delete ports[appId];
+        emberInspectorChromePort.onDisconnect.addListener(function() {
+          delete emberInspectorChromePorts[appId];
         });
       } else if (message.from === 'devtools') {
+        // all other messages from EmberInspector are forwarded to the content-script
+        // https://developer.chrome.com/extensions/tabs#method-sendMessage
         chrome.tabs.sendMessage(appId, message);
       }
     });
   });
 
-  chrome.tabs.onUpdated.addListener(function(tabId){
-    // Re-render the Tomster when a tab changes.
+  /**
+   * Listen for messages from the content-script.
+   * A few events trigger specfic behavior, all others are forwarded to EmberInspector.
+   * @param {Object} request
+   * @param {MessageSender} sender
+   */
+  chrome.extension.onMessage.addListener(function(request, sender) {
+    // only listen to messages from the content-script
+    if (!sender.tab) {
+      // noop
+    } else if (request && request.type === 'emberVersion') {
+      // set the version info and update title
+      activeTabs[sender.tab.id] = request.versions;
+      updateTabAction(sender.tab.id);
+    } else if (request && request.type === 'resetEmberIcon') {
+      // hide the Tomster icon
+      hideAction(sender.tab.id);
+    } else {
+      // forward the message to EmberInspector
+      var emberInspectorChromePort = emberInspectorChromePorts[sender.tab.id];
+      if (emberInspectorChromePort) { emberInspectorChromePort.postMessage(request); }
+    }
+  });
+
+
+
+  /**
+   * Event listener for when the tab is updated, usually reloaded.
+   * Check to see if a ClientApp exists for this tab, and reset the icon
+   * to show the latest data.
+   * @param {Number} tabId - the current tab
+   */
+  chrome.tabs.onUpdated.addListener(function(tabId) {
     if (activeTabs[tabId]) {
       updateTabAction(tabId);
     }
-
   });
 
 }());

--- a/skeleton_chrome/content-script.js
+++ b/skeleton_chrome/content-script.js
@@ -1,48 +1,81 @@
-(function() {
+/* global chrome*/
 
+/**
+ * Content script injected into the app page by chrome, works in tandem with the
+ * background-script to coordinate messaging between EmberDebug, EmberInspector and the
+ * ClientApp.  The content-script serves as a proxy between EmberDebug
+ * and the background-script.
+ *
+ * Content scripts are loaded into every page, and have access to the DOM.  This uses that
+ * to inject the in-page-script to determine the ClientApp version onLoad.
+ */
+(function() {
   "use strict";
 
+  /**
+   * Add an event listener for window.messages.
+   * The initial message from EmberDebug is used to setup the event listener
+   * that proxies between the content-script and EmberDebug using a MessagingChannel.
+   *
+   * All events from the window are filtered by checking that data and data.type
+   * properties exist before sending messages on to the background-script.
+   *
+   * See:
+   *     https://developer.mozilla.org/en-US/docs/Web/API/Channel_Messaging_API
+   */
   window.addEventListener('message', function(event) {
+    // received initial message from EmberDebug
     if (event.data === 'debugger-client') {
-      var port = event.ports[0];
-      listenToPort(port);
+      var emberDebugPort = event.ports[0];
+      listenToEmberDebugPort(emberDebugPort);
     } else if (event.data && event.data.type) {
       chrome.extension.sendMessage(event.data);
     }
   });
 
-  function listenToPort(port) {
-    port.addEventListener('message', function(event) {
+  /**
+   * Listen for messages from EmberDebug.
+   * @param {Object} emberDebugPort
+   */
+  function listenToEmberDebugPort(emberDebugPort) {
+    // listen for messages from EmberDebug, and pass them on to the background-script
+    emberDebugPort.addEventListener('message', function(event) {
       chrome.extension.sendMessage(event.data);
     });
 
+    // listen for messages from the EmberInspector, and pass them on to EmberDebug
     chrome.extension.onMessage.addListener(function(message) {
       if (message.from === 'devtools') {
-        port.postMessage(message);
+        // forward message to EmberDebug
+        emberDebugPort.postMessage(message);
       }
     });
 
-    port.start();
+    emberDebugPort.start();
   }
 
   // document.documentElement.dataset is not present for SVG elements
   // this guard prevents that condition from triggering an error
   if (document.documentElement && document.documentElement.dataset) {
-    // let ember-debug know that content script has executed
+    // let EmberDebug know that content script has executed
     document.documentElement.dataset.emberExtension = 1;
   }
 
 
 
   // Iframes should not reset the icon so we make sure
-  // it's the parent window before resetting.
+  // it's the top level window before resetting.
   if (window.top === window) {
     // Clear a possible previous Ember icon
     chrome.extension.sendMessage({ type: 'resetEmberIcon' });
   }
 
 
-  // inject JS into the page to check for an app on domready
+  /**
+   * Inject JS into the page to check for an app on domready.  The in-page-script
+   * is used by all variants of ember-inspector (Chrome, FF, Bookmarklet) to get
+   * the libraries running in the ClientApp
+   */
   var script = document.createElement('script');
   script.type = "text/javascript";
   script.src = chrome.extension.getURL("panes/in-page-script.js");
@@ -53,13 +86,20 @@
     };
   }
 
+  /**
+   * Gather the iframes running in the ClientApp
+   */
   var iframes = document.getElementsByTagName('iframe');
   var urls = [];
   for (var i = 0, l = iframes.length; i < l; i ++) {
     urls.push(iframes[i].src);
   }
 
-  // FIXME
+  /**
+   * Send the iframes to EmberInspector so that it can run
+   * EmberDebug in the context of the iframe.
+   */
+  //FIX ME
   setTimeout(function() {
     chrome.extension.sendMessage({type: 'iframes', urls: urls});
   }, 500);

--- a/skeleton_chrome/devtools.js
+++ b/skeleton_chrome/devtools.js
@@ -1,5 +1,9 @@
 /*global chrome*/
 
+/**
+ * Run when devtools.html is automatically added to the Chrome devtools panels.
+ * It creates a new pane using the panes/index.html which includes EmberInspector.
+ */
 var panelWindow, injectedPanel = false, injectedPage = false, panelVisible = false, savedStack = [];
 
 chrome.devtools.panels.create("Ember", "images/ember-icon-final.png", "panes/index.html");

--- a/skeleton_chrome/options.js
+++ b/skeleton_chrome/options.js
@@ -1,6 +1,19 @@
+/*global chrome*/
+
+/**
+ * Extension options for Chrome.
+ * This allows the user to decide if the Tomster icon should show when visiting
+ * a webpage that has Ember running.
+ *
+ * see:
+ *     https://developer.chrome.com/extensions/options
+ */
 (function() {
   "use strict";
 
+  /**
+   * Load the options from storage.
+   */
   function loadOptions() {
     chrome.storage.sync.get('options', function(data) {
       var options = data.options;
@@ -9,6 +22,9 @@
     });
   }
 
+  /**
+   * Save the updated options to storage.
+   */
   function storeOptions() {
     /*jshint validthis:true */
     var showTomster = this.checked;

--- a/tests/ember_debug/object_inspector_test.js
+++ b/tests/ember_debug/object_inspector_test.js
@@ -268,7 +268,7 @@ test("Properties can be updated through a port message", function(assert) {
 });
 
 test("Date properties are converted to dates before being updated", function(assert) {
-  let newDate = new Date('2015-01-01');
+  let newDate = new Date(2015, 0, 1);
 
   let inspected = Ember.Object.extend({
     date: null


### PR DESCRIPTION
Work for #378 

This is a first pass at documentation for the chrome extension files for EmberInspector:
  - content-script.js
  - background-script.js
  - in-page-script.js
  - devtools.js
  - options.js

I wanted to understand the setup and communication flow before getting into the
internals of either EmberDebug or EmberInspector.  The basic pattern is outlined
here, https://developer.chrome.com/extensions/devtools#more, but I wanted to see
exactly how it is all happening.

**There is one logic change**: I removed the setTimeout that called sendIframe in content-script.js.  This seemed unnecessary since EmberInspector calls _injectDebugger() during setup.  Everything
still works locally, but I'm not sure if that is necessary for backward compatibility.

Some Questions:
  - Is camel case naming for the products alright? or should they be dasherized?
     - ex: EmberDebug vs ember-debug?
  - deprecated/old chrome apis? ex. extension.connect vs runtime.connect?
    - There are some differences between the chrome extension docs and the mehtods used throughout the ember-inspector extension.  Do they need to be updated or are they there for older version of chrome?
