### PR TITLE
Use "::" instead of  "/" when displaying component names

### DIFF
--- a/app/helpers/classify.js
+++ b/app/helpers/classify.js
@@ -2,7 +2,7 @@ import { classify } from '@ember/string';
 import { helper } from '@ember/component/helper';
 
 export function classifyString([str]) {
-  return classify(str);
+  return classify(str).replace(/\//g, '::');
 }
 
 export default helper(classifyString);

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -20,10 +20,12 @@ const {
   typeOf,
   Component,
   Controller,
-  A
+  A,
+  String
 } = Ember;
 const { later } = run;
 const { readOnly } = computed;
+const { classify } = String;
 
 const keys = Object.keys || Ember.keys;
 
@@ -375,7 +377,7 @@ export default EmberObject.extend(PortMixin, {
         output += `<p class='view'><span>view</span>=<span data-label='layer-view'>${escapeHTML(view.name)}</span></p>`;
       }
     } else {
-      output += `<p class='component'><span>component</span>=<span data-label='layer-component'>${escapeHTML(view.name)}</span></p>`;
+      output += `<p class='component'><span>component</span>=<span data-label='layer-component'>${classify(escapeHTML(view.name)).replace(/\//g, '::')}</span></p>`;
     }
 
     let model = options.model;


### PR DESCRIPTION
Hey all, first PR to this repo 👍 

This PR updates the display of component names to use `::` instead of `/`, so that it matches the [Angle Bracket Nested Invocation RFC](https://emberjs.github.io/rfcs/0457-nested-lookups.html)

In addition, this updates the component names used when "Inspecting" components so that they also match this syntax.

Before:
<img width="1438" alt="Screen Shot 2019-10-03 at 3 39 32 PM" src="https://user-images.githubusercontent.com/6216460/66169609-db452200-e5f5-11e9-92cf-e5bd3dc915fe.png">

After:
<img width="1440" alt="Screen Shot 2019-10-03 at 3 37 41 PM" src="https://user-images.githubusercontent.com/6216460/66169616-e26c3000-e5f5-11e9-8780-80c3de297885.png">

