### PR TITLE
UI Tweaks to Match Latest Inspectors

### DIFF
--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -10,7 +10,7 @@ html, body {
 }
 
 body, input {
-  font-family: "Lucida Grande", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-family: -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Cantarell', 'Oxygen', 'Ubuntu', 'Helvetica Neue', helvetica, arial, sans-serif;
   color: #333;
 }
 

--- a/app/styles/nav.scss
+++ b/app/styles/nav.scss
@@ -15,7 +15,6 @@
   text-overflow: ellipsis;
   overflow: hidden;
   color: #6e6e6e;
-  text-transform: uppercase;
   text-shadow: rgba(255, 255, 255, 0.75) 0 1px 0;
   float: left;
   padding: 0;
@@ -49,7 +48,7 @@
 .nav li > a {
   display: block;
   height: 18px;
-  line-height: 15px;
+  line-height: 18px;
   margin-top: 1px;
   padding: 2px 5px;
   white-space: nowrap;

--- a/app/styles/split.scss
+++ b/app/styles/split.scss
@@ -60,7 +60,7 @@
 .split__panel__ft {
   border-top-width: 1px;
   border-top-style: solid;
-  background: #e8e8e8;
+  background: #F3F3F3;
 }
 
 /* Fix visibility issue with phantomjs test runner
@@ -75,7 +75,7 @@
 /* Custom panels */
 
 .split__panel--sidebar-1 .split__panel__bd {
-  background: #e8e8e8;
+  background: #F3F3F3;
 }
 
 .split__panel--sidebar-1 > .split__panel__ft {

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -501,13 +501,16 @@ export default EmberObject.extend(PortMixin, {
         span.style.background = '#666';
         span.style.color = '#eee';
         span.style.fontFamily = 'helvetica, sans-serif';
-        span.style.fontSize = '12px';
+        span.style.fontSize = '14px';
         span.style.width = '16px';
         span.style.height = '16px';
         span.style.lineHeight = '14px';
         span.style.borderRadius = '16px';
         span.style.textAlign = 'center';
         span.style.cursor = 'pointer';
+        span.style.opacity = '0.5';
+        span.style.fontWeight = 'normal';
+        span.style.textShadow = 'none';
         span.addEventListener('click', (e) => {
           cancelEvent(e);
           this.hideLayer();


### PR DESCRIPTION
- The Lucida Grande font is feeling a bit dated, how about system fonts?

<details>
 <summary>Font Screenshots</summary>

Original:
<img width="457" alt="font - old" src="https://user-images.githubusercontent.com/3692/35016625-4ab8b3fa-face-11e7-96d2-2b613699f940.png">

System font Mac/Chrome:
<img width="457" alt="font - new" src="https://user-images.githubusercontent.com/3692/35016630-50901ef8-face-11e7-8447-9564337b81d1.png">

System font Mac/Firefox:
<img width="480" alt="font - firefox new" src="https://user-images.githubusercontent.com/3692/35016643-618802ac-face-11e7-924f-641013f9e8c2.png">

System font Ubuntu/Firefox:
(alignment of "components" label was not centered for me before the font change)
<img width="488" alt="font - firefox ubuntu new" src="https://user-images.githubusercontent.com/3692/35016648-6a2b0918-face-11e7-9859-0f34a6b27f89.png">
</details>


- I also tweaked the sidebar background color to match what I found in the latest Chrome.

- Last but not least, I tweaked the close button. I felt it was difficult to see and the "x" was way too chunky.
<details>
 <summary>Close Button Screenshots</summary>

Old:

<img width="101" alt="close - old" src="https://user-images.githubusercontent.com/3692/35016766-f358673a-face-11e7-8f4a-d12927513cea.png">

New:

<img width="99" alt="close - new" src="https://user-images.githubusercontent.com/3692/35016767-f3748bb8-face-11e7-9e35-945235b12891.png">
</details>