### PR TITLE
Add ability to sort models by record count

### DIFF
--- a/app/templates/model-types-toolbar.hbs
+++ b/app/templates/model-types-toolbar.hbs
@@ -5,4 +5,10 @@
         Hide Empty Model Types
       </label>
     </div>
+    <div class="toolbar__checkbox js-filter-order-records-by-count">
+      <label for="options-orderByRecordCount">
+        {{input type="checkbox" checked=orderByRecordCount id="options-orderByRecordCount"}}
+        Order Models By Record Count
+      </label>
+    </div>
 </div>

--- a/app/templates/model-types.hbs
+++ b/app/templates/model-types.hbs
@@ -1,7 +1,7 @@
 {{item-types
   header='Model Types'
   setIsDragging=(route-action 'setIsDragging')
-  sorted=(readonly sorted)
+  sorted=(readonly (if orderByRecordCount sortByDescCount sortByName))
   type='model'
   width=navWidth
 }}

--- a/app/utils/local-storage-keys.js
+++ b/app/utils/local-storage-keys.js
@@ -1,0 +1,5 @@
+// Names of keys set in the storage service.
+
+export const HIDE_EMPTY_MODELS_KEY = 'are-model-types-hidden';
+
+export const ORDER_MODELS_BY_COUNT_KEY = 'are-models-ordered-by-record-count';


### PR DESCRIPTION
It would be nice to be able to sort models by their record count as well as alphabetically (current option).

### This PR
- Adds ability to sort models by record count

- Adds test for new sort functionality

- DRYs up the code to get, set, and remove  model sorting keys from Storage


### Feature in action
<img width="815" alt="screen shot 2018-09-01 at 12 13 05 pm" src="https://user-images.githubusercontent.com/1477357/44949140-698e1980-ade0-11e8-9632-27644c0792f1.png">
