### PR TITLE
Fix a issue for Chrome 61

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -458,12 +458,12 @@ export default EmberObject.extend(PortMixin, {
     let div;
     let isPreview = options.isPreview;
 
-    // take into account the scrolling position as mentioned in docs
-    // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
     // there's another issue with Chrome 61, rect has an extra toJSON property,
     // we do not need that property for our styling,
     // so we specifically select the properties we need
     rect = {
+      // take into account the scrolling position as mentioned in docs
+      // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
       left: rect.left + window.scrollX,,
       top: rect.top + window.scrollY,
       right: rect.right,

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -458,7 +458,7 @@ export default EmberObject.extend(PortMixin, {
     let div;
     let isPreview = options.isPreview;
 
-    // there's another issue with Chrome 61, rect has an extra toJSON property,
+    // there's an issue with Chrome 61, rect has an extra toJSON property,
     // we do not need that property for our styling,
     // so we specifically select the properties we need
     rect = {

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -464,7 +464,7 @@ export default EmberObject.extend(PortMixin, {
     rect = {
       // take into account the scrolling position as mentioned in docs
       // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
-      left: rect.left + window.scrollX,,
+      left: rect.left + window.scrollX,
       top: rect.top + window.scrollY,
       right: rect.right,
       bottom: rect.bottom,

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -464,6 +464,13 @@ export default EmberObject.extend(PortMixin, {
     rect.top = rect.top + window.scrollY;
     rect.left = rect.left + window.scrollX;
 
+    // in Chrome 61, rect has an extra toJSON property which will break
+    // $(div).css(rect)
+    // Error: Uncaught TypeError: Illegal invocation
+    if (rect.hasOwnProperty('toJSON')) {
+      delete rect.toJSON;
+    }
+
     if (isPreview) {
       div = previewDiv;
     } else {

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -460,16 +460,17 @@ export default EmberObject.extend(PortMixin, {
 
     // take into account the scrolling position as mentioned in docs
     // https://developer.mozilla.org/en-US/docs/Web/API/element.getBoundingClientRect
-    rect = $.extend({}, rect);
-    rect.top = rect.top + window.scrollY;
-    rect.left = rect.left + window.scrollX;
-
-    // in Chrome 61, rect has an extra toJSON property which will break
-    // $(div).css(rect)
-    // Error: Uncaught TypeError: Illegal invocation
-    if (rect.hasOwnProperty('toJSON')) {
-      delete rect.toJSON;
-    }
+    // there's another issue with Chrome 61, rect has an extra toJSON property,
+    // we do not need that property for our styling,
+    // so we specifically select the properties we need
+    rect = {
+      left: rect.left + window.scrollX,,
+      top: rect.top + window.scrollY,
+      right: rect.right,
+      bottom: rect.bottom,
+      width: rect.width,
+      height: rect.height
+    };
 
     if (isPreview) {
       div = previewDiv;


### PR DESCRIPTION
In Chrome 61, they add a new property `toJSON` in ClientRect.
After we have a $.extend({}, rect), the `toJSON` property becomes
an ownProperty.
This will break the code `$(div).css(rect)`.
The fix is to delete that toJSON property