### PR TITLE
Fix Ember Inspector during tests for Ember >= 3

### DIFF
--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -66,11 +66,6 @@ export default EmberObject.extend(PortMixin, {
   port: readOnly('namespace.port'),
 
   /**
-   * @type {Application}
-   */
-  application: readOnly('namespace.owner.application'),
-
-  /**
    * Sends a reply back indicating if the app has been booted.
    *
    * `__inspector__booted` is a property set on the application instance
@@ -79,7 +74,7 @@ export default EmberObject.extend(PortMixin, {
    */
   sendBooted() {
     this.sendMessage('applicationBooted', {
-      booted: this.get('application.__inspector__booted')
+      booted: this.get('namespace.owner.__inspector__booted')
     });
   },
 

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -104,7 +104,7 @@ const EmberDebug = EmberObject.extend({
   },
 
   reset($keepAdapter) {
-    if (!this.get('isTesting')) {
+    if (!this.get('isTesting') && !this.get('owner')) {
       this.set('owner', getOwner(this.get('_application')));
     }
     this.destroyContainer();
@@ -164,7 +164,11 @@ function getApplication() {
 }
 
 function getOwner(application) {
-  return application.__deprecatedInstance__;
+  if (application.autoboot) {
+    return application.__deprecatedInstance__;
+  } else if (application._applicationInstances /* Ember 3.1+ */) {
+    return application._applicationInstances[0];
+  }
 }
 
 export default EmberDebug;


### PR DESCRIPTION
The primary difference between acceptance tests for Ember < 3 vs Ember >= 3 is that for Ember < 3, every test created a new application + one application instance, whereas in Ember > 3 all the tests use the same application, but a different application instance for each test. The inspector was relying on the application boot, (which only happens once during tests in Ember >=3, and it happens even before the first test starts which was causing the inspector to fail and throw errors as it was starting even before the first application instance was created).

On the plus side, making the inspector only boot on application instance boot (instead of on application boot) also works for prior versions, and feels more "correct", so this should resolve everything everywhere.

Resolves #816 
Resolves #818 
Closes #846 