### PR TITLE
Expose storage type to use via LocalStorage service

### DIFF
--- a/app/components/x-list.js
+++ b/app/components/x-list.js
@@ -63,7 +63,8 @@ export default Component.extend({
    * @property storage
    * @return {Service}
    */
-  storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
+  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
+
 
   /**
    * The key used to cache the current schema. Defaults

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -8,7 +8,7 @@ import { HIDE_EMPTY_MODELS_KEY, ORDER_MODELS_BY_COUNT_KEY } from 'ember-inspecto
 export default Controller.extend({
   application: controller(),
   navWidth: 180,
-  storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
+  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
 
   init() {
     this._super(...arguments);

--- a/app/controllers/render-tree.js
+++ b/app/controllers/render-tree.js
@@ -25,7 +25,8 @@ export default Controller.extend({
    * @property storage
    * @type {Service}
    */
-  storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
+  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
+
 
   /**
    * Checks if the user previously closed the warning by referencing localStorage

--- a/app/routes/launch.js
+++ b/app/routes/launch.js
@@ -12,7 +12,8 @@ const STORE_KEY = 'last-version-opened';
 
 export default Route.extend({
   version: oneWay('config.VERSION').readOnly(),
-  storage: service(`storage/${LocalStorageService.SUPPORTED ? 'local' : 'memory'}`),
+  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
+
 
   lastVersionOpened() {
     if (chromeStoreSupported) {

--- a/app/services/storage/local.js
+++ b/app/services/storage/local.js
@@ -83,7 +83,15 @@ LocalStorage.reopenClass({
    * @property SUPPORTED
    * @type {Boolean}
    */
-  SUPPORTED: LOCAL_STORAGE_SUPPORTED
+  SUPPORTED: LOCAL_STORAGE_SUPPORTED,
+
+  /**
+   * The type of storage to use based on the browser's feature support. Will be 'local' or 'memory'.
+   *
+   * @property STORAGE_TYPE_TO_USE
+   * @type {String}
+   */
+  STORAGE_TYPE_TO_USE: LOCAL_STORAGE_SUPPORTED ? 'local' : 'memory'
 });
 
 export default LocalStorage;

--- a/tests/acceptance/data-test.js
+++ b/tests/acceptance/data-test.js
@@ -35,8 +35,7 @@ module('Data Tab', function(hooks) {
   hooks.afterEach(function() {
     name = null;
     // This is to ensure settings in Storage do not persist across multiple test runs.
-    let storageServiceToUse = LocalStorageService.SUPPORTED ? 'local' : 'memory';
-    let storageService = this.owner.lookup(`service:storage/${storageServiceToUse}`);
+    let storageService = this.owner.lookup(`service:storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`);
 
     storageService.removeItem(HIDE_EMPTY_MODELS_KEY);
     storageService.removeItem(ORDER_MODELS_BY_COUNT_KEY);


### PR DESCRIPTION
The ternary to determine the type of the storage to use is repeated several times, this cleans that up.