### PR TITLE
Avoid error in some environments

### DIFF
--- a/ember_debug/services/session.js
+++ b/ember_debug/services/session.js
@@ -7,8 +7,29 @@ const Session = EmberObject.extend({
   getItem(/*key*/) {}
 });
 
+let SESSION_STORAGE_SUPPORTED = false;
+
+try {
+  if (typeof sessionStorage !== 'undefined') {
+    SESSION_STORAGE_SUPPORTED = true;
+  }
+} catch (e) {
+  // This can be reached with the following succession of events:
+  //
+  //   1. On Google Chrome
+  //   2. Disable 3rd-party cookies
+  //   3. Open the browser inspector
+  //   4. Open on the Ember inspector
+  //   5. Visit a page showing an Ember app, on a frame
+  //      loaded from a different domain
+  //
+  // It's important that the Ember inspector is already open when
+  // you land on the page (hence step 4 before 5). Reloading the iframe
+  // page with the Ember inspector open also reproduces the problem.
+}
+
 // Feature detection
-if (typeof sessionStorage !== 'undefined') {
+if (SESSION_STORAGE_SUPPORTED) {
   Session.reopen({
     sessionStorage,
     prefix: '__ember__inspector__',


### PR DESCRIPTION
There seems to be a problem, in very specific circumstances, with the code that detects support for session storage:

![screen shot 2017-03-03 at 18 36 55](https://cloud.githubusercontent.com/assets/36066/23563889/93e440f0-0040-11e7-9688-d7e1c33d45ce.png)

To reproduce follow these steps:

  1. On Google Chrome
  2. Disable 3rd-party cookies
  3. Open the browser inspector
  4. Open on the Ember inspector
  5. Visit a page showing an Ember app, on a frame
     loaded from a different domain

It's important that the Ember inspector is already open when you land on the page (hence step 4 before 5). Reloading the iframe page with the Ember inspector open also reproduces the problem.

This PR appears to fix the problem for me.