### PR TITLE
Port gruntfile to grunt-jpm to build an valid xpi for Firefox 44+

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,30 +3,10 @@ module.exports = function(grunt) {
   var config = {
     pkg: grunt.file.readJSON('package.json'),
     env: process.env,
-    "mozilla-cfx-xpi": {
-      "stable": {
-        options: {
-          "mozilla-addon-sdk": "latest",
-          extension_dir: "dist/firefox",
-          dist_dir: "tmp/xpi"
-        }
-      }
-    },
-    "mozilla-addon-sdk": {
-      "latest": {
-        options: {
-          revision: "latest",
-          dest_dir: "tmp/mozilla-addon-sdk"
-        }
-      }
-    },
-    "mozilla-cfx": {
-      "run": {
-        options: {
-          "mozilla-addon-sdk": "latest",
-          extension_dir: "dist/firefox",
-          command: "run"
-        }
+    "jpm": {
+      options: {
+        src: "dist/firefox",
+        xpi: "tmp/xpi"
       }
     },
     "version": {
@@ -70,17 +50,14 @@ module.exports = function(grunt) {
 
   grunt.initConfig(config);
 
-  grunt.loadNpmTasks('grunt-mozilla-addon-sdk');
+  grunt.loadNpmTasks('grunt-jpm');
   grunt.loadNpmTasks('grunt-version');
   grunt.loadNpmTasks('grunt-s3');
   grunt.loadNpmTasks('grunt-contrib-compress');
 
-  grunt.registerTask('build-xpi', [
-    'mozilla-addon-sdk',
-    'mozilla-cfx-xpi'
-  ]);
+  grunt.registerTask('build-xpi', ['jpm:xpi']);
 
-  grunt.registerTask('run-xpi', ['build-xpi', 'mozilla-cfx:run']);
+  grunt.registerTask('run-xpi', ['jpm:run']);
 
   grunt.registerTask('clean-tmp', function() {
     grunt.file.delete('./tmp');

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "grunt": "^0.4.5",
     "grunt-cli": "^0.1.13",
     "grunt-contrib-compress": "^0.12.0",
-    "grunt-mozilla-addon-sdk": "~0.4.0",
+    "grunt-jpm": "~0.1.3",
     "grunt-s3": "^0.2.0-alpha.3",
     "grunt-version": "^0.3.0",
     "js-string-escape": "^1.0.0"

--- a/skeleton_firefox/lib/tomster-locationbar-button.js
+++ b/skeleton_firefox/lib/tomster-locationbar-button.js
@@ -4,7 +4,7 @@ const { openEmberInspector } = require("./tomster-devtool-panel");
 
 const tabs = require("./tomster-tabs");
 
-const { UrlbarButton } = require("urlbarbutton");
+const { UrlbarButton } = require("./urlbarbutton");
 
 const { Panel } = require("sdk/panel");
 

--- a/skeleton_firefox/package.json
+++ b/skeleton_firefox/package.json
@@ -5,6 +5,7 @@
   "id": "ember-inspector@emberjs.com",
   "description": "Tool for debugging Ember applications.",
   "permissions": {"private-browsing": true},
+  "main": "lib/main.js",
   "preferences": [{
     "name": "tomsterLocationbarButtonToggle",
         "title": "Display The Tomster icon when a site runs Ember.js",


### PR DESCRIPTION
This PR fixes #518 by applying small changes in the grunt-based xpi building process to use jpm (through grunt-jpm) instead of cfx (through grunt-mozilla-addon-sdk).

A couple on minor tweaks of the Firefox package.json and javascript sources have been necessary to fix minor incompatibilities between cfx and jpm. 