### PR TITLE
Add undefined check for getDescriptorFor()

### DIFF
--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -1,4 +1,5 @@
 const Ember = window.Ember;
+const { descriptorForDecorator, descriptorForProperty } = Ember.__loader.require('@ember/-internals/metal');
 const { ComputedProperty } = Ember;
 
 /**
@@ -30,7 +31,7 @@ export function isDescriptor(value) {
  */
 export function getDescriptorFor(object, key) {
   if (Ember.Debug.isComputed) {
-    return Ember.__loader.require('@ember/-internals/metal').descriptorForDecorator(object[key]);
+    return descriptorForDecorator(object[key]) || descriptorForProperty(object, key);
   }
 
   return object[key];

--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -1,5 +1,4 @@
 const Ember = window.Ember;
-const { descriptorForDecorator, descriptorForProperty } = Ember.__loader.require('@ember/-internals/metal');
 const { ComputedProperty } = Ember;
 
 /**
@@ -31,6 +30,7 @@ export function isDescriptor(value) {
  */
 export function getDescriptorFor(object, key) {
   if (Ember.Debug.isComputed) {
+    const { descriptorForDecorator, descriptorForProperty } = Ember.__loader.require('@ember/-internals/metal');
     return descriptorForDecorator(object[key]) || descriptorForProperty(object, key);
   }
 


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember-inspector/issues/999.

`getDescriptorFor()` returns undefined for certain properties ( like computed properties through _ember-redux_, for example), so wrap it with a logical OR to prevent the _dependentKeys accessor from throwing an exception.