### PR TITLE
Workaround for Ember v1.10.0 to v1.12.0 update Container/Registry reset.

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -61,8 +61,33 @@ App.initializer({
   }
 });
 
-
 loadInitializers(App, config.modulePrefix);
 
+/**
+ * This is here a "temporary" workaround for Container reset that Ember v1.10 provided "out of the box"
+ *
+ * Problem: Ember v1.11.0 introduced ApplicationInstance concept and with this Application.reset()
+ * method changed. In v1.10.0 reset() always created new Container() and thus everything in Container was reset.
+ * Since v1.11.0 it no longer does that but Inspector depends on that behavior, because inspector is
+ * able to instrument multiple applications, typically embedded Ember apps in iframes.
+ *
+ * See "controllers/iframes.js" for app.reset() call.
+ *
+ * Without this here, this is no longer possible and Inspector crashes, because
+ * it cannot re-register required injections, like adapter:main when new application is selected for inspection.
+ * Also it does not help us to protect initializers in the app with registry.has('my:thing')
+ * because we cannot protect against third party initializers.
+ *
+ * Therefore current solution is to reopen App and call buildRegistry() on reset().
+ *
+ * // TODO: Improve support for multiple app instrumentation, in a way that app.reset() call is not required
+ */
+
+App.reopen({
+  reset() {
+    this.buildRegistry();
+    this._super(...arguments);
+  }
+});
 
 export default App;

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-inspector",
   "dependencies": {
     "jquery": "1.11.1",
-    "ember": "1.12.0",
+    "ember": "1.12.2",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",


### PR DESCRIPTION
This fixes multiple Ember app inspection issue. 

Release v1.10.0 introduced regression, when selecting another app to inspect from `<select>` it crashed with error, that is cannot "re-register adapter:main". This commit provides workaround until we sort out multiple app instrumentation without calling app.reset() in between.

Ember Twiddle demonstrating the issue [https://ember-twiddle.com/918ee5f4d473abe786f6e5a102b7b619](https://ember-twiddle.com/918ee5f4d473abe786f6e5a102b7b619)

[Ember v1.12 reset](https://github.com/emberjs/ember.js/blob/v1.12.0/packages/ember-application/lib/system/application.js#L658)
[Ember v1.10 reset](https://github.com/emberjs/ember.js/blob/v1.10.0/packages/ember-application/lib/system/application.js#L658)

Commit that upgraded Ember v1.10.0 to v1.12.0 for Inspector - 524afb5

@nathanhammond - CC as requested.
