### PR TITLE
Fix emberApp's query selector

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -298,7 +298,7 @@ export default EmberObject.extend(PortMixin, {
     if (!emberApp) {
       return false;
     }
-    let applicationView = document.querySelector('body > .ember-view');
+    let applicationView = document.querySelector(`${emberApp.rootElement} > .ember-view`);
     let applicationViewId = applicationView ? applicationView.id : undefined;
     let rootView = this.get('viewRegistry')[applicationViewId];
     // In case of App.reset view is destroyed


### PR DESCRIPTION
The applicationView's selector was hard coded to `body > .ember-view`,
this does not work for applications that are not using body as their
rootElement. We need to respect rootElement.