### PR TITLE
Tweak Firefox skeleton again for 44 and later

### DIFF
--- a/skeleton_firefox/lib/devtools-utils.js
+++ b/skeleton_firefox/lib/devtools-utils.js
@@ -6,11 +6,12 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
 function importDevTools(name) {
   // The path to this file was moved in Firefox 44 and later.
-  // See https://bugzil.la/912121 for more details.
+  // See https://bugzil.la/912121 and https://bugzil.la/1203159
+  // for more details.
   let value;
   try {
-    value = Cu.import("resource:///modules/devtools/client/framework/" +
-                      "gDevTools.jsm", {})[name];
+    value = Cu.import("resource://devtools/client/framework/gDevTools.jsm",
+                      {})[name];
   } catch (e) {
     value = Cu.import("resource:///modules/devtools/gDevTools.jsm", {})[name];
   }


### PR DESCRIPTION
In #470, I updated some internal Firefox DevTools paths for 44 and later.

On the Firefox DevTools team, we made [one more change][1] that also landed in 44, so here's another update to cover that. No other changes like this are anticipated in the near future.

[1]: https://bugzil.la/1203159