### PR TITLE
Fix rootElement.getAttribute error

### DIFF
--- a/ember_debug/libs/glimmer-tree.js
+++ b/ember_debug/libs/glimmer-tree.js
@@ -141,7 +141,9 @@ export default class {
 
     // set root element's id
     let rootElement = this.elementForRoot();
-    outletTree.value.elementId = rootElement.getAttribute('id');
+    if (rootElement instanceof HTMLElement) {
+      outletTree.value.elementId = rootElement.getAttribute('id');
+    }
     outletTree.value.tagName = 'div';
 
     return outletTree;


### PR DESCRIPTION
Closes #775 

I think it is okay to do this. It doesn't seem to effect other functionality.

cc @Bestra @Turbo87 