### PR TITLE
'$E' now also prints the name of object sent to console.

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -207,7 +207,11 @@ export default EmberObject.extend(PortMixin, {
     if (value instanceof Error) {
       value = value.stack;
     }
-    this.get("adapter").log('Ember Inspector ($E): ', value);
+    let args = [value];
+    if (value instanceof EmberObject) {
+      args.unshift(inspect(value));
+    }
+    this.get("adapter").log('Ember Inspector ($E): ', ...args);
   },
 
   digIntoObject(objectId, property) {


### PR DESCRIPTION
### PR for issue #214 

Clicking the '$E' now also prints the name of the object sent to console along with the object for easier identification and clarity, resulting in more helpful output.

It does so by making use of the `inspect` function

Looks like this:- 
- includes a controller, route and a model 
<img width="638" alt="screen shot 2016-11-05 at 11 12 04 pm" src="https://cloud.githubusercontent.com/assets/12858057/20032441/df0bc49c-a3af-11e6-91b0-0fbc8415473a.png">
