### PR TITLE
Save _super before reopening

### DIFF
--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -118,8 +118,11 @@ if (typeof env !== 'undefined') {
 
         app.reopen({
           didBecomeReady: function() {
+            // _super will get reset when we reopen the app
+            // so we store it in this variable to call it later.
+            var _super = this._super;
             callback(app);
-            return this._super.apply(this, arguments);
+            return _super.apply(this, arguments);
           }
         });
       }


### PR DESCRIPTION
If you call `reopen` in an object's method on the object itself `_super` will be reset and can no longer be used.

This stores `_super` in a variable to we can call it later.

Fixes https://github.com/emberjs/ember-inspector/issues/461
Fixes https://github.com/emberjs/ember-inspector/issues/478
Fixes https://github.com/emberjs/ember.js/issues/12439