### PR TITLE
Fix Inspector tab display in Firefox Developer Edition

### DIFF
--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -5,26 +5,38 @@
   "description": "Tool for debugging Ember applications.",
   "version": "{{EMBER_INSPECTOR_VERSION}}",
 
+  "applications": {
+    "gecko": {
+      "id": "@emberjs.com",
+      "strict_min_version": "48.0"
+    }
+  },
+
   "icons": {
     "16":  "{{PANE_ROOT}}/assets/images/icon16.png",
     "48":  "{{PANE_ROOT}}/assets/images/icon48.png",
     "128": "{{PANE_ROOT}}/assets/images/icon128.png"
   },
+
   "permissions": [
     "<all_urls>",
     "storage"
   ],
+
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "devtools_page": "devtools.html",
+
   "content_scripts": [{
     "matches": ["<all_urls>"],
     "js": ["content-script.js"],
     "run_at": "document_end",
     "all_frames": true
   }],
+
   "background": {
     "scripts": ["background-script.js"]
   },
+
   "page_action": {
     "default_icon": {
       "19": "{{PANE_ROOT}}/assets/images/icon19.png",
@@ -32,12 +44,13 @@
     },
     "default_title": "This webpage is not running Ember.js"
   },
+
   "web_accessible_resources": [
     "scripts/in-page-script.js"
   ],
-  "options_page": "options.html",
+  
   "options_ui": {
     "page": "options-dialog.html",
-    "chrome_style": true
+    "browser_style": true
   }
 }


### PR DESCRIPTION
Description:
---
- Addresses #802 
- Error due to the property `options_page` in manifest.json

![image](https://user-images.githubusercontent.com/4172262/39828113-8d87abbe-537f-11e8-8389-5f4a3de12c13.png)
