### PR TITLE
Do not include leading zeros when calculating version number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Update manifest.json
         if: github.event_name == 'schedule'
         run: |
-          DATE="$(date +"%Y.%m.%d")"
+          DATE="$(date +"%Y.%-m.%-d")"
           SHA="${GITHUB_SHA:0:7}"
           VERSION="$(jq -r '.version' package.json)"
           CONTENT="$(cat "$FILE")"
@@ -122,7 +122,7 @@ jobs:
       - name: Update package.json
         if: github.event_name == 'schedule'
         run: |
-          DATE="$(date +"%Y.%m.%d")"
+          DATE="$(date +"%Y.%-m.%-d")"
           SHA="${GITHUB_SHA:0:7}"
           CONTENT="$(cat "$FILE")"
 


### PR DESCRIPTION
yarn pack will remove the leading zeros from months and days when making the version string, so we need to make sure that the generated tar matches that.

I have address both the day and the month so we should be good when January rolls in.