### PR TITLE
Start converting to module imports

### DIFF
--- a/app/adapters/basic.js
+++ b/app/adapters/basic.js
@@ -11,11 +11,11 @@
  * });
  * ```
  */
-import Ember from "ember";
-import config from 'ember-inspector/config/environment';
-const { computed } = Ember;
+import EmberObject, { computed } from '@ember/object';
 
-export default Ember.Object.extend({
+import config from 'ember-inspector/config/environment';
+
+export default EmberObject.extend({
   /**
    * Called when the adapter is created (when
    * the inspector app boots).

--- a/app/adapters/bookmarklet.js
+++ b/app/adapters/bookmarklet.js
@@ -1,7 +1,7 @@
 /* eslint no-useless-escape: 0 */
+import { computed } from '@ember/object';
+
 import BasicAdapter from "./basic";
-import Ember from 'ember';
-const { computed } = Ember;
 
 export default BasicAdapter.extend({
   name: 'bookmarklet',

--- a/app/adapters/web-extension.js
+++ b/app/adapters/web-extension.js
@@ -1,8 +1,8 @@
 /* globals chrome */
+import { computed } from '@ember/object';
+
 import BasicAdapter from "./basic";
-import Ember from 'ember';
 import config from 'ember-inspector/config/environment';
-const { computed } = Ember;
 
 let emberDebug = null;
 

--- a/app/adapters/websocket.js
+++ b/app/adapters/websocket.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
+import { computed } from '@ember/object';
 import BasicAdapter from "./basic";
-const { computed } = Ember;
 
 export default BasicAdapter.extend({
   init() {
@@ -17,7 +17,7 @@ export default BasicAdapter.extend({
 
   _connect() {
     this.get('socket').on('emberInspectorMessage', message => {
-      Ember.run(() => {
+      run(() => {
         this._messageReceived(message);
       });
     });

--- a/app/app.js
+++ b/app/app.js
@@ -1,4 +1,5 @@
-import Ember from 'ember';
+import { typeOf } from '@ember/utils';
+import Application from '@ember/application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
@@ -7,7 +8,7 @@ import PromiseAssembler from "ember-inspector/libs/promise-assembler";
 
 const version = '{{EMBER_INSPECTOR_VERSION}}';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver
@@ -39,7 +40,7 @@ App.initializer({
 
     // register and inject adapter
     let Adapter;
-    if (Ember.typeOf(instance.adapter) === 'string') {
+    if (typeOf(instance.adapter) === 'string') {
       Adapter = instance.resolveRegistration(`adapter:${instance.adapter}`);
     } else {
       Adapter = instance.adapter;

--- a/app/components/action-checkbox.js
+++ b/app/components/action-checkbox.js
@@ -1,5 +1,4 @@
-import Ember from 'ember';
-const { Component } = Ember;
+import Component from '@ember/component';
 
 export default Component.extend({
   tagName: 'input',

--- a/app/components/container-instance.js
+++ b/app/components/container-instance.js
@@ -7,9 +7,9 @@
  *
  * Since it has no tag it has no effect on the DOM hierarchy.
  */
-import Ember from 'ember';
+import Component from '@ember/component';
+
 import RowEventsMixin from 'ember-inspector/mixins/row-events';
-const { Component } = Ember;
 export default Component.extend(RowEventsMixin, {
   /**
    * No tag

--- a/app/components/date-property-field.js
+++ b/app/components/date-property-field.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
+import { on } from '@ember/object/evented';
+import { once } from '@ember/runloop';
 import DatePicker from "ember-inspector/components/pikaday-input";
-const { on, run: { once } } = Ember;
 const KEY_EVENTS = {
   escape: 27
 };

--- a/app/components/deprecation-item-source.js
+++ b/app/components/deprecation-item-source.js
@@ -1,6 +1,6 @@
-import Ember from 'ember';
-const { Component, computed } = Ember;
-const { bool, readOnly, and } = computed;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { bool, readOnly, and } from '@ember/object/computed';
 
 export default Component.extend({
   /**

--- a/app/components/deprecation-item.js
+++ b/app/components/deprecation-item.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
-const { Component, computed } = Ember;
-const { notEmpty } = computed;
+import Component from '@ember/component';
+import { notEmpty } from '@ember/object/computed';
 
 export default Component.extend({
   isExpanded: true,

--- a/app/components/drag-handle.js
+++ b/app/components/drag-handle.js
@@ -1,15 +1,17 @@
-import Ember from "ember";
+import $ from 'jquery';
+import { equal } from '@ember/object/computed';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 
-const { computed, String: { htmlSafe } } = Ember;
-
-export default Ember.Component.extend({
+export default Component.extend({
   classNames: ['drag-handle'],
   classNameBindings: ['isLeft:drag-handle--left', 'isRight:drag-handle--right', 'faded:drag-handle--faded'],
   attributeBindings: ['style'],
   position: 0,
   side: '',
-  isRight: Ember.computed.equal('side', 'right'),
-  isLeft: Ember.computed.equal('side', 'left'),
+  isRight: equal('side', 'right'),
+  isLeft: equal('side', 'left'),
   minWidth: 60,
 
   /**
@@ -56,7 +58,7 @@ export default Ember.Component.extend({
 
     this.sendAction('action', true);
 
-    Ember.$('body').on(`mousemove.${namespace}`, e => {
+    $('body').on(`mousemove.${namespace}`, e => {
       let position = this.get('isLeft') ?
                        e.pageX - $containerOffsetLeft :
                        $containerOffsetRight - e.pageX;
@@ -74,7 +76,7 @@ export default Ember.Component.extend({
 
   stopDragging() {
     this.sendAction('action', false);
-    Ember.$('body').off(`.drag-${this.get('elementId')}`);
+    $('body').off(`.drag-${this.get('elementId')}`);
   },
 
   willDestroyElement() {

--- a/app/components/draggable-column.js
+++ b/app/components/draggable-column.js
@@ -2,9 +2,8 @@
 // ===============
 // A wrapper for a resizable-column and a drag-handle component
 
-import Ember from "ember";
-const { Component, inject } = Ember;
-const { service } = inject;
+import Component from '@ember/component';
+import { inject as service } from '@ember/service';
 
 export default Component.extend({
   tagName: '', // Prevent wrapping in a div

--- a/app/components/icon-button.js
+++ b/app/components/icon-button.js
@@ -1,5 +1,4 @@
-import Ember from "ember";
-const { Component } = Ember;
+import Component from '@ember/component';
 export default Component.extend({
   attributeBindings: ['title'],
 

--- a/app/components/iframe-picker.js
+++ b/app/components/iframe-picker.js
@@ -1,6 +1,8 @@
-import Ember from "ember";
-const { Component, computed, run, observer, getOwner } = Ember;
-const { alias } = computed;
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { observer, computed } from '@ember/object';
+import { getOwner } from '@ember/application';
+import { alias } from '@ember/object/computed';
 
 export default Component.extend({
   model: computed('port.detectedApplications.[]', function() {

--- a/app/components/main-content.js
+++ b/app/components/main-content.js
@@ -1,5 +1,7 @@
-import Ember from "ember";
-const { Component, run: { schedule }, $, inject: { service } } = Ember;
+import Component from '@ember/component';
+import { schedule } from '@ember/runloop';
+import $ from 'jquery';
+import { inject as service } from '@ember/service';
 import { task, timeout } from 'ember-concurrency';
 
 // Currently used to determine the height of list-views

--- a/app/components/mixin-detail.js
+++ b/app/components/mixin-detail.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
-const { computed, Component } = Ember;
-const { readOnly, sort } = computed;
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { readOnly, sort } from '@ember/object/computed';
 
 export default Component.extend({
   /**

--- a/app/components/mixin-details.js
+++ b/app/components/mixin-details.js
@@ -1,5 +1,4 @@
-import Ember from "ember";
-const { Component } = Ember;
+import Component from '@ember/component';
 export default Component.extend({
   actions: {
     traceErrors() {

--- a/app/components/mixin-property.js
+++ b/app/components/mixin-property.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
-const { computed, Component } = Ember;
-const { equal, alias } = computed;
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { equal, alias } from '@ember/object/computed';
 
 export default Component.extend({
   isEdit: false,

--- a/app/components/object-inspector.js
+++ b/app/components/object-inspector.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
-const { Component, computed } = Ember;
-const get = Ember.get;
+import Component from '@ember/component';
+import { computed, get } from '@ember/object';
 export default Component.extend({
   tagName: '',
 

--- a/app/components/promise-item.js
+++ b/app/components/promise-item.js
@@ -1,7 +1,8 @@
-import Ember from "ember";
-
-const { Component, computed, String: { htmlSafe }, isEmpty } = Ember;
-const { notEmpty, gt, equal } = computed;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+import { isEmpty } from '@ember/utils';
+import { notEmpty, gt, equal } from '@ember/object/computed';
 
 const COLOR_MAP = {
   red: '#ff2717',

--- a/app/components/property-field.js
+++ b/app/components/property-field.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-export default Ember.TextField.extend({
+import TextField from '@ember/component/text-field';
+export default TextField.extend({
   attributeBindings: ['label:data-label'],
 
   /**

--- a/app/components/record-filter.js
+++ b/app/components/record-filter.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-const { computed, Component } = Ember;
+import { computed } from '@ember/object';
+import Component from '@ember/component';
 export default Component.extend({
   filterValue: null,
   checked: computed('filterValue', 'model.name', function() {

--- a/app/components/record-item.js
+++ b/app/components/record-item.js
@@ -1,6 +1,8 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+import { isEmpty } from '@ember/utils';
 import RowEventsMixin from 'ember-inspector/mixins/row-events';
-const { Component, computed, String: { htmlSafe }, isEmpty } = Ember;
 const COLOR_MAP = {
   red: '#ff2717',
   blue: '#174fff',

--- a/app/components/render-item.js
+++ b/app/components/render-item.js
@@ -1,8 +1,12 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { isNone, isEmpty } from '@ember/utils';
+import { run } from '@ember/runloop';
+import { on } from '@ember/object/evented';
+import { observer, computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
 
-const { Component, computed, isEmpty, isNone, run, on, observer, String: { htmlSafe } } = Ember;
-const { gt } = computed;
+import { gt } from '@ember/object/computed';
 const { once } = run;
 
 export default Component.extend({

--- a/app/components/resizable-column.js
+++ b/app/components/resizable-column.js
@@ -1,5 +1,6 @@
-import Ember from "ember";
-const { Component, computed, String: { htmlSafe } } = Ember;
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 export default Component.extend({
   width: null,
 

--- a/app/components/route-item.js
+++ b/app/components/route-item.js
@@ -1,6 +1,7 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 import checkCurrentRoute from "ember-inspector/utils/check-current-route";
-const { Component, computed, String: { htmlSafe } } = Ember;
 
 export default Component.extend({
   // passed as an attribute to the component

--- a/app/components/send-to-console.js
+++ b/app/components/send-to-console.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-export default Ember.Component.extend({
+import Component from '@ember/component';
+export default Component.extend({
   tagName: 'button',
   classNames: ['send-to-console', 'js-send-to-console-btn'],
   action: 'sendValueToConsole',

--- a/app/components/sidebar-toggle.js
+++ b/app/components/sidebar-toggle.js
@@ -1,5 +1,6 @@
-import Ember from "ember";
-export default Ember.Component.extend({
+import { equal } from '@ember/object/computed';
+import Component from '@ember/component';
+export default Component.extend({
 
   tagName: 'button',
 
@@ -7,7 +8,7 @@ export default Ember.Component.extend({
 
   isExpanded: false,
 
-  isRight: Ember.computed.equal('side', 'right'),
+  isRight: equal('side', 'right'),
 
   classNames: 'sidebar-toggle',
 

--- a/app/components/view-item.js
+++ b/app/components/view-item.js
@@ -1,7 +1,8 @@
-import Ember from "ember";
+import { computed } from '@ember/object';
+import Component from '@ember/component';
+import { htmlSafe } from '@ember/string';
 import RowEventsMixin from 'ember-inspector/mixins/row-events';
-const { computed, Component, String: { htmlSafe } } = Ember;
-const { not, bool, equal } = computed;
+import { not, bool, equal } from '@ember/object/computed';
 
 export default Component.extend(RowEventsMixin, {
   /**

--- a/app/components/x-app.js
+++ b/app/components/x-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-const { Component, computed: { not } } = Ember;
+import Component from '@ember/component';
+import { not } from '@ember/object/computed';
 export default Component.extend({
   classNames: ['app'],
 

--- a/app/components/x-list-cell.js
+++ b/app/components/x-list-cell.js
@@ -14,8 +14,10 @@
  * {{/xlist}}
  * ```
  */
-import Ember from 'ember';
-const { Component, computed, String: { htmlSafe } } = Ember;
+import Component from '@ember/component';
+
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
 export default Component.extend({
   /**
    * Defaults to a table cell. For headers

--- a/app/components/x-list-content.js
+++ b/app/components/x-list-content.js
@@ -1,8 +1,9 @@
-import Ember from 'ember';
-
-const { Component, computed, String: { htmlSafe }, Evented, run, Object: EmberObject, inject } = Ember;
-const { schedule } = run;
-const { service } = inject;
+import Component from '@ember/component';
+import { htmlSafe } from '@ember/string';
+import Evented from '@ember/object/evented';
+import EmberObject, { computed } from '@ember/object';
+import { run, schedule } from '@ember/runloop';
+import { inject as service } from '@ember/service';
 
 /**
  * Base list view config

--- a/app/components/x-list.js
+++ b/app/components/x-list.js
@@ -1,12 +1,11 @@
-import Ember from 'ember';
+import Component from '@ember/component';
+import { run, scheduleOnce } from '@ember/runloop';
+import $ from 'jquery';
 import { task, timeout } from 'ember-concurrency';
 import ResizableColumns from 'ember-inspector/libs/resizable-columns';
 import LocalStorageService from "ember-inspector/services/storage/local";
-
-const { Component, run, computed, inject, $ } = Ember;
-const { scheduleOnce } = run;
-const { service } = inject;
-const { readOnly, reads } = computed;
+import { inject as service } from '@ember/service';
+import { readOnly, reads } from '@ember/object/computed';
 
 const CHECK_HTML = '&#10003;';
 
@@ -208,7 +207,7 @@ export default Component.extend({
    * @method willDestroyElement
    */
   willDestroyElement() {
-    Ember.$(window).off(`.${this.get('elementId')}`);
+    $(window).off(`.${this.get('elementId')}`);
     this.$('.list__header').contextMenu('destroy');
     this.get('layout').off('resize', this.onResize);
     return this._super(...arguments);

--- a/app/computed/debounce.js
+++ b/app/computed/debounce.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-const { run, computed } = Ember;
+import { run } from '@ember/runloop';
+import { computed } from '@ember/object';
 const { debounce } = run;
 
 // Use this if you want a property to debounce

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
-
-const { Controller, computed, computed: { equal } } = Ember;
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+import { equal } from '@ember/object/computed';
 
 export default Controller.extend({
   isDragging: false,

--- a/app/controllers/container-type.js
+++ b/app/controllers/container-type.js
@@ -1,8 +1,8 @@
-import Ember from "ember";
+import { get } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
 import debounceComputed from "ember-inspector/computed/debounce";
 import searchMatch from "ember-inspector/utils/search-match";
-const { Controller, computed, get, inject: { controller } } = Ember;
-const { filter } = computed;
+import { filter } from '@ember/object/computed';
 
 export default Controller.extend({
   application: controller(),

--- a/app/controllers/container-types.js
+++ b/app/controllers/container-types.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-const { Controller, computed: { sort } } = Ember;
+import Controller from '@ember/controller';
+import { sort } from '@ember/object/computed';
 
 export default Controller.extend({
   sortProperties: ['name'],

--- a/app/controllers/deprecations.js
+++ b/app/controllers/deprecations.js
@@ -1,8 +1,8 @@
-import Ember from "ember";
+import { get } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
 import debounceComputed from "ember-inspector/computed/debounce";
 import searchMatch from "ember-inspector/utils/search-match";
-const { Controller, computed, get, inject: { controller } } = Ember;
-const { filter } = computed;
+import { filter } from '@ember/object/computed';
 
 export default Controller.extend({
   /**

--- a/app/controllers/info.js
+++ b/app/controllers/info.js
@@ -1,5 +1,4 @@
-import Ember from 'ember';
-const { Controller, inject: { controller } } = Ember;
+import Controller, { inject as controller } from '@ember/controller';
 
 export default Controller.extend({
   application: controller()

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -1,8 +1,8 @@
-import Ember from 'ember';
+import Controller, { inject as controller } from '@ember/controller';
+import { get, computed } from '@ember/object';
 import LocalStorageService from 'ember-inspector/services/storage/local';
-const { Controller, computed, get, inject } = Ember;
-const { sort } = computed;
-const { controller, service } = inject;
+import { sort } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
 
 export default Controller.extend({
   application: controller(),

--- a/app/controllers/promise-tree.js
+++ b/app/controllers/promise-tree.js
@@ -1,8 +1,8 @@
-import Ember from "ember";
-
-const { Controller, computed, observer, run, inject: { controller }, isEmpty } = Ember;
-const { equal, bool, and, not, filter } = computed;
-const { next, once, debounce } = run;
+import { observer } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
+import { isEmpty } from '@ember/utils';
+import { equal, bool, and, not, filter } from '@ember/object/computed';
+import { debounce, next, once } from '@ember/runloop';
 
 export default Controller.extend({
   application: controller(),

--- a/app/controllers/records.js
+++ b/app/controllers/records.js
@@ -1,9 +1,9 @@
-import Ember from "ember";
+import { isEmpty } from '@ember/utils';
+import { observer, computed, get } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
-const { Controller, computed, observer, inject: { controller }, String } = Ember;
-const { none, readOnly } = computed;
-const { dasherize } = String;
-const get = Ember.get;
+import { none, readOnly } from '@ember/object/computed';
+import { dasherize } from '@ember/string';
 
 export default Controller.extend({
   application: controller(),
@@ -82,7 +82,7 @@ export default Controller.extend({
       }
 
       // check search
-      if (!Ember.isEmpty(search)) {
+      if (!isEmpty(search)) {
         let searchString = this.recordToString(item);
         return !!searchString.match(new RegExp(`.*${escapeRegExp(search.toLowerCase())}.*`));
       }
@@ -110,7 +110,7 @@ export default Controller.extend({
      * @property {Object}
      */
     inspectModel(model) {
-      this.get('port').send('data:inspectModel', { objectId: Ember.get(model, 'objectId') });
+      this.get('port').send('data:inspectModel', { objectId: get(model, 'objectId') });
     }
   }
 });

--- a/app/controllers/render-tree.js
+++ b/app/controllers/render-tree.js
@@ -1,11 +1,11 @@
-import Ember from "ember";
+import { computed, get } from '@ember/object';
+import { isEmpty } from '@ember/utils';
+import Controller, { inject as controller } from '@ember/controller';
+import { inject as service } from '@ember/service';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
 import debounceComputed from "ember-inspector/computed/debounce";
 import LocalStorageService from "ember-inspector/services/storage/local";
-
-const { computed, isEmpty, Controller, inject: { controller, service } } = Ember;
-const { and, equal, filter } = computed;
-const get = Ember.get;
+import { and, equal, filter } from '@ember/object/computed';
 
 export default Controller.extend({
   application: controller(),

--- a/app/controllers/route-tree.js
+++ b/app/controllers/route-tree.js
@@ -1,7 +1,7 @@
-import Ember from "ember";
+import { alias } from '@ember/object/computed';
+import { computed } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
 import checkCurrentRoute from "ember-inspector/utils/check-current-route";
-
-const { Controller, computed, inject: { controller } } = Ember;
 
 export default Controller.extend({
   application: controller(),
@@ -9,7 +9,7 @@ export default Controller.extend({
   queryParams: ['hideRoutes'],
 
   currentRoute: null,
-  hideRoutes: computed.alias('options.hideRoutes'),
+  hideRoutes: alias('options.hideRoutes'),
 
   options: {
     hideRoutes: false

--- a/app/controllers/view-tree.js
+++ b/app/controllers/view-tree.js
@@ -1,7 +1,8 @@
-import Ember from "ember";
+import { on } from '@ember/object/evented';
+import { observer, get } from '@ember/object';
+import Controller, { inject as controller } from '@ember/controller';
 import searchMatch from "ember-inspector/utils/search-match";
-const { computed, Controller, get, on, observer, inject: { controller } } = Ember;
-const { alias, filter } = computed;
+import { alias, filter } from '@ember/object/computed';
 
 export default Controller.extend({
   application: controller(),

--- a/app/helpers/build-style.js
+++ b/app/helpers/build-style.js
@@ -8,8 +8,9 @@
  * @param {Object} options The options that become styles
  * @return {String} The style sting.
  */
-import Ember from 'ember';
-const { Helper: { helper }, String: { htmlSafe } } = Ember;
+import { helper } from '@ember/component/helper';
+
+import { htmlSafe } from '@ember/string';
 const { keys } = Object;
 
 export function buildStyle(_, options) {

--- a/app/helpers/escape-url.js
+++ b/app/helpers/escape-url.js
@@ -1,5 +1,4 @@
-import Ember from 'ember';
-const { Helper: { helper } } = Ember;
+import { helper } from '@ember/component/helper';
 /**
  * Escape a url component
  *

--- a/app/helpers/ms-to-time.js
+++ b/app/helpers/ms-to-time.js
@@ -1,5 +1,4 @@
-import Ember from 'ember';
-const { Helper: { helper } } = Ember;
+import { helper } from '@ember/component/helper';
 
 export function msToTime([time]) {
   if (time && !isNaN(+time)) {

--- a/app/helpers/one-way.js
+++ b/app/helpers/one-way.js
@@ -6,8 +6,7 @@
  * @param {Array} [val] The array containing one value.
  * @return {Any} The value passed
  */
-import Ember from 'ember';
-const { Helper: { helper } } = Ember;
+import { helper } from '@ember/component/helper';
 
 export function oneWay([val]) {
   return val;

--- a/app/helpers/schema-for.js
+++ b/app/helpers/schema-for.js
@@ -7,8 +7,9 @@
  * @param {Array} [name] First element is the name of the schema
  * @return {Object} The schema
  */
-import Ember from 'ember';
-const { Helper, getOwner } = Ember;
+import Helper from '@ember/component/helper';
+
+import { getOwner } from '@ember/application';
 export default Helper.extend({
   compute([name]) {
     return getOwner(this).resolveRegistration(`schema:${name}`);

--- a/app/libs/promise-assembler.js
+++ b/app/libs/promise-assembler.js
@@ -1,17 +1,19 @@
-import Ember from "ember";
+import { assert } from '@ember/debug';
+import { copy } from '@ember/object/internals';
+import { later } from '@ember/runloop';
+import EmberObject, { computed } from '@ember/object';
+import EventedMixin from '@ember/object/evented';
 import Promise from "ember-inspector/models/promise";
 
-let EventedMixin = Ember.Evented;
-
-let arrayComputed = Ember.computed(function() {
+let arrayComputed = computed(function() {
   return [];
 });
 
-let objectComputed = Ember.computed(function() {
+let objectComputed = computed(function() {
   return {};
 });
 
-export default Ember.Object.extend(EventedMixin, {
+export default EmberObject.extend(EventedMixin, {
   all: arrayComputed,
   topSort: arrayComputed,
   topSortMeta: objectComputed,
@@ -43,7 +45,7 @@ export default Ember.Object.extend(EventedMixin, {
     // Lazily destroy promises
     // Allows for a smooth transition on deactivate,
     // and thus providing the illusion of better perf
-    Ember.run.later(this, function() {
+    later(this, function() {
       this.destroyPromises(all);
     }, 500);
     this.set('all', []);
@@ -66,7 +68,7 @@ export default Ember.Object.extend(EventedMixin, {
 
   rebuildPromises(promises) {
     promises.forEach(props => {
-      props = Ember.copy(props);
+      props = copy(props);
       let childrenIds = props.children;
       let parentId = props.parent;
       delete props.children;
@@ -161,7 +163,7 @@ export default Ember.Object.extend(EventedMixin, {
 
   findOrCreate(guid) {
     if (!guid) {
-      Ember.assert('You have tried to findOrCreate without a guid');
+      assert('You have tried to findOrCreate without a guid');
     }
     return this.find(guid) || this.createPromise({ guid });
   }

--- a/app/libs/resizable-columns.js
+++ b/app/libs/resizable-columns.js
@@ -4,9 +4,12 @@
  *
  * Uses local storage to cache a user's preferred settings.
  */
-import Ember from 'ember';
+import { set } from '@ember/object';
+
+import { isNone } from '@ember/utils';
+import { copy } from '@ember/object/internals';
+import { merge } from '@ember/polyfills';
 import compareArrays from 'ember-inspector/utils/compare-arrays';
-const { set, isNone, copy, merge } = Ember;
 const { floor } = Math;
 const { keys } = Object;
 const THIRTY_DAYS_FROM_NOW = 1000 * 60 * 60 * 24 * 30;

--- a/app/mixins/row-events.js
+++ b/app/mixins/row-events.js
@@ -6,8 +6,11 @@
  * the yielded `x-list` and index to it. Then you'll be able to listen
  * to events on `rowEvents`.
  */
-import Ember from 'ember';
-const { Mixin, assert, isNone, computed: { readOnly } } = Ember;
+import Mixin from '@ember/object/mixin';
+
+import { assert } from '@ember/debug';
+import { isNone } from '@ember/utils';
+import { readOnly } from '@ember/object/computed';
 
 export default Mixin.create({
   /**

--- a/app/models/promise.js
+++ b/app/models/promise.js
@@ -1,6 +1,9 @@
-import Ember from "ember";
+import { once } from '@ember/runloop';
+import $ from 'jquery';
+import { typeOf, isEmpty } from '@ember/utils';
+import EmberObject, { computed, observer } from '@ember/object';
+import { not, equal, or } from '@ember/object/computed';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
-const { $, observer, typeOf, computed, computed: { or, equal, not } } = Ember;
 
 const dateComputed = function() {
   return computed({
@@ -18,7 +21,7 @@ const dateComputed = function() {
   });
 };
 
-export default Ember.Object.extend({
+export default EmberObject.extend({
   createdAt: dateComputed(),
   settledAt: dateComputed(),
 
@@ -95,7 +98,7 @@ export default Ember.Object.extend({
   }),
 
   addBranchLabel(label, replace) {
-    if (Ember.isEmpty(label)) {
+    if (isEmpty(label)) {
       return;
     }
     if (replace) {
@@ -131,7 +134,7 @@ export default Ember.Object.extend({
   stateOrParentChanged: observer('isPending', 'isFulfilled', 'isRejected', 'parent', function() {
     let parent = this.get('parent');
     if (parent) {
-      Ember.run.once(parent, 'recalculateExpanded');
+      once(parent, 'recalculateExpanded');
     }
   }),
 

--- a/app/port.js
+++ b/app/port.js
@@ -1,7 +1,7 @@
-import Ember from "ember";
-const { computed } = Ember;
+import Evented from '@ember/object/evented';
+import EmberObject, { computed } from '@ember/object';
 
-export default Ember.Object.extend(Ember.Evented, {
+export default EmberObject.extend(Evented, {
   applicationId: undefined,
 
   detectedApplications: computed(function() {

--- a/app/router.js
+++ b/app/router.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import EmberRouter from '@ember/routing/router';
 import config from './config/environment';
 
-const Router = Ember.Router.extend({
+const Router = EmberRouter.extend({
   location: config.locationType,
   rootURL: config.rootURL
 });

--- a/app/routes/app-detected.js
+++ b/app/routes/app-detected.js
@@ -1,5 +1,6 @@
-import Ember from 'ember';
-const { Route, RSVP: { Promise }, getOwner } = Ember;
+import Route from '@ember/routing/route';
+import { Promise } from 'rsvp';
+import { getOwner } from '@ember/application';
 
 export default Route.extend({
   model() {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,9 +1,11 @@
+import { set, get } from '@ember/object';
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { schedule } from '@ember/runloop';
 import Ember from "ember";
-const { Route, inject, run, NativeArray } = Ember;
-const { service } = inject;
-const { schedule } = run;
-const set = Ember.set;
-const get = Ember.get;
+const {
+  NativeArray
+} = Ember;
 
 export default Route.extend({
 

--- a/app/routes/container-type.js
+++ b/app/routes/container-type.js
@@ -1,7 +1,6 @@
-import Ember from "ember";
+import { Promise } from 'rsvp';
+import { get } from '@ember/object';
 import TabRoute from "ember-inspector/routes/tab";
-const get = Ember.get;
-const { RSVP: { Promise } } = Ember;
 
 export default TabRoute.extend({
   setupController(controller) {

--- a/app/routes/container-types.js
+++ b/app/routes/container-types.js
@@ -1,5 +1,5 @@
-import Ember from "ember";
-const { Route, RSVP: { Promise } } = Ember;
+import Route from '@ember/routing/route';
+import { Promise } from 'rsvp';
 
 export default Route.extend({
   model() {

--- a/app/routes/data/index.js
+++ b/app/routes/data/index.js
@@ -1,7 +1,7 @@
-import Ember from "ember";
-const { RSVP: { Promise } } = Ember;
+import Route from '@ember/routing/route';
+import { Promise } from 'rsvp';
 
-export default Ember.Route.extend({
+export default Route.extend({
   model() {
     let route = this;
     return new Promise(function(resolve) {

--- a/app/routes/deprecations.js
+++ b/app/routes/deprecations.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
+import { set } from '@ember/object';
 import TabRoute from "ember-inspector/routes/tab";
-const set = Ember.set;
 
 export default TabRoute.extend({
   setupController() {

--- a/app/routes/info.js
+++ b/app/routes/info.js
@@ -1,8 +1,6 @@
-import Ember from "ember";
+import { Promise } from 'rsvp';
 import TabRoute from "ember-inspector/routes/tab";
-
-const { RSVP: { Promise }, computed } = Ember;
-const { oneWay } = computed;
+import { oneWay } from '@ember/object/computed';
 
 export default TabRoute.extend({
   version: oneWay('config.VERSION').readOnly(),

--- a/app/routes/model-type.js
+++ b/app/routes/model-type.js
@@ -1,7 +1,8 @@
-import Ember from "ember";
-const { RSVP: { Promise } } = Ember;
+import { get } from '@ember/object';
+import Route from '@ember/routing/route';
+import { Promise } from 'rsvp';
 /*eslint camelcase: 0 */
-export default Ember.Route.extend({
+export default Route.extend({
   setupController(controller, model) {
     this._super(controller, model);
     this.controllerFor('model-types').set('selected', model);
@@ -23,6 +24,6 @@ export default Ember.Route.extend({
   },
 
   serialize(model) {
-    return { type_id: Ember.get(model, 'name') };
+    return { type_id: get(model, 'name') };
   }
 });

--- a/app/routes/model-types.js
+++ b/app/routes/model-types.js
@@ -1,6 +1,6 @@
-import Ember from "ember";
+import { set } from '@ember/object';
+import { Promise } from 'rsvp';
 import TabRoute from "ember-inspector/routes/tab";
-const { RSVP: { Promise } } = Ember;
 
 export default TabRoute.extend({
   setupController(controller, model) {
@@ -33,7 +33,7 @@ export default TabRoute.extend({
     let route = this;
     message.modelTypes.forEach(function(modelType) {
       const currentType = route.get('currentModel').findBy('objectId', modelType.objectId);
-      Ember.set(currentType, 'count', modelType.count);
+      set(currentType, 'count', modelType.count);
     });
   }
 });

--- a/app/routes/promise-tree.js
+++ b/app/routes/promise-tree.js
@@ -1,7 +1,5 @@
-import Ember from "ember";
+import { Promise } from 'rsvp';
 import TabRoute from "ember-inspector/routes/tab";
-
-const { RSVP: { Promise } } = Ember;
 
 export default TabRoute.extend({
   model() {

--- a/app/routes/records.js
+++ b/app/routes/records.js
@@ -1,7 +1,5 @@
-import Ember from "ember";
+import { set } from '@ember/object';
 import TabRoute from "ember-inspector/routes/tab";
-
-const set = Ember.set;
 
 export default TabRoute.extend({
   setupController(controller, model) {

--- a/app/routes/render-tree.js
+++ b/app/routes/render-tree.js
@@ -1,7 +1,5 @@
-import Ember from "ember";
+import { Promise } from 'rsvp';
 import TabRoute from "ember-inspector/routes/tab";
-
-const { RSVP: { Promise } } = Ember;
 
 export default TabRoute.extend({
   model() {

--- a/app/routes/route-tree.js
+++ b/app/routes/route-tree.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
+import $ from 'jquery';
 import TabRoute from "ember-inspector/routes/tab";
-const $ = Ember.$;
 
 export default TabRoute.extend({
   setupController() {

--- a/app/routes/tab.js
+++ b/app/routes/tab.js
@@ -1,6 +1,6 @@
 /* eslint no-empty:0 */
-import Ember from "ember";
-export default Ember.Route.extend({
+import Route from '@ember/routing/route';
+export default Route.extend({
   renderTemplate() {
     this.render();
     try {

--- a/app/routes/view-tree.js
+++ b/app/routes/view-tree.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
+import $ from 'jquery';
 import TabRoute from "ember-inspector/routes/tab";
-const $ = Ember.$;
 
 export default TabRoute.extend({
   model() {

--- a/app/services/layout.js
+++ b/app/services/layout.js
@@ -10,8 +10,9 @@
  * @class Layout
  * @extends Service
  */
-import Ember from 'ember';
-const { Service, Evented } = Ember;
+import Service from '@ember/service';
+
+import Evented from '@ember/object/evented';
 export default Service.extend(Evented, {
   /**
    * Stores the app's content height. This property is kept up-to-date

--- a/app/services/storage/local.js
+++ b/app/services/storage/local.js
@@ -5,8 +5,9 @@
  * @class Local
  * @extends Service
  */
-import Ember from 'ember';
-const { Service, isNone } = Ember;
+import Service from '@ember/service';
+
+import { isNone } from '@ember/utils';
 const { parse, stringify } = JSON;
 let LOCAL_STORAGE_SUPPORTED;
 

--- a/app/services/storage/memory.js
+++ b/app/services/storage/memory.js
@@ -5,8 +5,9 @@
  * @class Memory
  * @extends Service
  */
-import Ember from 'ember';
-const { Service, computed } = Ember;
+import Service from '@ember/service';
+
+import { computed } from '@ember/object';
 const { keys } = Object;
 
 export default Service.extend({

--- a/app/utils/search-match.js
+++ b/app/utils/search-match.js
@@ -1,6 +1,5 @@
-import Ember from "ember";
+import { isEmpty } from '@ember/utils';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
-const { isEmpty } = Ember;
 
 export default function(text, searchQuery) {
   if (isEmpty(searchQuery)) {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ember-async-image": "0.1.1",
     "ember-cli": "~2.13.3 ",
     "ember-cli-app-version": "^3.0.0",
-    "ember-cli-babel": "^6.4.0",
+    "ember-cli-babel": "^6.6.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-deprecation-workflow": "^0.2.2",
     "ember-cli-eslint": "^3.0.0",

--- a/tests/acceptance/container-test.js
+++ b/tests/acceptance/container-test.js
@@ -1,8 +1,16 @@
+import { run } from '@ember/runloop';
 import Ember from "ember";
 import { module } from 'qunit';
 import { test } from 'ember-qunit';
 import startApp from '../helpers/start-app';
-import { visit, findAll, find, click, fillIn, currentURL } from 'ember-native-dom-helpers';
+import {
+  visit,
+  findAll,
+  find,
+  click,
+  fillIn,
+  currentURL
+} from 'ember-native-dom-helpers';
 let App;
 
 let port, message, name;
@@ -17,7 +25,7 @@ module('Container Tab', {
   afterEach() {
     name = null;
     message = null;
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/data-test.js
+++ b/tests/acceptance/data-test.js
@@ -1,10 +1,11 @@
-import Ember from "ember";
+import { guidFor } from '@ember/object/internals';
+import EmberObject from '@ember/object';
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 import { visit, findAll, click, fillIn } from 'ember-native-dom-helpers';
 
-const { run } = Ember;
 let App;
 
 let port, name;
@@ -71,10 +72,10 @@ function recordFactory(attr, filterValues) {
   for (let i in attr) {
     searchKeywords.push(attr[i]);
   }
-  let object = Ember.Object.create();
+  let object = EmberObject.create();
   return {
     columnValues: attr,
-    objectId: attr.objectId || Ember.guidFor(object),
+    objectId: attr.objectId || guidFor(object),
     filterValues,
     searchKeywords
   };

--- a/tests/acceptance/deprecation-test.js
+++ b/tests/acceptance/deprecation-test.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
@@ -46,7 +46,7 @@ module('Deprecation Tab', {
   afterEach() {
     name = null;
     message = null;
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/info-test.js
+++ b/tests/acceptance/info-test.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
@@ -28,7 +28,7 @@ module('Info Tab', {
     });
   },
   afterEach() {
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/object-inspector-test.js
+++ b/tests/acceptance/object-inspector-test.js
@@ -1,8 +1,15 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
-import { visit, find, findAll, click, fillIn, keyEvent } from 'ember-native-dom-helpers';
+import {
+  visit,
+  find,
+  findAll,
+  click,
+  fillIn,
+  keyEvent
+} from 'ember-native-dom-helpers';
 
 let App;
 let port, message, name;
@@ -24,7 +31,7 @@ module('Object Inspector', {
   afterEach() {
     name = null;
     message = null;
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/promise-test.js
+++ b/tests/acceptance/promise-test.js
@@ -1,4 +1,4 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
@@ -28,7 +28,7 @@ module('Promise Tab', {
   afterEach() {
     name = null;
     message = null;
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/render-tree-test.js
+++ b/tests/acceptance/render-tree-test.js
@@ -1,8 +1,14 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
-import { visit, find, findAll, click, fillIn } from 'ember-native-dom-helpers';
+import {
+  visit,
+  find,
+  findAll,
+  click,
+  fillIn
+} from 'ember-native-dom-helpers';
 let App;
 
 let port;
@@ -18,7 +24,7 @@ module('Render Tree Tab', {
     });
   },
   afterEach() {
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/acceptance/route-tree-test.js
+++ b/tests/acceptance/route-tree-test.js
@@ -1,11 +1,16 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
-import { visit, find, findAll, click, triggerEvent } from 'ember-native-dom-helpers';
+import {
+  visit,
+  find,
+  findAll,
+  click,
+  triggerEvent
+} from 'ember-native-dom-helpers';
 
 let App;
-const { run } = Ember;
 
 let port;
 

--- a/tests/acceptance/view-tree-test.js
+++ b/tests/acceptance/view-tree-test.js
@@ -1,11 +1,17 @@
-import Ember from "ember";
+import { run } from '@ember/runloop';
 import { test } from 'ember-qunit';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
-import { visit, fillIn, find, findAll, click, triggerEvent } from 'ember-native-dom-helpers';
+import {
+  visit,
+  fillIn,
+  find,
+  findAll,
+  click,
+  triggerEvent
+} from 'ember-native-dom-helpers';
 
 let App;
-const { run } = Ember;
 
 let port;
 
@@ -17,7 +23,7 @@ module('View Tree Tab', {
     port = App.__container__.lookup('port:main');
   },
   afterEach() {
-    Ember.run(App, App.destroy);
+    run(App, App.destroy);
   }
 });
 

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
+import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,9 +1,7 @@
+import { Promise } from 'rsvp';
 import { module } from 'qunit';
-import Ember from 'ember';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
-
-const { RSVP: { Promise } } = Ember;
 
 export default function(name, options = {}) {
   module(name, {

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -1,5 +1,9 @@
 /* eslint no-unused-vars: 0 */
 
+import { run } from '@ember/runloop';
+
+import { merge } from '@ember/polyfills';
+
 import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
@@ -8,8 +12,8 @@ const { generateGuid } = Ember;
 
 export default function startApp(attrs) {
 
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
 
   Application.instanceInitializer({
     name: `${generateGuid()}-detectEmberApplication`,
@@ -20,7 +24,7 @@ export default function startApp(attrs) {
     }
   });
 
-  return Ember.run(() => {
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();

--- a/tests/helpers/trigger-port.js
+++ b/tests/helpers/trigger-port.js
@@ -1,5 +1,5 @@
-import Ember from 'ember';
-const { run, Test: { registerHelper } } = Ember;
+import { run } from '@ember/runloop';
+import { registerHelper } from '@ember/test';
 export default registerHelper('triggerPort', async function t(app, ...args) {
   run(() => app.__container__.lookup('port:main').trigger(...args));
   await wait();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2466,7 +2466,7 @@ ember-cli-babel@^5.0.0, ember-cli-babel@^5.1.5, ember-cli-babel@^5.1.6, ember-cl
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.4.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.10.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.0, ember-cli-babel@^6.8.1:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.11.0.tgz#79cb184bac3c05bfe181ddc306bac100ab1f9493"
   dependencies:


### PR DESCRIPTION
If I understand correctly, we cannot use modules in `ember_debug`, since it uses Ember versions from the apps right or can we enforce the `ember-cli-babel` version?

Assuming we needed to leave things as is there, I just converted to module imports in our actual `app` directory.

Is this correct @teddyzeenny?