### PR TITLE
Fix test failures by passing function references to `off`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   fail_fast: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ env:
 jobs:
   fail_fast: true
   allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:

--- a/tests/ember_debug/promise-assembler-test.js
+++ b/tests/ember_debug/promise-assembler-test.js
@@ -72,9 +72,11 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     let date = new Date();
     let event;
 
-    assembler.on('chained', function(e) {
+    function captureEvent(e) {
       event = e;
-    });
+    }
+
+    assembler.on('chained', captureEvent);
 
     fakeRSVP.trigger('chained', {
       guid: 1,
@@ -97,7 +99,7 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     assert.equal(parent.get('children.length'), 1);
     assert.equal(child.get('guid'), 2);
     assert.equal(child.get('parent'), parent);
-
+    assembler.off('chained', captureEvent);
   });
 
   test('Chains a promise correctly (parent and child existing)', function(assert) {
@@ -120,16 +122,21 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
 
     assembler.off('created', captureParent);
 
-    assembler.on('created', captureParent);
+    function captureChild(e) {
+      child = e.promise;
+    }
+
+    assembler.on('created', captureChild);
 
     fakeRSVP.trigger('created', {
       guid: 2
     });
 
-
-    assembler.on('chained', function(e) {
+    function captureEvent(e) {
       event = e;
-    });
+    }
+
+    assembler.on('chained', captureEvent);
 
     fakeRSVP.trigger('chained', {
       guid: 1,
@@ -152,7 +159,8 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     assert.equal(parent.get('children.length'), 1);
     assert.equal(child.get('guid'), 2);
     assert.equal(child.get('parent'), parent);
-
+    assembler.off('chained', captureEvent);
+    assembler.off('created', captureChild);
   });
 
   test('Fulfills a promise correctly', function(assert) {

--- a/tests/ember_debug/promise-assembler-test.js
+++ b/tests/ember_debug/promise-assembler-test.js
@@ -108,19 +108,19 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     let parent;
     let child;
 
-    assembler.on('created', function(e) {
+    function captureParent(e) {
       parent = e.promise;
-    });
+    }
+
+    assembler.on('created', captureParent);
 
     fakeRSVP.trigger('created', {
       guid: 1
     });
 
-    assembler.off('created');
+    assembler.off('created', captureParent);
 
-    assembler.on('created', function(e) {
-      child = e.promise;
-    });
+    assembler.on('created', captureParent);
 
     fakeRSVP.trigger('created', {
       guid: 2
@@ -161,15 +161,17 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     let event;
     let promise;
 
-    assembler.on('created', function(e) {
+    function capturePromise(e) {
       promise = e.promise;
-    });
+    }
+
+    assembler.on('created', capturePromise);
 
     fakeRSVP.trigger('created', {
       guid: 1
     });
 
-    assembler.off('created');
+    assembler.off('created', capturePromise);
 
     assert.equal(promise.get('state'), 'created');
 
@@ -196,15 +198,17 @@ module('Ember Debug - PromiseAssembler', function(hooks) {
     let event;
     let promise;
 
-    assembler.on('created', function(e) {
+    function capturePromise(e) {
       promise = e.promise;
-    });
+    }
+
+    assembler.on('created', capturePromise);
 
     fakeRSVP.trigger('created', {
       guid: 1
     });
 
-    assembler.off('created');
+    assembler.off('created', capturePromise);
 
     assert.equal(promise.get('state'), 'created');
 


### PR DESCRIPTION
We need to allow beta and canary to fail, until we can find a way to run all Inspector tests as part of Ember PRs.