### PR TITLE
Fix loading main outlet

### DIFF
--- a/ember_debug/libs/glimmer-tree.js
+++ b/ember_debug/libs/glimmer-tree.js
@@ -325,7 +325,9 @@ export default class {
    * @return {Object} The application outlet state
    */
   getApplicationOutlet() {
-    return this.getRoot().outletState.outlets.main;
+    // Support multiple paths to outletState for various Ember versions
+    const outletState = this.getRoot().outletState || this.getRoot().state.ref.outletState;
+    return outletState.outlets.main;
   }
 
   /**


### PR DESCRIPTION
I was trying running the dev mode of this and got errors on my site. I am assuming `getRoot` changed in Ember 3.1 or something in glimmer, but this should support both.