### PR TITLE
Fix inspector in Electron

### DIFF
--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -76,6 +76,12 @@
    * @param {Boolean} force don't use the activeTabs array to check for an existing context menu
    */
   function updateContextMenu(force) {
+    // The Chromium that Electron runs does not have a chrome.contextMenus,
+    // so make sure this doesn't throw an error in Electron
+    if (!chrome.contextMenus) {
+      return;
+    }
+
     // Only add context menu item when an Ember app has been detected
     var isEmberApp = !!activeTabs[activeTabId] || force;
     if (!isEmberApp && contextMenuAdded) {


### PR DESCRIPTION
Electron's Chromium doesn't have `chrome.contextMenus`, so this code was throwing an error and preventing the inspector from working.