### PR TITLE
Skip in page script injection in Chrome PDF Viewer

### DIFF
--- a/skeleton_chrome/content-script.js
+++ b/skeleton_chrome/content-script.js
@@ -79,7 +79,7 @@
   var script = document.createElement('script');
   script.type = "text/javascript";
   script.src = chrome.extension.getURL("panes/in-page-script.js");
-  if (document.body) {
+  if (document.body && document.contentType !== "application/pdf") {
     document.body.appendChild(script);
     script.onload = function() {
       document.body.removeChild(script);


### PR DESCRIPTION
There's an issue in all current Chrome versions, where the built-in PDF-Viewer only displays a blank page, if the Ember Inspector extension is active.

This fix works around the issue, by skipping the injection if the document's content type is reported as PDF which should never be true for normal HTML pages.

Fixes #532.

For a test case see issue #532.