### PR TITLE
WIP: Context menu item for "Inspect Ember Component"

### DIFF
--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -71,12 +71,14 @@ const flattenSearchTree = (
 
 export default Controller.extend({
   application: controller(),
+  queryParams: ['pinnedObjectId'],
   pinnedObjectId: null,
   inspectingViews: false,
   components: true,
   options: {
     components: true,
   },
+  viewTreeLoaded: false,
 
   /**
    * Bound to the search field to filter the component list.

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,6 +18,7 @@ export default Route.extend({
     port.on('objectInspector:updateErrors', this, this.updateErrors);
     port.on('objectInspector:droppedObject', this, this.droppedObject);
     port.on('deprecation:count', this, this.setDeprecationCount);
+    port.on('view:inspectComponent', this, this.inspectComponent);
     port.send('deprecation:getCount');
   },
 
@@ -28,6 +29,19 @@ export default Route.extend({
     port.off('objectInspector:updateErrors', this, this.updateErrors);
     port.off('objectInspector:droppedObject', this, this.droppedObject);
     port.off('deprecation:count', this, this.setDeprecationCount);
+    port.off('view:inspectComponent', this, this.inspectComponent);
+  },
+
+  inspectComponent({ viewId }) {
+    const isActive = this.get('controller.active');
+    if (!isActive) {
+      //TODO: Tell the user to open the Ember devtools panel
+    }
+    this.transitionTo('component-tree', {
+      queryParams: {
+        pinnedObjectId: viewId
+      }
+    });
   },
 
   updateObject(options) {

--- a/app/routes/component-tree.js
+++ b/app/routes/component-tree.js
@@ -1,13 +1,20 @@
 import TabRoute from "ember-inspector/routes/tab";
 
 export default TabRoute.extend({
+  queryParams: {
+    pinnedObjectId: {
+      replace: true
+    }
+  },
+
   setupController() {
     this._super(...arguments);
     this.get('port').on('view:viewTree', this, this.setViewTree);
     this.get('port').on('view:stopInspecting', this, this.stopInspecting);
     this.get('port').on('view:startInspecting', this, this.startInspecting);
     this.get('port').on('view:inspectDOMElement', this, this.inspectDOMElement);
-    this.get('port').on('view:inspectComponent', this, this.inspectComponent);
+
+    this.set('controller.viewTreeLoaded', false);
     this.get('port').send('view:setOptions', { options: this.get('controller.options') });
     this.get('port').send('view:getTree');
   },
@@ -17,12 +24,17 @@ export default TabRoute.extend({
     this.get('port').off('view:stopInspecting', this, this.stopInspecting);
     this.get('port').off('view:startInspecting', this, this.startInspecting);
     this.get('port').off('view:inspectDOMElement', this, this.inspectDOMElement);
-    this.get('port').off('view:inspectComponent', this, this.inspectComponent);
-
   },
 
   setViewTree(options) {
     this.set('controller.viewTree', options.tree);
+    this.set('controller.viewTreeLoaded', true);
+
+    // If we're waiting for view tree to inspect a component
+    const componentToInspect = this.get('controller.pinnedObjectId');
+    if (componentToInspect) {
+      this.inspectComponent(componentToInspect);
+    }
   },
 
   startInspecting() {
@@ -33,11 +45,24 @@ export default TabRoute.extend({
     this.set('controller.inspectingViews', false);
   },
 
-  inspectComponent({ viewId }) {
+  inspectComponent(viewId) {
+    if (!this.get('controller.viewTreeLoaded')) {
+      return;
+    }
+
     this.get('controller').send('inspect', viewId);
   },
 
   inspectDOMElement({ elementSelector }) {
     this.get('port.adapter').inspectDOMElement(elementSelector);
+  },
+
+  actions: {
+    queryParamsDidChange(params) {
+      const { pinnedObjectId } = params;
+      if (pinnedObjectId) {
+        this.inspectComponent(pinnedObjectId);
+      }
+    }
   }
 });

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -172,7 +172,9 @@ export default EmberObject.extend(PortMixin, {
     },
     inspectById(message) {
       const obj = this.sentObjects[message.objectId];
-      this.sendObject(obj);
+      if (obj) {
+        this.sendObject(obj);
+      }
     },
     inspectByContainerLookup(message) {
       const container = this.get('namespace.owner');

--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -12,7 +12,8 @@
   },
   "permissions": [
     "<all_urls>",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "devtools_page": "devtools.html",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39039/38908365-5dfc77c0-42af-11e8-8d1e-13dc9a89f00d.png)

This adds "Inspect Ember Component" context menu item to all pages when Ember has been detected. It adds the object id to the query string which keeps the component selected between page refreshes.

Things to improve:
- [ ] Add tests.
- [ ] Scroll to the selected component in the inspector.
- [ ] Show a message when the ember inspector is not visible (tell the user to open the inspector, not possible with code).
- [ ] Show a message when a component is not found.