### PR TITLE
[port] Change the way we set up the port property to be used by logic in the port-mixin

### DIFF
--- a/ember_debug/container-debug.js
+++ b/ember_debug/container-debug.js
@@ -6,7 +6,6 @@ const { readOnly } = computed;
 export default EmberObject.extend(PortMixin, {
   namespace: null,
 
-  port: readOnly('namespace.port'),
   objectInspector: readOnly('namespace.objectInspector'),
 
   container: computed('namespace.owner', function() {

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -10,8 +10,6 @@ const { registerDeprecationHandler } = Debug;
 export default EmberObject.extend(PortMixin, {
   portNamespace: 'deprecation',
 
-  port: readOnly('namespace.port'),
-
   adapter: readOnly('port.adapter'),
 
   sourceMap: computed(function() {

--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -59,13 +59,6 @@ export default EmberObject.extend(PortMixin, {
   emberCliConfig: null,
 
   /**
-  * Used by PortMixin.
-  *
-  * @type {Port}
-  */
-  port: readOnly('namespace.port'),
-
-  /**
    * Sends a reply back indicating if the app has been booted.
    *
    * `__inspector__booted` is a property set on the application instance

--- a/ember_debug/mixins/port-mixin.js
+++ b/ember_debug/mixins/port-mixin.js
@@ -1,13 +1,17 @@
 const Ember = window.Ember;
 const { Mixin } = Ember;
+
 export default Mixin.create({
   port: null,
+
   messages: {},
 
   portNamespace: null,
 
   init() {
     this._super(...arguments);
+
+    this.set('port', this.get('namespace.port'));
 
     this.setupOrRemovePortListeners('on');
   },

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -6,7 +6,6 @@ const { readOnly } = computed;
 
 export default EmberObject.extend(PortMixin, {
   namespace: null,
-  port: readOnly('namespace.port'),
   objectInspector: readOnly('namespace.objectInspector'),
   adapter: readOnly('namespace.adapter'),
   portNamespace: 'promise',

--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -57,7 +57,6 @@ subscribe("render", {
 
 export default EmberObject.extend(PortMixin, {
   namespace: null,
-  port: readOnly('namespace.port'),
   viewDebug: readOnly('namespace.viewDebug'),
   portNamespace: 'render',
 

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -16,7 +16,6 @@ const { hasOwnProperty } = Object.prototype;
 
 export default EmberObject.extend(PortMixin, {
   namespace: null,
-  port: readOnly('namespace.port'),
 
   router: computed('namespace.owner', function() {
     return this.get('namespace.owner').lookup('router:main');

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -35,7 +35,6 @@ export default EmberObject.extend(PortMixin, {
   namespace: null,
 
   adapter: readOnly('namespace.adapter'),
-  port: readOnly('namespace.port'),
   objectInspector: readOnly('namespace.objectInspector'),
 
   portNamespace: 'view',


### PR DESCRIPTION
This fixes a bug with the new application switcher functionality where `this.get('port')` was not set at times other code was trying to use it.

I removed the `port: readOnly('namespace.port')` in all the things that use the `port-mixin` and set the property in the init method of the mixin itself instead.