### PR TITLE
Sort model properties

### DIFF
--- a/app/components/mixin-detail.js
+++ b/app/components/mixin-detail.js
@@ -1,6 +1,6 @@
 import Ember from "ember";
 const { computed, Component } = Ember;
-const { readOnly } = computed;
+const { readOnly, sort } = computed;
 
 export default Component.extend({
   /**
@@ -16,6 +16,9 @@ export default Component.extend({
   isExpanded: computed('model.expand', 'model.properties.length', function() {
     return this.get('model.expand') && this.get('model.properties.length') > 0;
   }),
+
+  sortProperties: ['name'],
+  sortedProperties: sort('model.properties', 'sortProperties'),
 
   actions: {
     calculate({ name }) {

--- a/app/components/mixin-detail.js
+++ b/app/components/mixin-detail.js
@@ -17,7 +17,20 @@ export default Component.extend({
     return this.get('model.expand') && this.get('model.properties.length') > 0;
   }),
 
+  /**
+   * Used by the `sort` computed macro.
+   *
+   * @property sortProperties
+   * @type {Array<String>}
+   */
   sortProperties: ['name'],
+
+  /**
+   * Sort the properties by name to make them easier to find in the object inspector.
+   *
+   * @property sortedProperties
+   * @type {Array<Object>}
+   */
   sortedProperties: sort('model.properties', 'sortProperties'),
 
   actions: {

--- a/app/templates/components/mixin-details.hbs
+++ b/app/templates/components/mixin-details.hbs
@@ -25,7 +25,7 @@
       {{/if}}
       {{#if mixin.isExpanded}}
         <ul class="mixin__properties">
-          {{#each mixin.model.properties as |prop|}}
+          {{#each mixin.sortedProperties as |prop|}}
             {{#mixin-property model=prop mixin=mixin as |property|}}
               <li class="{{if property.model.overridden 'mixin__property_state_overridden'}} mixin__property js-object-property">
                 {{#if property.model.value.computed}}


### PR DESCRIPTION
Sort the properties of the selected mixin on the object-inspector sidebar.

Mentioned in this issue: https://github.com/emberjs/ember-inspector/issues/562

(I had some issues with tests, though running it against my Ember app, the properties were sorted correctly)