### PR TITLE
When forming the URL to retrieve a source map, if it is already an absolute URL then use it as is

### DIFF
--- a/ember_debug/libs/source-map.js
+++ b/ember_debug/libs/source-map.js
@@ -92,7 +92,14 @@ function retrieveSourceMap(source) {
 }
 
 function relativeToAbsolute(file, url) {
-  if (!file) { return url; }
+  // Regex from https://stackoverflow.com/a/19709846
+  // This will match the most common prefixes we care about: "http://", "https://", "//"
+  let absoluteUrlRegex = new RegExp('^(?:[a-z]+:)?//', 'i');
+
+  // If we don't have a file URL or the sourcemap URL is absolute, then return the sourcemap URL.
+  if (!file || absoluteUrlRegex.test(url)) { return url; }
+
+  // Otherwise, find the sourcemap URL relative to the original file.
   let dir = file.split('/');
   dir.pop();
   dir.push(url);


### PR DESCRIPTION
This fixes the issues I found in #908 by testing if a sourcemap URL is absolute before assuming it is relative to the original file.

If it is an absolute URL, it will use it for retrieval directly, otherwise it will use the original code to find a URL for it relative to the original file.