### PR TITLE
View tree search filter

### DIFF
--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -12,11 +12,28 @@ export default Controller.extend({
     components: false
   },
 
+  searchText: "",
+
+  viewNames: computed('searchText', 'filteredList.[]', function() {
+    let list = this.get('filteredList');
+    if (list.length) return list.map(v => v.value.name).join(" ");
+    return `hello ${this.get('searchText')}`;
+  }),
+
+  filteredList: computed('model', 'searchText', function() {
+    let searchText = this.get('searchText') || false;
+    if (!searchText) return this.get('model');
+
+    let filtered = this.get('model').filter(v => v.value.name.indexOf(searchText) > -1);
+    return filtered;
+  }),
+
   optionsChanged: on('init', observer('options.components', function() {
     this.port.send('view:setOptions', { options: this.get('options') });
   })),
 
   actions: {
+
     previewLayer({ value: { objectId, elementId, renderNodeId } }) {
       // We are passing all of objectId, elementId, and renderNodeId to support post-glimmer 1, post-glimmer 2, and root for
       // post-glimmer 2

--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -14,12 +14,6 @@ export default Controller.extend({
 
   searchText: "",
 
-  viewNames: computed('searchText', 'filteredList.[]', function() {
-    let list = this.get('filteredList');
-    if (list.length) return list.map(v => v.value.name).join(" ");
-    return `hello ${this.get('searchText')}`;
-  }),
-
   filteredList: computed('model', 'searchText', function() {
     let searchText = this.get('searchText') || false;
     if (!searchText) return this.get('model');
@@ -33,7 +27,6 @@ export default Controller.extend({
   })),
 
   actions: {
-
     previewLayer({ value: { objectId, elementId, renderNodeId } }) {
       // We are passing all of objectId, elementId, and renderNodeId to support post-glimmer 1, post-glimmer 2, and root for
       // post-glimmer 2

--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -1,6 +1,7 @@
 import Ember from "ember";
-const { computed, Controller, on, observer, inject: { controller } } = Ember;
-const { alias } = computed;
+import searchMatch from "ember-inspector/utils/search-match";
+const { computed, Controller, get, on, observer, inject: { controller } } = Ember;
+const { alias, filter } = computed;
 
 export default Controller.extend({
   application: controller(),
@@ -12,18 +13,24 @@ export default Controller.extend({
     components: false
   },
 
-  searchText: "",
+  /**
+   * Bound to the search field to filter the component list.
+   *
+   * @property searchText
+   * @type {String}
+   * @default ''
+   */
+  searchText: '',
 
-  filteredList: computed('model', 'searchText', function() {
-    let searchText = this.get('searchText');
-
-    if (!searchText) {
-      return this.get('model');
-    }
-
-    let filtered = this.get('model').filter(v => v.value.name.includes(searchText));
-    return filtered;
-  }),
+  /**
+   * The filtered view list.
+   *
+   * @property filteredList
+   * @type {Array<Object>}
+   */
+  filteredList: filter('model', function(item) {
+    return searchMatch(get(item, 'value.name'), this.get('searchText'));
+  }).property('model.[]', 'searchText'),
 
   optionsChanged: on('init', observer('options.components', function() {
     this.port.send('view:setOptions', { options: this.get('options') });

--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -15,10 +15,13 @@ export default Controller.extend({
   searchText: "",
 
   filteredList: computed('model', 'searchText', function() {
-    let searchText = this.get('searchText') || false;
-    if (!searchText) return this.get('model');
+    let searchText = this.get('searchText');
 
-    let filtered = this.get('model').filter(v => v.value.name.indexOf(searchText) > -1);
+    if (!searchText) {
+      return this.get('model');
+    }
+
+    let filtered = this.get('model').filter(v => v.value.name.includes(searchText));
     return filtered;
   }),
 

--- a/app/templates/view-tree-toolbar.hbs
+++ b/app/templates/view-tree-toolbar.hbs
@@ -13,4 +13,10 @@
   <div class="toolbar__checkbox js-filter-components">
     {{input type="checkbox" checked=options.components id="options-components"}} <label for="options-components">Components</label>
   </div>
+
+  <div class="divider"></div>
+
+  <div class="toolbar__search js-filter-views">
+    {{input type="text" id="options-views" placeholder="Search Views" value=searchText}}
+  </div>
 </div>

--- a/app/templates/view-tree.hbs
+++ b/app/templates/view-tree.hbs
@@ -1,4 +1,3 @@
-{{input value=searchText}}{{viewNames}}
 {{#x-list name="view-tree" schema=(schema-for "view-tree") as |list|}}
   {{#list.vertical-collection content=filteredList as |content index|}}
     {{view-item

--- a/app/templates/view-tree.hbs
+++ b/app/templates/view-tree.hbs
@@ -1,5 +1,6 @@
+{{input value=searchText}}{{viewNames}}
 {{#x-list name="view-tree" schema=(schema-for "view-tree") as |list|}}
-  {{#list.vertical-collection content=model as |content index|}}
+  {{#list.vertical-collection content=filteredList as |content index|}}
     {{view-item
         model=content
         inspect=(action "inspect")

--- a/tests/acceptance/view-tree-test.js
+++ b/tests/acceptance/view-tree-test.js
@@ -21,6 +21,10 @@ module('View Tree Tab', {
   }
 });
 
+function textFor(selector, context) {
+  return find(selector, context).textContent.trim();
+}
+
 let treeId = 0;
 function viewNodeFactory(props) {
   if (!props.template) {
@@ -125,10 +129,6 @@ test("It should correctly display the view tree", async function(assert) {
   let viewClassNames = [];
   let durations = [];
 
-  function textFor(selector, context) {
-    return find(selector, context).textContent.trim();
-  }
-
   [...treeNodes].forEach(function(node) {
     templateNames.push(textFor('.js-view-template', node));
     controllerNames.push(textFor('.js-view-controller', node));
@@ -199,7 +199,7 @@ test("It should filter the view tree using the search text", async function(asse
   let treeNodes = findAll('.js-view-tree-item');
   assert.equal(treeNodes.length, 3, 'expected some tree nodes');
 
-  fillIn('.js-filter-views input', 'post');
+  await fillIn('.js-filter-views input', 'post');
   treeNodes = findAll('.js-view-tree-item');
   assert.equal(treeNodes.length, 1, 'expected filtered tree nodes');
 
@@ -208,10 +208,6 @@ test("It should filter the view tree using the search text", async function(asse
   let modelNames = [];
   let viewClassNames = [];
   let durations = [];
-
-  function textFor(selector, context) {
-    return find(selector, context).textContent.trim();
-  }
 
   [...treeNodes].forEach(function(node) {
     templateNames.push(textFor('.js-view-template', node));


### PR DESCRIPTION
When dealing with a complicated view tree, it can be cumbersome scrolling through all the views trying to identify the one that is of interest.

To help make finding it easier I added an input field to filter the list that is visible in the scroll view.
It naively looks for the substring to be present in the name of the view to determine a match.
The filter also works with the components included in the view tree.

Demo:
![view-tree-filter](https://user-images.githubusercontent.com/11997716/31304917-b30905e0-aafb-11e7-8c20-391975d5f464.gif)

Refs Issue https://github.com/emberjs/ember-inspector/issues/677

Looking for feedback around contribution guidelines, and if this solution fits the pattern being used in the application. Otherwise also accepting suggestions for improving the implementation.