### PR TITLE
Remove arrow function syntax from bookmarklet/load_inspector.js

### DIFF
--- a/skeletons/bookmarklet/load_inspector.js
+++ b/skeletons/bookmarklet/load_inspector.js
@@ -46,7 +46,7 @@
    * another version of ember-debug.
    *
    */
-  window.addEventListener('message', e => {
+  window.addEventListener('message', function(e) {
     if (e.origin !== window.emberInspector.url) {
       return;
     }


### PR DESCRIPTION
I've tried the [bookmarklet](https://github.com/emberjs/ember-inspector#bookmarklet-all-browsers) approach in Safari and caught unexpected ES6 syntax in the http://ember-extension.s3.amazonaws.com/dist_bookmarklet/load_inspector.js