### PR TITLE
Update Inspect Views Icon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
   - "6"
 
 dist: trusty
-sudo: false
+sudo: required
 
 cache:
   yarn: true

--- a/app/templates/view-tree-toolbar.hbs
+++ b/app/templates/view-tree-toolbar.hbs
@@ -1,9 +1,9 @@
 <div class="toolbar">
   <button class="{{if inspectingViews 'active'}} toolbar__icon-button js-inspect-views" {{action "toggleViewInspection"}}>
-    <svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-      <g class="svg-stroke" transform="translate(3.000000, 4.000000)" stroke="#000000" stroke-width="2" fill="none"  fill-rule="evenodd">
-        <path d="M7.5,7.5 L10.5,10.5" stroke-linecap="square"></path>
-        <circle cx="4" cy="4" r="4"></circle>
+    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="17">
+      <g class="svg-fill" fill-rule="evenodd" transform="translate(0, 2)">
+        <path d="M8 7l2.29 8 2.33-2.33L14.81 15l1.14-1.14-2.29-2.29L16 9.25z"/>
+        <path d="M7 13v1H2c-1.13 0-2-.88-2-2V2C0 .88.87 0 2 0h11c1.12 0 2 .88 2 2v4h-1V2c0-.37-.63-1-1-1H2c-.37 0-1 .63-1 1v10c0 .37.62 1 1 1h5z"/>
       </g>
     </svg>
   </button>


### PR DESCRIPTION
The magnifying glass was confusing me so I created an icon that is similar to the inspect icons in Chrome and Firefox.

Original:
<img width="236" alt="original" src="https://user-images.githubusercontent.com/3692/34966658-326b6d72-fa12-11e7-812b-4698a695f046.png">

New Chrome:
<img width="236" alt="new - chrome" src="https://user-images.githubusercontent.com/3692/34966656-324e2be0-fa12-11e7-9cbe-40221f8799cd.png">

New Firefox:
<img width="239" alt="new - firefox" src="https://user-images.githubusercontent.com/3692/34966659-3282ca08-fa12-11e7-9c90-38ccbd121f0e.png">