### PR TITLE
Opera Add Bower Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ OR:
 
 - Clone the repository
 - cd into the repo directory
-- run `npm install`
+- run `npm install && bower install`
 - run `npm install -g ember-cli`
 - run `npm run build` to build the `dist` directory
 - Visit chrome://extensions in chrome


### PR DESCRIPTION
Adds `bower install` to the Opera directions, as it is necessary and included in the installation instructions for Chrome and Firefox.