### PR TITLE
Prevent error when `renderNode` is null/undefined.

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -694,7 +694,9 @@ export default EmberObject.extend(PortMixin, {
    * @return {Boolean}
    */
   _nodeIsView(renderNode) {
-    if (renderNode.getState) {
+    if (!renderNode) {
+      return false;
+    } else if (renderNode.getState) {
       return !!renderNode.getState().manager;
     } else {
       return !!renderNode.state.manager;


### PR DESCRIPTION
During some portions of view teardown, when the inspector is open `renderNode` can be `undefined` (because it was already removed).  This guards to prevent an error in that case...

Thanks to @andrewtimberlake for reporting...