### PR TITLE
Add missing npm artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,11 @@ jobs:
         with:
           name: firefox
           path: dist/firefox
+      - name: Upload artifacts (npm)
+        uses: actions/upload-artifact@master
+        with:
+          name: npm
+          path: dist/npm
 
   publish-bookmarklet:
     name: Publish bookmarklet


### PR DESCRIPTION
This should have been included in #1080, it was needed for the npm publishing step.