### PR TITLE
Use `_target`, remove some duplication

### DIFF
--- a/app/routes/component-tree.js
+++ b/app/routes/component-tree.js
@@ -1,29 +1,10 @@
-import TabRoute from "ember-inspector/routes/tab";
+import ViewTree from "ember-inspector/routes/view-tree";
 
-export default TabRoute.extend({
+export default ViewTree.extend({
   queryParams: {
     pinnedObjectId: {
       replace: true
     }
-  },
-
-  setupController() {
-    this._super(...arguments);
-    this.get('port').on('view:viewTree', this, this.setViewTree);
-    this.get('port').on('view:stopInspecting', this, this.stopInspecting);
-    this.get('port').on('view:startInspecting', this, this.startInspecting);
-    this.get('port').on('view:inspectDOMElement', this, this.inspectDOMElement);
-
-    this.set('controller.viewTreeLoaded', false);
-    this.get('port').send('view:setOptions', { options: this.get('controller.options') });
-    this.get('port').send('view:getTree');
-  },
-
-  deactivate() {
-    this.get('port').off('view:viewTree', this, this.setViewTree);
-    this.get('port').off('view:stopInspecting', this, this.stopInspecting);
-    this.get('port').off('view:startInspecting', this, this.startInspecting);
-    this.get('port').off('view:inspectDOMElement', this, this.inspectDOMElement);
   },
 
   setViewTree(options) {
@@ -37,24 +18,12 @@ export default TabRoute.extend({
     }
   },
 
-  startInspecting() {
-    this.set('controller.inspectingViews', true);
-  },
-
-  stopInspecting() {
-    this.set('controller.inspectingViews', false);
-  },
-
   inspectComponent(viewId) {
     if (!this.get('controller.viewTreeLoaded')) {
       return;
     }
 
     this.get('controller').send('inspect', viewId);
-  },
-
-  inspectDOMElement({ elementSelector }) {
-    this.get('port.adapter').inspectDOMElement(elementSelector);
   },
 
   actions: {

--- a/app/routes/view-tree.js
+++ b/app/routes/view-tree.js
@@ -12,6 +12,8 @@ export default TabRoute.extend({
     this.get('port').on('view:stopInspecting', this, this.stopInspecting);
     this.get('port').on('view:startInspecting', this, this.startInspecting);
     this.get('port').on('view:inspectDOMElement', this, this.inspectDOMElement);
+
+    this.set('controller.viewTreeLoaded', false);
     this.get('port').send('view:setOptions', { options: this.get('controller.options') });
     this.get('port').send('view:getTree');
   },

--- a/ember_debug/libs/glimmer-tree.js
+++ b/ember_debug/libs/glimmer-tree.js
@@ -541,7 +541,7 @@ export default class {
    * @return {Controller}           The target controller.
    */
   controllerForComponent(component) {
-    let controller = component.get('_targetObject');
+    let controller = component.get('_target') || component.get('_targetObject');
     if (!controller) {
       return null;
     }


### PR DESCRIPTION
Refactored the component tree route to extend the view tree route, since they had a lot of duplication. I also fixed an issue with `_targetObject` being removed, and we are now additionally checking for `_target`

Fixes #915 