### PR TITLE
Launch inspector if document ready state is "interactive"

### DIFF
--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -80,7 +80,7 @@ if (typeof env !== 'undefined') {
   }
 
   function onReady(callback) {
-    if (document.readyState === 'complete') {
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
       setTimeout(completed);
     } else {
       document.addEventListener( "DOMContentLoaded", completed, false);


### PR DESCRIPTION
This fixes a bug where the inspector wouldn't launch if it's opened after the page has loaded but not "completed".