### PR TITLE
Remove 2 uses of sendAction

### DIFF
--- a/app/components/action-checkbox.js
+++ b/app/components/action-checkbox.js
@@ -13,6 +13,6 @@ export default Component.extend({
 
   _updateElementValue() {
     this.set('checked', this.element.checked);
-    this.sendAction('on-update', this.get('checked'));
+    this.onUpdate(this.get('checked'));
   }
 });

--- a/app/components/send-to-console.js
+++ b/app/components/send-to-console.js
@@ -6,6 +6,6 @@ export default Component.extend({
   title: 'Send to Console',
   action: 'sendValueToConsole',
   click() {
-    this.sendAction('action', this.get('param'));
+    this.action(this.get('param'));
   }
 });

--- a/app/templates/promise-tree-toolbar.hbs
+++ b/app/templates/promise-tree-toolbar.hbs
@@ -65,7 +65,7 @@
   <div class="toolbar__checkbox js-with-stack">
     <label for="instrument-with-stack">
       {{action-checkbox
-        on-update="updateInstrumentWithStack"
+        onUpdate=(action "updateInstrumentWithStack")
         checked=instrumentWithStack
         id="instrument-with-stack"
       }}


### PR DESCRIPTION
`sendAction` is deprecated, so I removed 2 of the simpler ones to clean up