### PR TITLE
Make Port#uniqueId a bit more resilient.

### DIFF
--- a/ember_debug/port.js
+++ b/ember_debug/port.js
@@ -1,5 +1,5 @@
 const Ember = window.Ember;
-const { Object: EmberObject, computed, run } = Ember;
+const { Object: EmberObject, computed, run, get } = Ember;
 const { oneWay } = computed;
 
 export default EmberObject.extend(Ember.Evented, {
@@ -13,8 +13,20 @@ export default EmberObject.extend(Ember.Evented, {
    * @property uniqueId
    * @type {String}
    */
-  uniqueId: computed('namespace._application.name', function() {
-    return this.get('namespace._application.name');
+  uniqueId: computed('namespace._application.{name,modulePrefix}', 'namespace.applicationId', function() {
+    let application = this.get('namespace._application');
+
+    // can be set by users to provide a "pretty" name for a given app when
+    // multiple applications are detected
+    let name = get(application, 'name');
+
+    // good default for "standard" ember-cli apps
+    let modulePrefix = get(application, 'modulePrefix');
+
+    // fallback to do "something" when neither name or modulePrefix are found
+    let fallback = `(unknown app - ${this.get('namespace.applicationId')})`;
+
+    return name || modulePrefix || fallback;
   }),
 
   init() {


### PR DESCRIPTION
Fixes app detection issues introduced in #898 by using a layered fallback system to control the uniqueId:

* Use `name` specified in `app/app.js` (the easiest for users to customize to control how their app is displayed in the inspector)
* Use `modulePrefix` specified in `app/app.js` (all ember-cli apps would have this, and is _generally_ still representative of what each app owner calls their app).
* Use `(unknown app - <RANDOM_GUID>)` as a last chance fallback to ensure **all** detected applications at least show up

Fixes https://github.com/emberjs/ember-inspector/issues/927