### PR TITLE
Guard against reading a property on undefined, fixes #1004

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -328,7 +328,7 @@ export default EmberObject.extend(PortMixin, {
   dropObject(objectId) {
     let object = this.sentObjects[objectId];
 
-    if (object.reopen) {
+    if (object && object.reopen) {
       object.reopen({ willDestroy: object._oldWillDestroy });
       delete object._oldWillDestroy;
     }


### PR DESCRIPTION
Fixes #1004

`!= null` checks for both `null` and `undefined`. It's faster than simply `if (object)`.