### PR TITLE
Fix tracked detection

### DIFF
--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -791,6 +791,7 @@ module('Ember Debug - Object Inspector', function(hooks) {
     let getter = message.details[1].properties[0];
     assert.equal(getter.name, 'hi');
     assert.ok(getter.isGetter);
+    assert.ok(!getter.isTracked);
     assert.equal(getter.value.type, 'type-number');
     assert.equal(getter.value.inspect, '123');
   });


### PR DESCRIPTION
call getter directly
Ember.get auto tracks properties is seems, breaking the tracked detection.
So, it marks Getters as tracked, if the getter does not depend on any tracked property,