### PR TITLE
Don't render excluded columns in tables.

### DIFF
--- a/app/components/x-list-cell.js
+++ b/app/components/x-list-cell.js
@@ -18,6 +18,7 @@ import Component from '@ember/component';
 
 import { computed } from '@ember/object';
 import { htmlSafe } from '@ember/string';
+import { isEmpty } from '@ember/utils';
 export default Component.extend({
   /**
    * Defaults to a table cell. For headers
@@ -28,31 +29,7 @@ export default Component.extend({
    * @type {String}
    * @default 'td'
    */
-  tagName: 'td',
-
-  /**
-   * @property classNames
-   * @type {Array}
-   */
-  classNames: ['list__cell'],
-
-  /**
-   * `highlight` and `clickable` or class modifiers.
-   *
-   * @property classNameBindings
-   * @type {Array}
-   */
-  classNameBindings: ['highlight:list__cell_highlight', 'clickable:list__cell_clickable'],
-
-  /**
-   * Style passed through the `style` property
-   * should end up as the DOM element's style.
-   * Same applies to the `title` attribute.
-   *
-   * @property attributeBindings
-   * @type {Array}
-   */
-  attributeBindings: ['safeStyle:style', 'title'],
+  tagName: '',
 
   /**
    * Avoid unsafe style warning. This property does not
@@ -105,6 +82,39 @@ export default Component.extend({
   highlight: false,
 
   /**
+   * The list of possible columns
+   * @property columns
+   * @type {Array<{id: String, name: String, maxWidth: Number, width: Number}>}
+   */
+  columns: null,
+
+  /**
+   * The column name that this cell corresponds to. If the column name doesn't
+   * exist in `columns, the cell won't render.
+   * @property column
+   * @type {String}
+   */
+  column: null,
+
+
+  showColumn: computed('columns.[]', 'column', function() {
+    if (isEmpty(this.get('columns')) || isEmpty(this.get('column'))) {
+      return true;
+    } else {
+      const ids = this.get('columns').map(c => c.id);
+      let show = ids.includes(this.get('column'));
+      return show;
+    }
+  }),
+
+  init() {
+    this._super(...arguments);
+    if (isEmpty(this.get('columns'))) {
+      this.set('columns', []);
+    }
+  },
+
+  /**
    * Action to trigger when the cell is clicked.
    * Pass the action through the template using the `action`
    * helper.
@@ -113,14 +123,4 @@ export default Component.extend({
    * @type {Function}
    */
   'on-click'() {},
-
-  /**
-   * DOM event triggered when cell is clicked.
-   * Calls the `on-click` action (if set).
-   *
-   * @method click
-   */
-  click() {
-    this.get('on-click')();
-  }
 });

--- a/app/components/x-list.js
+++ b/app/components/x-list.js
@@ -144,6 +144,10 @@ export default Component.extend({
     return this._super(...arguments);
   },
 
+  showBasicContext(e) {
+    basicContext.show(this.menuContent, e);
+  },
+
   /**
    * Setup the context menu which allows the user
    * to toggle the visibility of each column.
@@ -154,7 +158,7 @@ export default Component.extend({
    * @method setupContextMenu
    */
   setupContextMenu() {
-    let menu = this.resizableColumns.getColumnVisibility().reduce((arr, { id, name, visible }) => {
+    this.menuContent = this.resizableColumns.getColumnVisibility().reduce((arr, { id, name, visible }) => {
       let check = `${CHECK_HTML}`;
       if (!visible) {
         check = `<span style='opacity:0'>${check}</span>`;
@@ -168,13 +172,11 @@ export default Component.extend({
       return arr;
     }, []);
 
-    this.showBasicContext = (e) => {
-      basicContext.show(menu, e);
-    };
-
     const listHeader = this.element.querySelector('.list__header');
-    if (listHeader) {
-      listHeader.addEventListener('contextmenu', this.showBasicContext);
+
+    if (listHeader && !this._contextListenerAdded) {
+      listHeader.addEventListener('contextmenu', this.showBasicContext.bind(this));
+      this._contextListenerAdded = true;
     }
   },
 

--- a/app/templates/components/promise-item.hbs
+++ b/app/templates/components/promise-item.hbs
@@ -1,4 +1,7 @@
-{{#list.cell class=(concat "list__cell_main " expandedClass) style=labelStyle on-click=(action toggleExpand model)}}
+{{#list.cell class=(concat "list__cell_main " expandedClass)
+  column="label"
+  style=labelStyle
+  on-click=(action toggleExpand model)}}
   <div class="list__cell-partial list__cell-partial_size_medium">
     <span title="{{label}}" class="js-promise-label">
       <span class="list__cell-arrow"></span> {{label}}
@@ -12,10 +15,10 @@
     {{/if}}
   </div>
 {{/list.cell}}
-{{#list.cell}}
+{{#list.cell column="state"}}
   <div class="pill pill--bold js-promise-state" style={{style}}>{{state}}</div>
 {{/list.cell}}
-{{#list.cell class="js-promise-value"}}
+{{#list.cell class="js-promise-value" column="settled-value"}}
   {{#if hasValue}}
     <div class="list__cell-partial list__cell-partial_size_medium"  title="{{settledValue.inspect}}">
       {{#if isValueInspectable}}
@@ -37,6 +40,6 @@
   --
   {{/if}}
 {{/list.cell}}
-{{#list.cell class="list__cell list__cell_value_numeric js-promise-time"}}
+{{#list.cell class="list__cell list__cell_value_numeric js-promise-time" column="time"}}
   {{ms-to-time timeToSettle}}
 {{/list.cell}}

--- a/app/templates/components/record-item.hbs
+++ b/app/templates/components/record-item.hbs
@@ -1,5 +1,5 @@
-{{#each columns as |column|}}
-  {{#list.cell class="js-record-column" clickable=true style=style}}
-    {{column.value}}
+{{#each columns as |recordColumn|}}
+  {{#list.cell class="js-record-column" column=recordColumn.id clickable=true style=style}}
+    {{recordColumn.value}}
   {{/list.cell}}
 {{/each}}

--- a/app/templates/components/render-item.hbs
+++ b/app/templates/components/render-item.hbs
@@ -1,19 +1,22 @@
 <tr style={{nodeStyle}} class="list__row js-render-profile-item">
-  {{#list.cell class=(concat "list__cell_main " expandedClass " js-render-main-cell") on-click=(action "toggleExpand") style=nameStyle}}
+  {{#list.cell class=(concat "list__cell_main " expandedClass " js-render-main-cell")
+    column="name"
+    on-click=(action "toggleExpand")
+    style=nameStyle}}
     <span class="list__cell-arrow"></span>
     <span title="{{model.name}}">
       <span class="js-render-profile-name">{{model.name}}</span>
     </span>
   {{/list.cell}}
-  {{#list.cell class="list__cell_value_numeric"}}
+  {{#list.cell class="list__cell_value_numeric" column="render-time"}}
     <span class="pill pill--not-clickable js-render-profile-duration">{{ms-to-time model.duration}}</span>
   {{/list.cell}}
-  {{#list.cell class="list__cell_value_numeric js-render-profile-timestamp"}}
+  {{#list.cell class="list__cell_value_numeric js-render-profile-timestamp" column="timestamp"}}
     {{readableTime}}
   {{/list.cell}}
 </tr>
 {{#if isExpanded}}
   {{#each model.children as |child|}}
-    {{render-item model=child target=this list=list}}
+    {{render-item model=child target=this list=list columns=columns}}
   {{/each}}
 {{/if}}

--- a/app/templates/components/route-item.hbs
+++ b/app/templates/components/route-item.hbs
@@ -1,17 +1,20 @@
-{{#list.cell class="list__cell_main js-route-name" highlight=isCurrent}}
+{{#list.cell class="list__cell_main js-route-name"
+    highlight=isCurrent
+    column="name"}}
   <div style={{labelStyle}}>
     <span title={{model.value.name}} class="js-view-name">{{model.value.name}}</span>
   </div>
 {{/list.cell}}
-{{#list.cell}}
-  <div class="list__cell-partial list__cell-partial_clickable js-route-handler" {{action inspectRoute model.value.routeHandler.name}}>
+{{#list.cell column="route"}}
+  <div class="list__cell-partial list__cell-partial_clickable js-route-handler"
+    {{action inspectRoute model.value.routeHandler.name}}>
     <span title="{{model.value.routeHandler.className}}">{{model.value.routeHandler.className}}</span>
   </div>
   <div class="list__cell-helper">
     {{send-to-console action=sendRouteHandlerToConsole param=model.value.routeHandler.name}}
   </div>
 {{/list.cell}}
-{{#list.cell}}
+{{#list.cell column="controller"}}
   {{#if model.value.controller.exists}}
     <div class="list__cell-partial list__cell-partial_clickable js-route-controller" {{action inspectController model.value.controller}}>
       <span title={{model.value.controller.className}}>{{model.value.controller.className}}</span>
@@ -26,9 +29,9 @@
     </div>
   {{/if}}
 {{/list.cell}}
-{{#list.cell class="js-route-template"}}
+{{#list.cell class="js-route-template" column="template"}}
   <span title={{model.value.template.name}}>{{model.value.template.name}}</span>
 {{/list.cell}}
-{{#list.cell class="js-route-url"}}
+{{#list.cell class="js-route-url" column="url"}}
   <span title={{model.value.url}}>{{model.value.url}}</span>
 {{/list.cell}}

--- a/app/templates/components/view-item.hbs
+++ b/app/templates/components/view-item.hbs
@@ -1,13 +1,16 @@
-{{#list.cell class="list__cell_main"}}
+{{#list.cell class="list__cell_main" column="name"}}
   <div style={{labelStyle}}>
     <span title="{{model.value.name}}" class="js-view-name">{{model.value.name}}</span>
   </div>
 {{/list.cell}}
-{{#list.cell class="js-view-template" clickable=hasElement on-click=(action "inspectElement")}}
+{{#list.cell class="js-view-template"
+  column="template"
+  clickable=hasElement
+  on-click=(action "inspectElement")}}
   <span title="{{model.value.template}}">{{if hasTemplate model.value.template '--'}}</span>
 {{/list.cell}}
 
-{{#list.cell class="js-view-model"}}
+{{#list.cell class="js-view-model" column="model"}}
   {{#if hasModel}}
     <div class="list__cell-partial {{if modelInspectable 'list__cell-partial_clickable'}} js-view-model-clickable" {{action "inspectModel" model.value.model.objectId}}>
       <span title="{{model.value.model.completeName}}">{{model.value.model.name}}</span>
@@ -20,7 +23,7 @@
   {{/if}}
 {{/list.cell}}
 
-{{#list.cell class="js-view-controller"}}
+{{#list.cell class="js-view-controller" column="controller"}}
   {{#if hasController}}
     <div class="list__cell-partial {{if hasController 'list__cell-partial_clickable'}}" {{action inspect model.value.controller.objectId}} >
       <span title="{{model.value.controller.completeName}}">{{model.value.controller.name}}</span>
@@ -31,7 +34,7 @@
   {{/if}}
 {{/list.cell}}
 
-{{#list.cell class="js-view-class"}}
+{{#list.cell class="js-view-class" column="component"}}
   {{#if hasView}}
     <div class="list__cell-partial {{if hasView 'list__cell-partial_clickable'}}" {{action "inspectView"}} >
       <span title="{{model.value.completeViewClass}}">{{model.value.viewClass}}</span>
@@ -44,6 +47,6 @@
   {{/if}}
 {{/list.cell}}
 
-{{#list.cell class="list__cell_size_small list__cell_value_numeric"}}
+{{#list.cell class="list__cell_size_small list__cell_value_numeric" column="duration"}}
   <span class="pill pill--not-clickable pill--small js-view-duration">{{ms-to-time model.value.duration}}</span>
 {{/list.cell}}

--- a/app/templates/components/x-list-cell.hbs
+++ b/app/templates/components/x-list-cell.hbs
@@ -1,1 +1,8 @@
-{{yield}}
+{{#if showColumn}}
+    <td class="list__cell {{if highlight "list__cell_highlight"}} {{class}} {{if clickable "list__cell_clickable"}} "
+        {{action (action on-click)}}
+        title={{title}}
+        style={{safeStyle}}>
+      {{yield}}
+    </td>
+{{/if}}

--- a/app/templates/components/x-list.hbs
+++ b/app/templates/components/x-list.hbs
@@ -11,7 +11,6 @@
         <tr class="list__row">
           {{#each columns key="id" as |column|}}
             {{#x-list-cell
-              tagName="th"
               class="js-header-column"}}
               {{column.name}}
             {{/x-list-cell}}
@@ -26,7 +25,7 @@
 {{#x-list-content headerHeight=headerHeight columns=columns as |content|}}
   {{yield
     (hash
-      cell=(component "x-list-cell" tagName="td")
+      cell=(component "x-list-cell" columns=columns)
       rowEvents=content.rowEvents
       vertical-collection=(component "vertical-collection"
         estimateHeight=30

--- a/tests/integration/components/x-list-cell-test.js
+++ b/tests/integration/components/x-list-cell-test.js
@@ -1,0 +1,54 @@
+import {
+  module,
+  test
+} from 'qunit';
+import {
+  setupRenderingTest
+} from 'ember-qunit';
+import {
+  render
+} from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import {
+  find
+} from 'ember-native-dom-helpers';
+
+module('Integration | Component | x-list-cell', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders content in a td by default', async function (assert) {
+    await render(hbs `
+      {{#x-list-cell}}
+        <span>template block text</span>
+      {{/x-list-cell}}
+    `);
+
+    assert.equal(find('td').textContent.trim(), 'template block text');
+  });
+
+  test('it renders content when the column is one of the current columns', async function (assert) {
+    this.set('columns', [{
+      id: 'name'
+    }]);
+    await render(hbs `
+      {{#x-list-cell columns=columns column="name"}}
+        <span>template block text</span>
+      {{/x-list-cell}}
+    `);
+
+    assert.equal(find('td').textContent.trim(), 'template block text');
+  });
+
+  test('it renders nothing when the column is not one of the current columns', async function (assert) {
+    this.set('columns', [{
+      id: 'name'
+    }]);
+    await render(hbs `
+      {{#x-list-cell columns=columns column="otherField"}}
+        <span>template block text</span>
+      {{/x-list-cell}}
+    `);
+
+    assert.notOk(find('td'), 'it does not render an element');
+  });
+});


### PR DESCRIPTION
Fixes #803 

This PR attempts to fix issues we've been having with displaying the correct content in tables after users have filtered out some columns.
This PR threads the column schema down through the `x-list` into the `x-list-cell` component.  Consumers can then pass a `column` property to the `x-list-cell` that corresponds to one of the column ids defined in the schema.  Now when the columns change (when a user filters them out via the context menu) we don't render the `td` elements at all. 

This PR also fixes a problem on the data tab where the filters wouldn't work correctly after a user had selected a different model to view.  See f4f2283 for more details.


