### PR TITLE
Check for owner before calling isGlimmerTwo

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -153,7 +153,8 @@ export default EmberObject.extend(PortMixin, {
     };
     window.addEventListener('resize', this.resizeHandler);
 
-    if (this.isGlimmerTwo()) {
+    // We do not have an `owner` when testing, so check for an owner here before calling isGlimmerTwo
+    if (this.getOwner() && this.isGlimmerTwo()) {
       this.glimmerTree = new GlimmerTree({
         owner: this.getOwner(),
         retainObject: this.retainObject.bind(this),
@@ -356,7 +357,7 @@ export default EmberObject.extend(PortMixin, {
   },
 
   isGlimmerTwo() {
-    return this.get('namespace.owner').hasRegistration('service:-glimmer-environment');
+    return this.getOwner().hasRegistration('service:-glimmer-environment');
   },
 
   modelForView(view) {


### PR DESCRIPTION
Resolves #816 

This stops the errors from happening, when there is no owner, because now we are checking if we have an owner before trying to use the owner.

I am not sure if this is the correct solution or if there is a way to actually get the real owner again here, rather than just doing nothing if it does not exist.

@teddyzeenny do we want to support running the inspector on `localhost:4200/tests` anyway?