### PR TITLE
Increase size of click area of component tree disclosure triangle

### DIFF
--- a/app/styles/component_tree.scss
+++ b/app/styles/component_tree.scss
@@ -9,6 +9,13 @@
   position: relative;
 }
 
+.component-tree-item__expand {
+  align-self: stretch;
+  cursor: pointer;
+  padding-left: 3px;
+  padding-right: 3px;
+}
+
 .component-tree-item__action {
   align-items: center;
   background: transparent;

--- a/public/assets/svg/disclosure-triangle.svg
+++ b/public/assets/svg/disclosure-triangle.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="9px" height="9px" viewBox="0 0 43 36">
-  <polygon fill="#777" fill-rule="evenodd" points="39 18 4 -3 4 39" transform="rotate(90 21.5 18)"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="9px" height="9px" viewBox="0 0 9 9" fill="none">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 7.167l4.395-5.33H.105L4.5 7.167z" fill="#777"/>
 </svg>


### PR DESCRIPTION
**Trying to click a 9x9 svg is madness.**

Before _(gray background for illustration)_:
<img width="191" alt="Screen Shot 2019-06-04 at 4 35 14 PM" src="https://user-images.githubusercontent.com/3692/58920479-441f9a80-86e7-11e9-95e4-80f6eae7ae1b.png">

After _(gray background for illustration)_:
<img width="192" alt="Screen Shot 2019-06-04 at 4 35 05 PM" src="https://user-images.githubusercontent.com/3692/58920487-4a157b80-86e7-11e9-9a20-eefb5c0191f1.png">
