### PR TITLE
Fix event variable name

### DIFF
--- a/app/components/x-list-content.js
+++ b/app/components/x-list-content.js
@@ -99,7 +99,7 @@ export default Component.extend(Evented, {
     function simulateMouseEvent(eventName) {
       return function (e) {
         let target = e.target;
-        let related = event.relatedTarget;
+        let related = e.relatedTarget;
         let match;
         // search for a parent node matching the delegation selector
         while (target && target !== listContentElement && !(match = target.matches('tr'))) {


### PR DESCRIPTION
This was working accidentally because Chrome sets the `event` global to the current event.
It breaks in FF thankfully, which allowed me to catch it.