### PR TITLE
ember-inspector shows wrong tooltip - fixed

### DIFF
--- a/skeletons/chrome/manifest.json
+++ b/skeletons/chrome/manifest.json
@@ -30,7 +30,7 @@
       "19": "{{PANE_ROOT}}/assets/images/icon19.png",
       "38": "{{PANE_ROOT}}/assets/images/icon38.png"
     },
-    "default_title": "This webpage is running Ember.js"
+    "default_title": "This webpage is not running Ember.js"
   },
   "web_accessible_resources": [
     "scripts/in-page-script.js"


### PR DESCRIPTION
When Ember-Inspector is running Browser and you visit a website not running Ember, on hovering the extension logo, the tooltip says "this webpage is running Ember.js" which is wrong.

demo-url : https://url.siwalik.in/emberPRgif