### PR TITLE
Remove all usages of jQuery in tests

### DIFF
--- a/app/components/action-checkbox.js
+++ b/app/components/action-checkbox.js
@@ -13,7 +13,7 @@ export default Component.extend({
   },
 
   _updateElementValue() {
-    this.set('checked', this.$().prop('checked'));
+    this.set('checked', this.element.checked);
     this.sendAction('on-update', this.get('checked'));
   }
 });

--- a/app/components/date-property-field.js
+++ b/app/components/date-property-field.js
@@ -11,7 +11,7 @@ export default DatePicker.extend({
    * on a destroyed component.
    */
   onPikadayClose() {
-    if (!this.$()) { return; }
+    if (!this.element) { return; }
     return this._super(...arguments);
   },
 

--- a/tests/acceptance/object-inspector-test.js
+++ b/tests/acceptance/object-inspector-test.js
@@ -45,7 +45,7 @@ const objectAttr = {
 };
 
 function objectFactory(props) {
-  return Ember.$.extend(true, {}, objectAttr, props);
+  return Object.assign({}, objectAttr, props);
 }
 
 function objectToInspect() {

--- a/tests/acceptance/route-tree-test.js
+++ b/tests/acceptance/route-tree-test.js
@@ -21,8 +21,26 @@ module('Route Tree Tab', {
   }
 });
 
-function deepAssign(...objects) {
-  return Ember.$.extend(true, ...objects);
+export function isObject(item) {
+  return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+export function deepAssign(target, ...sources) {
+  if (!sources.length) return target;
+  const source = sources.shift();
+
+  if (isObject(target) && isObject(source)) {
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key]) Object.assign(target, { [key]: {} });
+        deepAssign(target[key], source[key]);
+      } else {
+        Object.assign(target, { [key]: source[key] });
+      }
+    }
+  }
+
+  return deepAssign(target, ...sources);
 }
 
 function routeValue(name, props) {

--- a/tests/acceptance/route-tree-test.js
+++ b/tests/acceptance/route-tree-test.js
@@ -21,6 +21,10 @@ module('Route Tree Tab', {
   }
 });
 
+function deepAssign(...objects) {
+  return Ember.$.extend(true, ...objects);
+}
+
 function routeValue(name, props) {
   let value = {
     name,
@@ -38,7 +42,7 @@ function routeValue(name, props) {
     }
   };
   props = props || {};
-  return Ember.$.extend(true, {}, value, props);
+  return deepAssign({}, value, props);
 }
 
 let routeTree = {

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -1,7 +1,7 @@
 import Ember from "ember";
 import { module, test } from 'qunit';
 import computed from 'ember-new-computed';
-import { visit } from 'ember-native-dom-helpers';
+import { visit, find, settings as nativeDomHelpersSettings } from 'ember-native-dom-helpers';
 
 let EmberDebug;
 let port, name, message;
@@ -25,7 +25,7 @@ function setupApp() {
 }
 
 let ignoreErrors = true;
-
+let defaultRootForFinder;
 module("Ember Debug - Object Inspector", {
   // eslint-disable-next-line object-shorthand
   beforeEach: async function() {
@@ -49,8 +49,11 @@ module("Ember Debug - Object Inspector", {
     await wait();
     objectInspector = EmberDebug.get('objectInspector');
     port = EmberDebug.port;
+    defaultRootForFinder = nativeDomHelpersSettings.rootElement;
+    nativeDomHelpersSettings.rootElement = 'body';
   },
   afterEach() {
+    nativeDomHelpersSettings.rootElement = defaultRootForFinder;
     name = null;
     message = null;
     EmberDebug.destroyContainer();
@@ -376,7 +379,7 @@ test("Views are correctly handled when destroyed during transitions", async func
 
   await visit('/simple');
 
-  objectId = find('.simple-view').get(0).id;
+  objectId = find('.simple-view').id;
   let view = App.__container__.lookup('-view-registry:main')[objectId];
   objectInspector.sendObject(view);
   await wait();

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -2,7 +2,7 @@ import Ember from "ember";
 import { module, test } from 'qunit';
 import { visit, find, click, triggerEvent, settings as nativeDomHelpersSettings } from 'ember-native-dom-helpers';
 
-const { $, Application } = Ember;
+const { Application } = Ember;
 
 /* globals require */
 const EmberDebug = require('ember-debug/main').default;
@@ -22,6 +22,10 @@ function destroyTemplates() {
     Ember.TEMPLATES[name] = OLD_TEMPLATES[name];
   }
   OLD_TEMPLATES = {};
+}
+
+function isVisible(elem) {
+  return elem.offsetWidth > 0 || elem.offsetHeight > 0 || elem.getClientRects().length > 0;
 }
 
 function setupApp() {
@@ -176,7 +180,8 @@ test("Highlighting Views on hover", async function t(assert) {
   await triggerEvent('.application', 'mousemove');
 
   let previewDiv = find('[data-label=preview-div]');
-  assert.ok($(previewDiv).is(':visible'));
+
+  assert.ok(isVisible(previewDiv));
   assert.notOk(find('[data-label=layer-component]'), "Component layer not shown on outlet views");
   assert.equal(find('[data-label=layer-controller]', previewDiv).textContent, 'App.ApplicationController');
   assert.equal(find('[data-label=layer-model]', previewDiv).textContent, 'Application model');
@@ -185,7 +190,7 @@ test("Highlighting Views on hover", async function t(assert) {
   let layerDiv = find('[data-label=layer-div]');
   await triggerEvent(layerDiv, 'mouseup');
 
-  assert.ok($(layerDiv).is(':visible'));
+  assert.ok(isVisible(layerDiv));
   assert.equal(find('[data-label=layer-model]', layerDiv).textContent, 'Application model');
   assert.equal(find('[data-label=layer-view]', layerDiv).textContent, '(unknown mixin)');
   await click('[data-label=layer-controller]', layerDiv);
@@ -202,7 +207,7 @@ test("Highlighting Views on hover", async function t(assert) {
   assert.equal(message.name, 'Application model');
   await click('[data-label=layer-close]');
 
-  assert.notOk($(layerDiv).is(':visible'));
+  assert.notOk(isVisible(layerDiv));
 
   run(() => port.trigger('view:inspectViews', { inspect: true }));
   await wait();
@@ -210,7 +215,7 @@ test("Highlighting Views on hover", async function t(assert) {
   await triggerEvent('.simple-input', 'mousemove');
 
   previewDiv = find('[data-label=preview-div]');
-  assert.ok($(previewDiv).is(':visible'));
+  assert.ok(isVisible(previewDiv));
   assert.equal(find('[data-label=layer-component]').textContent.trim(), "Ember.TextField");
   assert.notOk(find('[data-label=layer-controller]', previewDiv));
   assert.notOk(find('[data-label=layer-model]', previewDiv));


### PR DESCRIPTION
Before removing jQuery in the inspector itself, we have to update ember and ember-cli to 2.13

Since this repo is a bit unidiomatic, I might use some help with that.

@teddyzeenny Is there a reason for the inspector to be on an old version?