### PR TITLE
Remove "info" nav title

### DIFF
--- a/app/templates/info.hbs
+++ b/app/templates/info.hbs
@@ -5,9 +5,6 @@
     width=180
   }}
     <div class="split__panel__bd">
-      <div class="nav__title">
-        <h1>Info</h1>
-      </div>
       <ul>
         <li>{{#link-to "libraries"}}Libraries{{/link-to}}</li>
         <li>{{#link-to "whats-new"}}What's New{{/link-to}}</li>


### PR DESCRIPTION
This is a very low priority, but maybe I'm not the only one who find the `Info` heading hard to distinguish from the links underneath. It also doesn't add anything, as the user can already see that `Info` is highlighted in the left menu.

<img width="687" alt="screen shot 2019-01-30 at 10 20 46 pm" src="https://user-images.githubusercontent.com/1477357/52035028-838e6e00-24de-11e9-9b90-c00d78dec2b6.png">

If you disagree, feel free to close 😊