### PR TITLE
Remove unsafe-eval from the csp

### DIFF
--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -14,7 +14,7 @@
     "<all_urls>",
     "storage"
   ],
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "devtools_page": "devtools.html",
   "content_scripts": [{
     "matches": ["<all_urls>"],


### PR DESCRIPTION
Mozilla review requested to remove unsafe-eval. It seems we don't really need unsafe-eval for the inspector to function.