### PR TITLE
Fix file paths displayed in the Routes tab

### DIFF
--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -2,7 +2,7 @@ import PortMixin from 'ember-debug/mixins/port-mixin';
 
 const Ember = window.Ember;
 const { String: { classify, dasherize }, computed, observer, run: { later }, Object: EmberObject, getOwner } = Ember;
-const { oneWay } = computed;
+const { oneWay, readOnly } = computed;
 
 const { hasOwnProperty } = Object.prototype;
 
@@ -25,7 +25,7 @@ export default EmberObject.extend(PortMixin, {
 
   portNamespace: 'route',
 
-  emberCliConfig: oneWay('namespace.generalDebug.emberCliConfig').readOnly(),
+  emberCliConfig: readOnly('namespace.generalDebug.emberCliConfig'),
 
   messages: {
     getTree() {


### PR DESCRIPTION
- `emberCliConfig` was always false, using `getAttribute` instead of `attr` fixes the issue.
- From ember 2.7.0 the libraries are always found in `libraries._registry`, so we remove support for older versions.
- Documented `ember_debug/general-debug.js`.