### PR TITLE
Fix unloading a record in the data tab

### DIFF
--- a/ember_debug/data-debug.js
+++ b/ember_debug/data-debug.js
@@ -179,8 +179,8 @@ export default EmberObject.extend(PortMixin, {
         recordsUpdated => {
           this.recordsUpdated(recordsUpdated);
         },
-        () => {
-          this.recordsRemoved(...arguments);
+        (...args) => {
+          this.recordsRemoved(...args);
         }
       );
       this.releaseRecordsMethod = releaseMethod;


### PR DESCRIPTION
This is a regression caused when we moved to ES6 arrow functions