### PR TITLE
Use [class='ember-view'] selector to exclude anything with extra classes

### DIFF
--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -334,7 +334,7 @@ export default EmberObject.extend(PortMixin, {
     if (!emberApp) {
       return false;
     }
-    let applicationView = document.querySelector(`${emberApp.rootElement} > .ember-view`);
+    let applicationView = document.querySelector(`${emberApp.rootElement} > [class='ember-view']`);
     let applicationViewId = applicationView ? applicationView.id : undefined;
     let rootView = this.get('viewRegistry')[applicationViewId];
     // In case of App.reset view is destroyed


### PR DESCRIPTION
This should exclude liquid-fire elements or various others that add classes to the application container ember-view.

If you were adding your own classes to the application container, this would break, but I think this supports the majority of cases, and application wrappers are disabled by a lot of people these days anyway.

Resolves #419

@emberjs/inspector what do you guys think of this? It would hide liquid-fire etc from the view tree, but I think that is okay?