### PR TITLE
Bubble up deprecations for ember-deprecation-workflow (#857)

### DIFF
--- a/app/controllers/deprecations.js
+++ b/app/controllers/deprecations.js
@@ -1,4 +1,4 @@
-import { get } from '@ember/object';
+import { get, observer } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 import debounceComputed from "ember-inspector/computed/debounce";
 import searchMatch from "ember-inspector/utils/search-match";
@@ -14,10 +14,17 @@ export default Controller.extend({
   application: controller(),
   search: null,
   searchValue: debounceComputed('search', 300),
+  options: {
+    toggleDeprecationWorkflow: false
+  },
 
   filtered: filter('model', function(item) {
     return searchMatch(get(item, 'message'), this.get('search'));
   }).property('model.@each.message', 'search'),
+
+  optionsChanged: observer('options.toggleDeprecationWorkflow', function() {
+    this.port.send('deprecation:setOptions', { options: this.get('options') });
+  }),
 
   actions: {
     openResource(item) {

--- a/app/templates/deprecations-toolbar.hbs
+++ b/app/templates/deprecations-toolbar.hbs
@@ -4,6 +4,17 @@
     classNames="toolbar__icon-button js-clear-deprecations-btn"
   }}
 
+  <div class="toolbar__checkbox js-toggle-flush-deprecations">
+    <label for="options-toggle-deprecations" title="Deprecation workflow">
+      {{input
+        type="checkbox"
+        checked=options.toggleDeprecationWorkflow
+        id="options-toggle-deprecations"
+      }}
+      Toggle for Deprecation Workflow
+    </label>
+  </div>
+
   <div class="divider" aria-hidden="true"></div>
 
   <div class="toolbar__search js-deprecations-search">

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -167,7 +167,9 @@ export default EmberObject.extend(PortMixin, {
   },
 
   handleDeprecations() {
-    registerDeprecationHandler((message, options) => {
+    registerDeprecationHandler((message, options, next) => {
+      run.next(this, () => next(message, options));
+
       /* global __fail__*/
 
       let error;

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -31,6 +31,10 @@ export default EmberObject.extend(PortMixin, {
 
   emberCliConfig: oneWay('namespace.generalDebug.emberCliConfig').readOnly(),
 
+  options: {
+    toggleDeprecationWorkflow: false
+  },
+
   init() {
     this._super();
     this.handleDeprecations();
@@ -158,7 +162,11 @@ export default EmberObject.extend(PortMixin, {
 
     release() {
       this._watching = false;
-    }
+    },
+
+    setOptions({ options }) {
+      this.options.toggleDeprecationWorkflow = options.toggleDeprecationWorkflow;
+    },
   },
 
   willDestroy() {
@@ -168,7 +176,6 @@ export default EmberObject.extend(PortMixin, {
 
   handleDeprecations() {
     registerDeprecationHandler((message, options, next) => {
-      run.next(this, () => next(message, options));
 
       /* global __fail__*/
 
@@ -218,6 +225,10 @@ export default EmberObject.extend(PortMixin, {
           this.get("adapter").warn("Deprecations were detected, see the Ember Inspector deprecations tab for more details.");
           this._warned = true;
         }
+      }
+
+      if (this.options.toggleDeprecationWorkflow) {
+        next(message, options);
       }
     });
   }


### PR DESCRIPTION
Fixes #857 

This adds a checkbox (to the Deprecations tab) to bubble up deprecations to `ember-deprecation-workflow`. Toggling allows you to call `deprecationWorkflow.flushDeprecations` and have it work properly. 

<img width="951" alt="Screen Shot 2019-03-18 at 11 41 04 AM" src="https://user-images.githubusercontent.com/118005/54555002-09715600-4973-11e9-9b04-ba6aaafba7d8.png">
