### PR TITLE
preserve model type hiding

### DIFF
--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -1,14 +1,28 @@
-import Ember from "ember";
+import Ember from 'ember';
+import LocalStorageService from 'ember-inspector/services/storage/local';
 const { Controller, computed, get, inject } = Ember;
 const { sort } = computed;
-const { controller } = inject;
+const { controller, service } = inject;
 
 export default Controller.extend({
   application: controller(),
   navWidth: 180,
   sortProperties: ['name'],
+  storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
   options: {
-    hideEmptyModelTypes: false
+    hideEmptyModelTypes: computed({
+      get() {
+        return !!this.get('storage').getItem('are-model-types-hidden');
+      },
+      set(key, value) {
+        if (!value) {
+          this.get('storage').removeItem('are-model-types-hidden');
+        } else {
+          this.get('storage').setItem('are-model-types-hidden', value);
+        }
+        return value;
+      }
+    })
   },
 
   sorted: sort('filtered', 'sortProperties'),

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -9,29 +9,26 @@ export default Controller.extend({
   navWidth: 180,
   sortProperties: ['name'],
   storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
-  options: {
-    hideEmptyModelTypes: computed({
-      get() {
-        // TODO fix test resolution lookup
-        if (!this.get) { return false; }
-        return !!this.get('storage').getItem('are-model-types-hidden');
-      },
-      set(key, value) {
-        if (!value) {
-          this.get('storage').removeItem('are-model-types-hidden');
-        } else {
-          this.get('storage').setItem('are-model-types-hidden', value);
-        }
-        return value;
+  hideEmptyModelTypes: computed({
+    get() {
+      return !!this.get('storage').getItem('are-model-types-hidden');
+    },
+    set(key, value) {
+      if (!value) {
+        this.get('storage').removeItem('are-model-types-hidden');
+      } else {
+        this.get('storage').setItem('are-model-types-hidden', value);
       }
-    })
-  },
+      return value;
+    }
+  }),
+  options: {},
 
   sorted: sort('filtered', 'sortProperties'),
 
-  filtered: computed('model.@each.count', 'options.hideEmptyModelTypes', function() {
+  filtered: computed('model.@each.count', 'hideEmptyModelTypes', function() {
     return this.get('model').filter(item => {
-      let hideEmptyModels = get(this, 'options.hideEmptyModelTypes');
+      let hideEmptyModels = get(this, 'hideEmptyModelTypes');
 
       if (hideEmptyModels) {
         return !!get(item, 'count');

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -22,7 +22,6 @@ export default Controller.extend({
       return value;
     }
   }),
-  options: {},
 
   sorted: sort('filtered', 'sortProperties'),
 

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -12,6 +12,8 @@ export default Controller.extend({
   options: {
     hideEmptyModelTypes: computed({
       get() {
+        // TODO fix test resolution lookup
+        if (!this.get) { return false; }
         return !!this.get('storage').getItem('are-model-types-hidden');
       },
       set(key, value) {

--- a/app/templates/model-types-toolbar.hbs
+++ b/app/templates/model-types-toolbar.hbs
@@ -1,5 +1,5 @@
 <div class="toolbar">
     <div class="toolbar__checkbox js-filter-hide-empty-model-typess">
-      {{input type="checkbox" checked=options.hideEmptyModelTypes id="options-hideEmptyModelTypes"}} <label for="options-hideEmptyModelTypes">Hide Empty Model Types</label>
+      {{input type="checkbox" checked=hideEmptyModelTypes id="options-hideEmptyModelTypes"}} <label for="options-hideEmptyModelTypes">Hide Empty Model Types</label>
     </div>
 </div>


### PR DESCRIPTION
Resolve #741.
This is a bad PR in that it does not test the added functionality. I tried adding a test as you can see [here](https://github.com/efx/ember-inspector/tree/fix-741-broken-tests) but `moduleFor` blew up with
<img width="1413" alt="screen shot 2017-12-21 at 5 54 55 pm" src="https://user-images.githubusercontent.com/472721/34278402-8bcda34c-e678-11e7-9aec-3740ef8a93bd.png">

Given end of day before a break, I thought I'd just PR the functionality for whenever you get a chance to review. Thanks for the pointers in the issue. It made this trivial.
