### PR TITLE
Don't let mixin names wrap in the object inspector

### DIFF
--- a/app/styles/mixin.scss
+++ b/app/styles/mixin.scss
@@ -14,6 +14,9 @@
   background-color: #f0f0f0;
   cursor: default;
   user-select: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .mixin__name:active {

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -327,6 +327,9 @@ export default EmberObject.extend(PortMixin, {
 
     mixins.forEach(mixin => {
       let name = mixin[Ember.NAME_KEY] || mixin.ownerConstructor;
+      if (!name && typeof mixin.toString === 'function') {
+        name = mixin.toString();
+      }
       if (!name) {
         name = 'Unknown mixin';
       }


### PR DESCRIPTION
Some mixins' `toString` just prints the entire function - so we don't let it wrap.

Before:
![screen shot 2017-08-15 at 2 20 51 pm](https://user-images.githubusercontent.com/1061742/29314074-ff3fa0e6-81c4-11e7-8d59-a4b55af95ab9.png)

After:
![screen shot 2017-08-15 at 2 20 30 pm](https://user-images.githubusercontent.com/1061742/29314100-20052a94-81c5-11e7-9c78-5a3e1b2638b2.png)
