### PR TITLE
Fix websocket adapter ES6 conversion

### DIFF
--- a/ember_debug/adapters/websocket.js
+++ b/ember_debug/adapters/websocket.js
@@ -14,7 +14,7 @@ export default BasicAdapter.extend({
   }),
 
   _listen() {
-    this.get('socket').on('emberInspectorMessage', function(message) {
+    this.get('socket').on('emberInspectorMessage', message => {
       run(() => {
         this._messageReceived(message);
       });


### PR DESCRIPTION
The conversion to ES6 of this file a long time back broke it apparently as the scope of `this` was lost in this function