### PR TITLE
Fix dropdown arrow in dark mode

### DIFF
--- a/app/styles/dropdown.scss
+++ b/app/styles/dropdown.scss
@@ -35,4 +35,6 @@
   right: 5px;
   top: 9px;
   width: 6px;
+
+  path { fill: var(--base13); }
 }


### PR DESCRIPTION
**New:**

<img width="180" alt="screen shot 2018-12-25 at 1 32 36 pm" src="https://user-images.githubusercontent.com/3692/50426700-be4f1780-0849-11e9-8444-c22f8113fef7.png">

**Old:**

<img width="179" alt="screen shot 2018-12-25 at 1 34 25 pm" src="https://user-images.githubusercontent.com/3692/50426705-d58e0500-0849-11e9-8ac7-b112965a0ecc.png">