### PR TITLE
Name Known Ember Mixins

### DIFF
--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -220,13 +220,21 @@ module('Ember Debug - Object Inspector', function(hooks) {
 
   test('Correct mixin order with es6 class', function (assert) {
 
-    // eslint-disable-next-line ember/no-new-mixins
-    const MyMixin = Mixin.create({
+    class MyMixinClass extends Mixin {
+      toString() {
+        return 'MyMixin';
+      }
+    }
+    const MyMixin = MyMixinClass.create({
       a: 'custom',
     });
 
-    // eslint-disable-next-line ember/no-new-mixins
-    const MyMixin2 = Mixin.create({
+    class MyMixin2Class extends Mixin {
+      toString() {
+        return 'MyMixin2';
+      }
+    }
+    const MyMixin2 = MyMixin2Class.create({
       b: 'custom2',
     });
 
@@ -249,13 +257,12 @@ module('Ember Debug - Object Inspector', function(hooks) {
       'Own Properties',
       'Foo',
       'FooBar',
-      '(unknown)',
-      '(unknown mixin)',
-      '(unknown mixin)',
+      'MyMixin',
+      'MyMixin2',
       'Bar',
       'Baz',
       'EmberObject',
-      '(unknown mixin)',
+      'Observable Mixin',
       'CoreObject'
     ];
 
@@ -263,6 +270,47 @@ module('Ember Debug - Object Inspector', function(hooks) {
       assert.ok(mixinNames[i].includes(expectedMixinName), `${mixinNames[i]} : ${expectedMixinName}`);
     });
   });
+
+  test('Correct mixin properties', function (assert) {
+
+    // eslint-disable-next-line ember/no-new-mixins
+    class MyMixin extends Mixin {
+      toString() {
+        return 'MyMixin1';
+      }
+    }
+    // eslint-disable-next-line ember/no-new-mixins
+    class MyMixin2 extends Mixin {
+      toString() {
+        return 'MyMixin2';
+      }
+    }
+
+    const mix1 = MyMixin.create({a: 'custom1'});
+    const mix2 = MyMixin2.create({b: 'custom2'});
+
+    class Foo extends EmberObject.extend(mix1, mix2) {}
+
+    const instance = Foo.create({
+      ownProp: 'b'
+    });
+
+    objectInspector.sendObject(instance);
+
+    const details = message.details;
+
+    assert.equal(details[0].properties.length, 1, 'should not show mixin properties');
+    assert.equal(details[0].properties[0].name, 'ownProp');
+
+    assert.equal(details[2].name, 'MyMixin1');
+    assert.equal(details[2].properties.length, 1, 'should only show own mixin properties');
+    assert.equal(details[2].properties[0].value.inspect, inspect('custom1'));
+
+    assert.equal(details[3].name, 'MyMixin2');
+    assert.equal(details[3].properties.length, 1, 'should only show own mixin properties');
+    assert.equal(details[3].properties[0].value.inspect, inspect('custom2'));
+  });
+
 
   test('Computed properties are correctly calculated', function(assert) {
     let inspected = EmberObject.extend({
@@ -459,11 +507,7 @@ module('Ember Debug - Object Inspector', function(hooks) {
 
   test('Property grouping can be customized using _debugInfo', function(assert) {
     // eslint-disable-next-line ember/no-new-mixins
-    let mixinToSkip = Mixin.create({
-      toString() {
-        return 'MixinToSkip';
-      }
-    });
+    let mixinToSkip = Mixin.create({});
 
     let Inspected = EmberObject.extend(mixinToSkip, {
       name: 'Teddy',
@@ -518,6 +562,7 @@ module('Ember Debug - Object Inspector', function(hooks) {
 
     assert.equal(message.details[3].name, 'TestObject');
     assert.equal(message.details[3].properties.length, 3, 'Correctly merges properties');
+    assert.equal(message.details[3].properties[0].name, 'toString');
     assert.equal(message.details[3].properties[1].name, 'hasChildren');
     assert.equal(message.details[3].properties[2].name, 'expensiveProperty', 'property name is correct');
     assert.equal(message.details[3].properties[2].value.isCalculated, undefined, 'Does not calculate expensive properties');


### PR DESCRIPTION
set the names of known mixins
remove properties set by mixins unless different value
causes them to hide the class with only merged mixins from Object.extend(mix1, mix2)
