### PR TITLE
Context menu item for inspecting components

### DIFF
--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -71,12 +71,14 @@ const flattenSearchTree = (
 
 export default Controller.extend({
   application: controller(),
+  queryParams: ['pinnedObjectId'],
   pinnedObjectId: null,
   inspectingViews: false,
   components: true,
   options: {
     components: true,
   },
+  viewTreeLoaded: false,
 
   /**
    * Bound to the search field to filter the component list.

--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -13,6 +13,10 @@ import {
   isEmpty
 } from '@ember/utils';
 
+import {
+  schedule
+} from '@ember/runloop';
+
 import ComponentViewItem from 'ember-inspector/models/component-view-item';
 
 /**
@@ -168,7 +172,9 @@ export default Controller.extend({
 
     if (selectedItemIndex) {
       const averageItemHeight = 22;
-      document.querySelector('.js-component-tree').scrollTop = averageItemHeight * selectedItemIndex;
+      schedule('afterRender', () => {
+        document.querySelector('.js-component-tree').scrollTop = averageItemHeight * selectedItemIndex;
+      });
     }
   },
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -18,6 +18,7 @@ export default Route.extend({
     port.on('objectInspector:updateErrors', this, this.updateErrors);
     port.on('objectInspector:droppedObject', this, this.droppedObject);
     port.on('deprecation:count', this, this.setDeprecationCount);
+    port.on('view:inspectComponent', this, this.inspectComponent);
     port.send('deprecation:getCount');
   },
 
@@ -28,6 +29,19 @@ export default Route.extend({
     port.off('objectInspector:updateErrors', this, this.updateErrors);
     port.off('objectInspector:droppedObject', this, this.droppedObject);
     port.off('deprecation:count', this, this.setDeprecationCount);
+    port.off('view:inspectComponent', this, this.inspectComponent);
+  },
+
+  inspectComponent({ viewId }) {
+    const isActive = this.get('controller.active');
+    if (!isActive) {
+      //TODO: Tell the user to open the Ember devtools panel
+    }
+    this.transitionTo('component-tree', {
+      queryParams: {
+        pinnedObjectId: viewId
+      }
+    });
   },
 
   updateObject(options) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -33,10 +33,6 @@ export default Route.extend({
   },
 
   inspectComponent({ viewId }) {
-    const isActive = this.get('controller.active');
-    if (!isActive) {
-      //TODO: Tell the user to open the Ember devtools panel
-    }
     this.transitionTo('component-tree', {
       queryParams: {
         pinnedObjectId: viewId

--- a/app/routes/component-tree.js
+++ b/app/routes/component-tree.js
@@ -1,13 +1,20 @@
 import TabRoute from "ember-inspector/routes/tab";
 
 export default TabRoute.extend({
+  queryParams: {
+    pinnedObjectId: {
+      replace: true
+    }
+  },
+
   setupController() {
     this._super(...arguments);
     this.get('port').on('view:viewTree', this, this.setViewTree);
     this.get('port').on('view:stopInspecting', this, this.stopInspecting);
     this.get('port').on('view:startInspecting', this, this.startInspecting);
     this.get('port').on('view:inspectDOMElement', this, this.inspectDOMElement);
-    this.get('port').on('view:inspectComponent', this, this.inspectComponent);
+
+    this.set('controller.viewTreeLoaded', false);
     this.get('port').send('view:setOptions', { options: this.get('controller.options') });
     this.get('port').send('view:getTree');
   },
@@ -17,12 +24,17 @@ export default TabRoute.extend({
     this.get('port').off('view:stopInspecting', this, this.stopInspecting);
     this.get('port').off('view:startInspecting', this, this.startInspecting);
     this.get('port').off('view:inspectDOMElement', this, this.inspectDOMElement);
-    this.get('port').off('view:inspectComponent', this, this.inspectComponent);
-
   },
 
   setViewTree(options) {
     this.set('controller.viewTree', options.tree);
+    this.set('controller.viewTreeLoaded', true);
+
+    // If we're waiting for view tree to inspect a component
+    const componentToInspect = this.get('controller.pinnedObjectId');
+    if (componentToInspect) {
+      this.inspectComponent(componentToInspect);
+    }
   },
 
   startInspecting() {
@@ -33,11 +45,24 @@ export default TabRoute.extend({
     this.set('controller.inspectingViews', false);
   },
 
-  inspectComponent({ viewId }) {
+  inspectComponent(viewId) {
+    if (!this.get('controller.viewTreeLoaded')) {
+      return;
+    }
+
     this.get('controller').send('inspect', viewId);
   },
 
   inspectDOMElement({ elementSelector }) {
     this.get('port.adapter').inspectDOMElement(elementSelector);
+  },
+
+  actions: {
+    queryParamsDidChange(params) {
+      const { pinnedObjectId } = params;
+      if (pinnedObjectId) {
+        this.inspectComponent(pinnedObjectId);
+      }
+    }
   }
 });

--- a/app/templates/component-tree.hbs
+++ b/app/templates/component-tree.hbs
@@ -1,4 +1,4 @@
-<div class="list__content" style="height: 100%;">
+<div class="list__content js-component-tree" style="height: 100%;">
   {{#vertical-collection displayedList estimateHeight=20 as |item i|}}
     <div onmouseenter={{action "previewLayer" item}}
       onmouseleave={{action "hidePreview"}}>

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -66,6 +66,9 @@ const EmberDebug = EmberObject.extend({
     this.reset();
 
     this.get('adapter').debug('Ember Inspector Active');
+    this.get('adapter').sendMessage({
+      type: 'inspectorLoaded'
+    });
   },
 
   destroyContainer() {

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -172,7 +172,9 @@ export default EmberObject.extend(PortMixin, {
     },
     inspectById(message) {
       const obj = this.sentObjects[message.objectId];
-      this.sendObject(obj);
+      if (obj) {
+        this.sendObject(obj);
+      }
     },
     inspectByContainerLookup(message) {
       const container = this.get('namespace.owner');

--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -73,10 +73,11 @@
    * Update the tab's contextMenu: https://developer.chrome.com/extensions/contextMenus
    * Add a menu item called "Inspect Ember Component" that shows info
    * about the component in the inspector.
+   * @param {Boolean} force don't use the activeTabs array to check for an existing context menu
    */
-  function updateContextMenu() {
+  function updateContextMenu(force) {
     // Only add context menu item when an Ember app has been detected
-    var isEmberApp = !!activeTabs[activeTabId];
+    var isEmberApp = !!activeTabs[activeTabId] || force;
     if (!isEmberApp && contextMenuAdded) {
       chrome.contextMenus.remove('inspect-ember-component');
       contextMenuAdded = false;
@@ -153,6 +154,8 @@
     } else if (request && request.type === 'resetEmberIcon') {
       // hide the Tomster icon
       hideAction(sender.tab.id);
+    } else if (request && request.type === 'inspectorLoaded') {
+      updateContextMenu(true);
     } else {
       // forward the message to EmberInspector
       var emberInspectorChromePort = emberInspectorChromePorts[sender.tab.id];

--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -13,7 +13,8 @@
 
   "permissions": [
     "<all_urls>",
-    "storage"
+    "storage",
+    "contextMenus"
   ],
 
   "content_security_policy": "script-src 'self'; object-src 'self'",

--- a/tests/acceptance/component-tree-test.js
+++ b/tests/acceptance/component-tree-test.js
@@ -4,6 +4,7 @@ import {
   findAll,
   click,
   triggerEvent,
+  currentURL,
 } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
@@ -299,5 +300,22 @@ module('Component Tab', function(hooks) {
     await click('.component-tree-item--component code');
     assert.equal(messageSent.name, 'objectInspector:inspectById');
     assert.equal(messageSent.message.objectId, 'ember392');
+  });
+
+  test('Selects a component in the tree in response to a message from the context menu', async function(assert) {
+    // Go to the component tree and populate it before sending the message from the context menu
+    let viewTree = defaultViewTree();
+    await visit('/component-tree');
+    run(() => {
+      port.trigger('view:viewTree', { tree: viewTree });
+    });
+    await wait();
+
+    run(() => {
+      port.trigger('view:inspectComponent', { viewId: 'ember267' });
+    });
+    await wait();
+    assert.equal(currentURL(), '/component-tree?pinnedObjectId=ember267', 'It pins the element id as a query param');
+    assert.dom('.component-tree-item--selected').hasText('todo-item', 'It selects the item in the tree corresponding to the element');
   });
 });


### PR DESCRIPTION
![context_menu](https://user-images.githubusercontent.com/2043348/43336758-0c83bc4c-91a0-11e8-84c0-c9e104198b32.gif)
Features:
- Once the inspector is open and on screen, users can right click on an element and open it in the component tree via the context menu
- The component tree will scroll the relevant component into view.
This PR supersedes #788.  Closes #689 