### PR TITLE
Use the layout service to pass content height to lists

### DIFF
--- a/app/components/x-list.js
+++ b/app/components/x-list.js
@@ -165,8 +165,8 @@ export default Component.extend({
    * the table widths need to be recalculated due to some
    * resizing of the window or application.
    *
-   * @method debounceColumnWidths
-   * @type {Function}
+   * @property debounceColumnWidths
+   * @type {Object} Ember Concurrency task
    */
   debounceColumnWidths: task(function * () {
     yield timeout(100);

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -67,10 +67,5 @@ export default Controller.extend({
       this.set('mixinDetails', null);
     }
 
-  },
-  actions: {
-    updateContentHeight(height) {
-      this.set('contentHeight', height);
-    }
   }
 });

--- a/app/services/layout.js
+++ b/app/services/layout.js
@@ -12,4 +12,26 @@
  */
 import Ember from 'ember';
 const { Service, Evented } = Ember;
-export default Service.extend(Evented);
+export default Service.extend(Evented, {
+  /**
+   * Stores the app's content height. This property is kept up-to-date
+   * by the `main-content` component.
+   *
+   * @property contentHeight
+   * @type {Number}
+   */
+  contentHeight: null,
+
+  /**
+   * This is called by `main-content` whenever a window resize is detected
+   * and the app's content height has changed. We therefore update the
+   * `contentHeight` property and notify all listeners (mostly lists).
+   *
+   * @method updateContentHeight
+   * @param  {Number} height The new app content height
+   */
+  updateContentHeight(height) {
+    this.set('contentHeight', height);
+    this.trigger('content-height-update', height);
+  }
+});

--- a/app/templates/-main.hbs
+++ b/app/templates/-main.hbs
@@ -24,7 +24,7 @@
       {{/unless}}
     </div>
 
-    {{#main-content class="split__panel__bd" updateHeight=(action "updateContentHeight")}}
+    {{#main-content class="split__panel__bd"}}
       {{outlet}}
     {{/main-content}}
   </div>

--- a/app/templates/components/x-list.hbs
+++ b/app/templates/components/x-list.hbs
@@ -19,7 +19,7 @@
   </div>
 {{/if}}
 
-{{#x-list-content contentHeight=contentHeight headerHeight=headerHeight columns=columns as |content|}}
+{{#x-list-content headerHeight=headerHeight columns=columns as |content|}}
   {{yield
     (hash
       cell=(component "x-list-cell" tagName="td")

--- a/app/templates/container-type.hbs
+++ b/app/templates/container-type.hbs
@@ -1,4 +1,4 @@
-{{#x-list name="container-instance-list" schema=(hash columns=null) headerHeight=0 contentHeight=application.contentHeight  as |list|}}
+{{#x-list name="container-instance-list" schema=(hash columns=null) headerHeight=0 as |list|}}
   {{#list.vertical-collection content=filtered defaultHeight=30 itemClass="js-instance-row" as |content index|}}
     {{#container-instance list=list index=index on-click=(action "inspectInstance" content)}}
       {{#list.cell class="list__cell_main" clickable=content.inspectable}}

--- a/app/templates/deprecations.hbs
+++ b/app/templates/deprecations.hbs
@@ -1,4 +1,4 @@
-{{#x-list name="deprecation-list" schema=(hash columns=null) contentHeight=application.contentHeight headerHeight=0 class="js-deprecations list_no-alternate-color" as |list|}}
+{{#x-list name="deprecation-list" schema=(hash columns=null) headerHeight=0 class="js-deprecations list_no-alternate-color" as |list|}}
   {{#if filtered.length}}
     <tbody>
       {{#each filtered as |content|}}

--- a/app/templates/info.hbs
+++ b/app/templates/info.hbs
@@ -1,4 +1,4 @@
-{{#x-list name="info-list" schema=(schema-for "info-list") contentHeight=application.contentHeight as |list|}}
+{{#x-list name="info-list" schema=(schema-for "info-list") as |list|}}
   <tbody>
     {{#each model as |library|}}
       <tr class="list__row js-library-row">

--- a/app/templates/promise-tree.hbs
+++ b/app/templates/promise-tree.hbs
@@ -1,7 +1,7 @@
 {{#if shouldRefresh}}
   {{partial "page_refresh"}}
 {{else}}
-  {{#x-list name="promise-tree" schema=(schema-for "promise-tree") contentHeight=application.contentHeight class="js-promise-tree" as |list|}}
+  {{#x-list name="promise-tree" schema=(schema-for "promise-tree") class="js-promise-tree" as |list|}}
     {{#list.vertical-collection content=filtered as |content|}}
       {{promise-item
         model=content

--- a/app/templates/records.hbs
+++ b/app/templates/records.hbs
@@ -2,7 +2,6 @@
   name="record-list"
   schema=schema
   storageKey=(concat "record-list-" modelType.name)
-  contentHeight=application.contentHeight
   itemClass="list__row_highlight" as |list|}}
 
   {{#list.vertical-collection content=filtered as |content index|}}

--- a/app/templates/render-tree.hbs
+++ b/app/templates/render-tree.hbs
@@ -5,7 +5,7 @@
     <button class="js-toolbar-page-refresh-btn" {{action "refreshPage"}}>Reload</button>
   </div>
 {{else}}
-  {{#x-list name="render-tree" schema=(schema-for "render-tree") contentHeight=application.contentHeight class="list_no-alternate-color js-render-tree" as |list|}}
+  {{#x-list name="render-tree" schema=(schema-for "render-tree") class="list_no-alternate-color js-render-tree" as |list|}}
     <tbody>
       {{#each filtered as |item|}}
         {{render-item model=item search=search list=list}}

--- a/app/templates/route-tree.hbs
+++ b/app/templates/route-tree.hbs
@@ -1,4 +1,4 @@
-{{#x-list name="route-tree" schema=(schema-for "route-tree") contentHeight=application.contentHeight as |list|}}
+{{#x-list name="route-tree" schema=(schema-for "route-tree") as |list|}}
   {{#list.vertical-collection content=filtered as |content|}}
     {{route-item
       model=content

--- a/app/templates/view-tree.hbs
+++ b/app/templates/view-tree.hbs
@@ -1,4 +1,4 @@
-{{#x-list name="view-tree" schema=(schema-for "view-tree") contentHeight=application.contentHeight as |list|}}
+{{#x-list name="view-tree" schema=(schema-for "view-tree") as |list|}}
   {{#list.vertical-collection content=model as |content index|}}
     {{view-item
         model=content


### PR DESCRIPTION
This allows us to also trigger events whenever the content height changes. Events are needed to re-render the x-list content due to smoke and mirrors not being aware that content height has changed and requiring a rerender.

To reproduce the bug that this commit fixes:
- Open the inspector on an Ember.js app.
- Switch to the Console (or any other devtools tab).
- Reload the page (Inspector has now loaded but with height 0 since it's not visible).
- Visit the inspector.

Before this commit the view tree would only have one visible row due to smoke and mirrors not being aware that content height has changed.