### PR TITLE
Use Ember.get to get _debugInfo

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -728,8 +728,9 @@ function twoTenfilterHack(itemName, skipProperties) {
 
 function getDebugInfo(object) {
   let debugInfo = null;
-  if (object._debugInfo && typeof object._debugInfo === 'function') {
-    debugInfo = object._debugInfo();
+  const objectDebugInfo = get(object, '_debugInfo');
+  if (objectDebugInfo && typeof objectDebugInfo === 'function') {
+    debugInfo = objectDebugInfo();
   }
   debugInfo = debugInfo || {};
   let propertyInfo = debugInfo.propertyInfo || (debugInfo.propertyInfo = {});


### PR DESCRIPTION
Resolves #791

I believe using Ember.get should fix this issue right @rwjblue?

It was this error:

```
Error message: Assertion Failed: You attempted to access the `_debugInfo` property (of <DS.PromiseObject:ember2256>).
Since Ember 3.1, this is usually fine as you no longer need to use `.get()`
to access computed properties. **However, in this case, the object in question
is a special kind of Ember object (a proxy). Therefore, it is still necessary
to use `.get('_debugInfo')` in this case.**
```