### PR TITLE
[GLIMMER] New way to get the root element

### DIFF
--- a/ember_debug/libs/glimmer-tree.js
+++ b/ember_debug/libs/glimmer-tree.js
@@ -326,7 +326,7 @@ export default class {
    */
   elementForRoot() {
     let renderer = this.container.lookup('renderer:-dom');
-    return renderer._result && renderer._result.firstNode();
+    return renderer._roots && renderer._roots[0] && renderer._roots[0].result && renderer._roots[0].result.firstNode();
   }
 
   /**


### PR DESCRIPTION
This uses APIs that are too private. I think it may be good to have something like `ViewUtils.getRootElement`.