### PR TITLE
prevent undefined options error

### DIFF
--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -48,7 +48,7 @@
    */
   function updateTabAction(tabId){
     chrome.storage.sync.get("options", function(data) {
-      if (!data.options.showTomster) { return; }
+      if (!data.options || !data.options.showTomster) { return; }
       chrome.pageAction.show(tabId);
       setActionTitle(tabId);
     });


### PR DESCRIPTION
```
Error in response to storage.get: TypeError: Cannot read property 'showTomster' of undefined
    at Object.callback (chrome-extension://bmdblncegkenkacieihfhpjfppoconhi/background-script.js:51:25)
    at updateTabAction (chrome-extension://bmdblncegkenkacieihfhpjfppoconhi/background-script.js:50:25)
    at chrome-extension://bmdblncegkenkacieihfhpjfppoconhi/background-script.js:137:7
```