### PR TITLE
Object Inspector Large Key Name Fix

### DIFF
--- a/app/styles/mixin.scss
+++ b/app/styles/mixin.scss
@@ -117,13 +117,17 @@ $mixin-left-padding: 22px;
     padding: 0;
   }
 
-  .pad { width: $mixin-left-padding; }
+  .pad {
+    flex-shrink: 0;
+    width: $mixin-left-padding;
+  }
 
   .mixin__calc-btn svg {
     path, circle { fill: var(--spec18); }
   }
 
   .mixin__send-btn {
+    flex-shrink: 0;
     opacity: 0;
     padding-right: 6px;
   }
@@ -134,6 +138,10 @@ $mixin-left-padding: 22px;
 }
 
 .mixin__property-name {
+  max-width: 50%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   color: var(--base26);
 }
 

--- a/app/styles/object_inspector.scss
+++ b/app/styles/object_inspector.scss
@@ -64,6 +64,7 @@
 .mixin__property-dependency-item:first-child::before { display: none; }
 
 .mixin__property-icon-container {
+  flex-shrink: 0;
   width: $mixin-left-padding;
 }
 


### PR DESCRIPTION
https://github.com/emberjs/ember-inspector/issues/800

![croppercapture 1](https://user-images.githubusercontent.com/3692/39583817-cee106d4-4ea5-11e8-90c7-b3ae0113bf0e.png)

Flexbox was allowing the property key to push other elements out of the way.