### PR TITLE
Drop support for Ember versions < 3.4.0 in master

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-inspector",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Extends developer tools to allow you to better inspect your Ember.js apps.",
   "license": "MIT",
   "author": "Tilde, Inc.",
@@ -23,11 +23,12 @@
     "lock-version": "yarn build:production && yarn compress:panes && EMBER_ENV=production node scripts/upload-panes.js"
   },
   "emberVersionsSupported": [
-    "2.7.0",
+    "3.4.0",
     ""
   ],
   "previousEmberVersionsSupported": [
-    "0.0.0"
+    "0.0.0",
+    "2.7.0"
   ],
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",


### PR DESCRIPTION
This drops support for Ember < 3.4.0 in master. The published inspector will still support Ember versions back to 1.0.0 but will open up older inspectors depending on which Ember version the app is on.

I also bumped the inspector minor version to 3.11.0 on master following the 3.10.0 release.

#### To backport urgent/high priority fixes to the old inspectors:
- Ember Inspector v1.10.0 (supports Ember v1.0.x -> v2.6.x): commit to branch [ember-0.0.0-2.7.0](https://github.com/emberjs/ember-inspector/tree/ember-0.0.0-2.7.0) and re-upload it using `yarn lock-version`.
- Ember Inspector v3.10.0 (supports Ember v2.7.x -> v3.3.x): commit to the branch [ember-2.7.0-3.4.0](https://github.com/emberjs/ember-inspector/tree/ember-2.7.0-3.4.0) and re-upload it using `yarn lock-version`.

Finally build and release a new version of the main inspector which will include all of the above fixes.