### PR TITLE
Refactor app `port` into a regular service

### DIFF
--- a/app/components/app-picker.js
+++ b/app/components/app-picker.js
@@ -1,7 +1,6 @@
 import Component from '@ember/component';
 import { observer } from '@ember/object';
 import { alias, reads } from '@ember/object/computed';
-import { getOwner } from '@ember/application';
 
 export default Component.extend({
   classNames: ['app-picker'],
@@ -10,10 +9,7 @@ export default Component.extend({
   selectedApp: reads('port.applicationId'),
 
   selectedDidChange: observer('selectedApp', function() {
-    // Change app being debugged
-    const applicationId = this.selectedApp;
-    const port = getOwner(this).lookup('port:main');
-    port.set('applicationId', applicationId);
+    this.port.set('applicationId', this.selectedApp);
   }),
 
   init() {

--- a/app/initializers/setup.js
+++ b/app/initializers/setup.js
@@ -1,6 +1,5 @@
 import { typeOf } from '@ember/utils';
 import config from 'ember-inspector/config/environment';
-import Port from "ember-inspector/port";
 import PromiseAssembler from "ember-inspector/libs/promise-assembler";
 
 export default {
@@ -17,21 +16,20 @@ export default {
       Adapter = instance.adapter;
     }
     register(instance, 'adapter:main', Adapter);
-    instance.inject('port', 'adapter', 'adapter:main');
+    instance.inject('controller:deprecations', 'adapter', 'adapter:main');
     instance.inject('route:application', 'adapter', 'adapter:main');
     instance.inject('route:deprecations', 'adapter', 'adapter:main');
-    instance.inject('controller:deprecations', 'adapter', 'adapter:main');
+    instance.inject('service:port', 'adapter', 'adapter:main');
 
     // register config
     register(instance, 'config:main', config, { instantiate: false });
     instance.inject('route', 'config', 'config:main');
 
     // inject port
-    register(instance, 'port:main', instance.Port || Port);
-    instance.inject('controller', 'port', 'port:main');
-    instance.inject('route', 'port', 'port:main');
-    instance.inject('component', 'port', 'port:main');
-    instance.inject('promise-assembler', 'port', 'port:main');
+    instance.inject('component', 'port', 'service:port');
+    instance.inject('controller', 'port', 'service:port');
+    instance.inject('promise-assembler', 'port', 'service:port');
+    instance.inject('route', 'port', 'service:port');
 
     // register and inject promise assembler
     register(instance, 'promise-assembler:main', PromiseAssembler);

--- a/app/services/port.js
+++ b/app/services/port.js
@@ -1,7 +1,7 @@
 import Evented from '@ember/object/evented';
-import EmberObject from '@ember/object';
+import Service from '@ember/service';
 
-export default EmberObject.extend(Evented, {
+export default Service.extend(Evented, {
   applicationId: undefined,
   applicationName: undefined,
 

--- a/tests/acceptance/app-picker-test.js
+++ b/tests/acceptance/app-picker-test.js
@@ -12,7 +12,7 @@ module('App Picker', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       detectedApplications: [
         {

--- a/tests/acceptance/component-tree-test.js
+++ b/tests/acceptance/component-tree-test.js
@@ -17,7 +17,7 @@ module('Component Tab', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function () {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
   });
 
   function textFor(selector, context) {

--- a/tests/acceptance/container-test.js
+++ b/tests/acceptance/container-test.js
@@ -41,7 +41,7 @@ module('Container Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
   });
 
   hooks.afterEach(function() {

--- a/tests/acceptance/data-test.js
+++ b/tests/acceptance/data-test.js
@@ -22,7 +22,7 @@ module('Data Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       init() {},
       send(n, m) {

--- a/tests/acceptance/deprecation-test.js
+++ b/tests/acceptance/deprecation-test.js
@@ -40,7 +40,7 @@ module('Deprecation Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       send(n, m) {
         name = n;

--- a/tests/acceptance/info-test.js
+++ b/tests/acceptance/info-test.js
@@ -9,7 +9,7 @@ module('Info Tab', function(hooks) {
 
   hooks.beforeEach(function() {
     this.owner.lookup('config:main').VERSION = '9.9.9';
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       send(name) {
         if (name === 'general:getLibraries') {

--- a/tests/acceptance/object-inspector-test.js
+++ b/tests/acceptance/object-inspector-test.js
@@ -17,7 +17,7 @@ module('Object Inspector', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       send(n, m) {
         name = n;

--- a/tests/acceptance/promise-test.js
+++ b/tests/acceptance/promise-test.js
@@ -16,7 +16,7 @@ module('Promise Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       send(n, m) {
         if (n === 'promise:getAndObservePromises') {

--- a/tests/acceptance/render-tree-test.js
+++ b/tests/acceptance/render-tree-test.js
@@ -8,7 +8,7 @@ module('Render Tree Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
     port.reopen({
       send(/*n, m*/) {}
     });

--- a/tests/acceptance/route-tree-test.js
+++ b/tests/acceptance/route-tree-test.js
@@ -39,7 +39,7 @@ module('Route Tree Tab', function(hooks) {
   setupApplicationTest(hooks);
 
   hooks.beforeEach(function() {
-    port = this.owner.lookup('port:main');
+    port = this.owner.lookup('service:port');
   });
 
   hooks.afterEach(async () => {

--- a/tests/helpers/trigger-port.js
+++ b/tests/helpers/trigger-port.js
@@ -1,7 +1,7 @@
 import { run } from '@ember/runloop';
 import { settled } from '@ember/test-helpers';
 export async function triggerPort(app, ...args) {
-  run(() => app.owner.lookup('port:main').trigger(...args));
+  run(() => app.owner.lookup('service:port').trigger(...args));
   await settled();
 }
 


### PR DESCRIPTION
This is more idiomatic, and allows things like `@service port;` to work.