### PR TITLE
Clean up unused manifest property + prevent error in storage lookup

### DIFF
--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -45,7 +45,6 @@
   ],
 
   "options_ui": {
-    "page": "options-dialog.html",
-    "browser_style": true
+    "page": "options-dialog.html"
   }
 }

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -18,7 +18,7 @@
     chrome.storage.sync.get('options', function(data) {
       var options = data.options;
 
-      document.querySelector('[data-settings=tomster]').checked = options.showTomster;
+      document.querySelector('[data-settings=tomster]').checked = options && options.showTomster;
     });
   }
 


### PR DESCRIPTION
This PR removes a chrome manifest warning (visible when loading the unpacked extension produced by the steps in the readme) by removing an obsolete `browser_style` property from the top level `options_ui` hash:
<img width="629" alt="screenshot 2018-12-19 at 13 32 02" src="https://user-images.githubusercontent.com/7144173/50226522-4beabd00-039b-11e9-9f3c-ef69e759d712.png">


Per [the docs](https://developer.chrome.com/extensions/options#embedded_options) this property is no longer used, removing it has no effect as the default when specifying the options menu using [`options_ui`(embedded)](https://developer.chrome.com/extensions/options#embedded_options) - as opposed to simply [`options_page`(full page)](https://developer.chrome.com/extensions/options#full_page) - is this "modal" style options dialog:

<img width="433" alt="screenshot 2018-12-19 at 14 36 13" src="https://user-images.githubusercontent.com/7144173/50226970-830d9e00-039c-11e9-9ff3-0a4df26bd140.png">

There is also the option top explicitly set the `options_ui.open_in_tab` property to false. Would we prefer to be explicit or rely on the default here?

---

While working on a different issue I noticed a background script error caused by attempting to access a `showTomster` property of undefined so I've added a guard inside the `chrome.storage.sync.get` call for when our options haven't yet been initialised (before the first user prompted call to `storeOptions` sets the correct structure). I'm happy to move this change out into a different PR / drop it if you'd prefer.