### PR TITLE
Default theme for bookmarklet and tests

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -14,7 +14,7 @@
 
     {{content-for "head-footer"}}
   </head>
-  <body>
+  <body class="theme--light">
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/skeletons/bookmarklet/load_inspector.js
+++ b/skeletons/bookmarklet/load_inspector.js
@@ -53,7 +53,7 @@
     if (e.data.name === 'version-mismatch') {
       injectEmberDebug('panes-' + e.data.version.replace(/\./g, '-') + '/ember_debug.js');
     }
-  });  
+  });
 
   if (!window.emberInspector) {
     alert('Unable to open the inspector in a popup.  Please enable popups and retry.');

--- a/tests/index.html
+++ b/tests/index.html
@@ -31,7 +31,7 @@
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
-  <body>
+  <body class="theme--light">
 
     {{content-for "body"}}
     {{content-for "test-body"}}


### PR DESCRIPTION
The bookmarklet was not loading a theme so I added one to `app/index.html`. If Inspector is loaded in a browser extension `app/adapters/web_extension.js` will override based on browser chrome settings.