### PR TITLE
Add ember-cli-sass to build CSS file

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "ember-cli-moment-shim": "2.0.0",
     "ember-cli-qunit": "^2.2.1",
     "ember-cli-release": "0.2.8",
+    "ember-cli-sass": "^6.1.2",
     "ember-cli-uglify": "^1.2.0",
     "ember-concurrency": "0.7.8",
     "ember-export-application-global": "^1.0.5",


### PR DESCRIPTION
It seems like since moving to a table based `x-list`, the scroll
container for vertical collection didn't have the proper height to allow
rendering all the components.

Fixes #648 