### PR TITLE
Fix setting _channel by moving before super call

### DIFF
--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -1,4 +1,5 @@
-import BasicAdapter from "./basic";
+import BasicAdapter from './basic';
+
 const Ember = window.Ember;
 const { run, typeOf } = Ember;
 const { isArray } = Array;
@@ -6,9 +7,10 @@ const { keys } = Object;
 
 export default BasicAdapter.extend({
   init() {
-    this._super(...arguments);
     this.set('_channel', new MessageChannel());
     this.set('_chromePort', this.get('_channel.port1'));
+
+    this._super(...arguments);
   },
 
   connect() {


### PR DESCRIPTION
`_channel` was previously a computed. We moved to setting it in `init`, but calling super first was triggering sending a message that tried to use `_channel` and it was not already set. This PR ensures we set it before calling super.