### PR TITLE
Refactor `StorageService`

### DIFF
--- a/app/components/list.js
+++ b/app/components/list.js
@@ -2,7 +2,6 @@ import Component from '@ember/component';
 import { run, scheduleOnce } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
 import ResizableColumns from 'ember-inspector/libs/resizable-columns';
-import LocalStorageService from 'ember-inspector/services/storage/local';
 import { inject as service } from '@ember/service';
 import { readOnly, reads } from '@ember/object/computed';
 
@@ -63,8 +62,7 @@ export default Component.extend({
    * @property storage
    * @return {Service}
    */
-  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
-
+  storage: service(),
 
   /**
    * The key used to cache the current schema. Defaults

--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -1,16 +1,14 @@
 import Controller from '@ember/controller';
 import { get, computed } from '@ember/object';
-import LocalStorageService from 'ember-inspector/services/storage/local';
 import { sort } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import {
-  HIDE_EMPTY_MODELS_KEY,
-  ORDER_MODELS_BY_COUNT_KEY
-} from 'ember-inspector/utils/local-storage-keys';
+
+const HIDE_EMPTY_MODELS_KEY = 'are-model-types-hidden';
+const ORDER_MODELS_BY_COUNT_KEY = 'are-models-ordered-by-record-count';
 
 export default Controller.extend({
   navWidth: 180,
-  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
+  storage: service(),
 
   init() {
     this._super(...arguments);

--- a/app/controllers/render-tree.js
+++ b/app/controllers/render-tree.js
@@ -4,7 +4,6 @@ import Controller from '@ember/controller';
 import { inject as service } from '@ember/service';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
 import debounceComputed from "ember-inspector/computed/debounce";
-import LocalStorageService from "ember-inspector/services/storage/local";
 import { and, equal } from '@ember/object/computed';
 
 export default Controller.extend({
@@ -18,8 +17,7 @@ export default Controller.extend({
    * @property storage
    * @type {Service}
    */
-  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
-
+  storage: service(),
 
   /**
    * Checks if the user previously closed the warning by referencing localStorage

--- a/app/routes/launch.js
+++ b/app/routes/launch.js
@@ -3,17 +3,15 @@ import RSVP from 'rsvp';
 const { Promise } = RSVP;
 import { readOnly } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import LocalStorageService from 'ember-inspector/services/storage/local';
+import { LOCAL_STORAGE_SUPPORTED } from 'ember-inspector/services/storage/local';
 
 const chromeStoreSupported = (!!window.chrome && !!window.chrome.storage);
-const localStoreSupported = LocalStorageService.SUPPORTED;
-const storageSupported = chromeStoreSupported || localStoreSupported;
+const storageSupported = chromeStoreSupported || LOCAL_STORAGE_SUPPORTED;
 const STORE_KEY = 'last-version-opened';
 
 export default Route.extend({
   version: readOnly('config.VERSION'),
-  storage: service(`storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`),
-
+  storage: service(),
 
   lastVersionOpened() {
     if (chromeStoreSupported) {
@@ -24,16 +22,11 @@ export default Route.extend({
           );
         });
       });
-    }
-    else if (localStoreSupported) {
+    } else {
       return RSVP.resolve(
         (this.storage.getItem(STORE_KEY) || 0).toString()
       );
     }
-
-    return RSVP.resolve(
-      (0).toString()
-    );
   },
 
   setLastVersionOpened(version) {
@@ -45,9 +38,7 @@ export default Route.extend({
           resolve();
         });
       });
-    }
-
-    else if (localStoreSupported) {
+    } else {
       this.storage.setItem(STORE_KEY, version);
       return RSVP.resolve();
     }

--- a/app/services/storage.js
+++ b/app/services/storage.js
@@ -1,0 +1,69 @@
+import Service, { inject as service } from '@ember/service';
+import { LOCAL_STORAGE_SUPPORTED } from './storage/local';
+
+/**
+ * Service that wraps either the LocalStorageService or
+ * MemoryStorageService (depending on availability) and
+ * provide support for storing (JSON-serializable) objects
+ * on top of the lower level backends.
+ *
+ * @class StorageService
+ * @extends Service
+ */
+export default class StorageService extends Service {
+  @service(LOCAL_STORAGE_SUPPORTED ? 'storage/local' : 'storage/memory') backend;
+
+  /**
+   * Reads a stored object for a give key, if any.
+   *
+   * @method getItem
+   * @param  {String} key
+   * @return {Option<String>} The value, if found
+   */
+  getItem(key) {
+    let serialized = this.backend.getItem(key);
+
+    if (serialized === null) {
+      // Actual `null` values would have been serialized as `"null"`
+      return undefined;
+    } else {
+      return JSON.parse(serialized);
+    }
+  }
+
+  /**
+   * Store a string for a given key.
+   *
+   * @method setItem
+   * @param {String} key
+   * @param {String} value
+   */
+  setItem(key, value) {
+    if (value === undefined) {
+      this.removeItem(key);
+    } else {
+      let serialized = JSON.stringify(value);
+      this.backend.setItem(key, serialized);
+    }
+  }
+
+  /**
+   * Deletes the stored string for a given key.
+   *
+   * @method removeItem
+   * @param  {String} key
+   */
+  removeItem(key) {
+    this.backend.removeItem(key);
+  }
+
+  /**
+   * Returns the list of stored keys.
+   *
+   * @method keys
+   * @return {Array<String>} The array of keys
+   */
+  keys() {
+    return this.backend.keys();
+  }
+}

--- a/app/services/storage/local.js
+++ b/app/services/storage/local.js
@@ -1,60 +1,53 @@
-/**
- * Service that manages local storage. This service is useful because
- * it abstracts serialization and parsing of json.
- *
- * @class Local
- * @extends Service
- */
 import Service from '@ember/service';
 
-import { isNone } from '@ember/utils';
-const { parse, stringify } = JSON;
-let LOCAL_STORAGE_SUPPORTED;
+export let LOCAL_STORAGE_SUPPORTED = false;
 
-const LocalStorage = Service.extend({
+/**
+ * Service that wraps local storage. Only store strings. This
+ * is not intended to be used directly, use StorageServeice
+ * instead.
+ *
+ * @class LocalStorageService
+ * @extends Service
+ */
+export default class LocalStorageService extends Service {
   /**
-   * Reads a stored json string and parses it to
-   * and object.
+   * Reads a stored string for a give key, if any.
    *
    * @method getItem
-   * @param  {String} key The cache key
-   * @return {Object}     The json value
+   * @param  {String} key
+   * @return {Option<String>} The value, if found
    */
   getItem(key) {
-    let json = localStorage.getItem(key);
-    return json && parse(json);
-  },
+    return localStorage.getItem(key);
+  }
 
   /**
-   * Serializes an object into a json string
-   * and stores it in local storage.
+   * Store a string for a given key.
    *
    * @method setItem
-   * @param {String} key The cache key
-   * @param {Object} value The object
+   * @param {String} key
+   * @param {String} value
    */
   setItem(key, value) {
-    if (!isNone(value)) {
-      value = stringify(value);
-    }
-    return localStorage.setItem(key, value);
-  },
+    localStorage.setItem(key, value);
+  }
 
   /**
-   * Deletes an entry from local storage.
+   * Deletes the stored string for a given key.
    *
    * @method removeItem
-   * @param  {String} key The cache key
+   * @param  {String} key
    */
   removeItem(key) {
-    return localStorage.removeItem(key);
-  },
+    localStorage.removeItem(key);
+  }
 
   /**
-   * Returns the list keys of saved entries in local storage.
+   * Returns the list of stored keys.
    *
    * @method keys
-   * @return {Array}  The array of keys
+   * @return {Array<String>} The array of keys
    */
   keys() {
     let keys = [];
@@ -63,35 +56,17 @@ const LocalStorage = Service.extend({
     }
     return keys;
   }
-});
-
-try {
-  localStorage.setItem('test', 0);
-  localStorage.removeItem('test');
-  LOCAL_STORAGE_SUPPORTED = true;
-} catch (e) {
-  // Security setting in chrome that disables storage for third party
-  // throws an error when `localStorage` is accessed. Safari in Private mode
-  // also throws an error.
-  LOCAL_STORAGE_SUPPORTED = false;
 }
 
-LocalStorage.reopenClass({
-  /**
-   * Checks if `localStorage` is supported.
-   *
-   * @property SUPPORTED
-   * @type {Boolean}
-   */
-  SUPPORTED: LOCAL_STORAGE_SUPPORTED,
-
-  /**
-   * The type of storage to use based on the browser's feature support. Will be 'local' or 'memory'.
-   *
-   * @property STORAGE_TYPE_TO_USE
-   * @type {String}
-   */
-  STORAGE_TYPE_TO_USE: LOCAL_STORAGE_SUPPORTED ? 'local' : 'memory'
-});
-
-export default LocalStorage;
+try {
+  localStorage.setItem('test', 'testing');
+  LOCAL_STORAGE_SUPPORTED = localStorage.getItem('test') === 'testing';
+} catch (e) {
+  // ignore
+} finally {
+  try {
+    localStorage.removeItem('test');
+  } catch(e) {
+    // ignore
+  }
+}

--- a/app/services/storage/memory.js
+++ b/app/services/storage/memory.js
@@ -1,66 +1,67 @@
-/**
- * Service that manages storage in memory. Usually as a fallback
- * for local storage.
- *
- * @class Memory
- * @extends Service
- */
 import Service from '@ember/service';
 
-const { keys } = Object;
-
-export default Service.extend({
-  init() {
-    this._super(...arguments);
-
-    /**
-     * Where data is stored.
-     *
-     * @property hash
-     * @type {Object}
-     */
-    this.hash = {};
-  },
+/**
+ * Service that wraps an in-memory object with the same APIs as
+ * the LocalStorageService, usually as a fallback. Only store
+ * strings. This is not intended to be used directly, use
+ * StorageServeice instead.
+ *
+ * @class MemoryStorageService
+ * @extends Service
+ */
+export default class MemoryStorageService extends Service {
+  /**
+   * Where data is stored.
+   *
+   * @property store
+   * @type {Object}
+   * @private
+   */
+  store = Object.create(null);
 
   /**
-   * Reads a stored item.
+   * Reads a stored string for a give key, if any.
    *
    * @method getItem
-   * @param  {String} key The cache key
-   * @return {Object}     The stored value
+   * @param  {String} key
+   * @return {Option<String>} The value, if found
    */
   getItem(key) {
-    return this.hash[key];
-  },
+    if (key in this.store) {
+      return this.store[key];
+    } else {
+      return null;
+    }
+  }
 
   /**
-   * Stores an item in memory.
+   * Store a string for a given key.
    *
    * @method setItem
-   * @param {String} key The cache key
-   * @param {Object} value The item
+   * @param {String} key
+   * @param {String} value
    */
   setItem(key, value) {
-    this.hash[key] = value;
-  },
+    this.store[key] = value;
+  }
 
   /**
-   * Deletes an entry from memory storage.
+   * Deletes the stored string for a given key.
    *
    * @method removeItem
-   * @param  {String} key The cache key
+   * @param  {String} key
    */
   removeItem(key) {
-    delete this.hash[key];
-  },
+    delete this.store[key];
+  }
 
   /**
-   * Returns the list keys of saved entries in memory.
+   * Returns the list of stored keys.
    *
    * @method keys
-   * @return {Array}  The array of keys
+   * @return {Array<String>} The array of keys
    */
   keys() {
-    return keys(this.hash);
+    return Object.keys(this.store);
   }
-});
+}

--- a/app/utils/local-storage-keys.js
+++ b/app/utils/local-storage-keys.js
@@ -1,5 +1,0 @@
-// Names of keys set in the storage service.
-
-export const HIDE_EMPTY_MODELS_KEY = 'are-model-types-hidden';
-
-export const ORDER_MODELS_BY_COUNT_KEY = 'are-models-ordered-by-record-count';

--- a/tests/acceptance/data-test.js
+++ b/tests/acceptance/data-test.js
@@ -10,11 +10,6 @@ import EmberObject from '@ember/object';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { triggerPort } from '../helpers/trigger-port';
-import LocalStorageService from 'ember-inspector/services/storage/local';
-import {
-  HIDE_EMPTY_MODELS_KEY,
-  ORDER_MODELS_BY_COUNT_KEY
-} from 'ember-inspector/utils/local-storage-keys';
 
 let port, name;
 
@@ -42,11 +37,6 @@ module('Data Tab', function(hooks) {
 
   hooks.afterEach(function() {
     name = null;
-    // This is to ensure settings in Storage do not persist across multiple test runs.
-    let storageService = this.owner.lookup(`service:storage/${LocalStorageService.STORAGE_TYPE_TO_USE}`);
-
-    storageService.removeItem(HIDE_EMPTY_MODELS_KEY);
-    storageService.removeItem(ORDER_MODELS_BY_COUNT_KEY);
   });
 
   function modelTypeFactory(options) {

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -1,19 +1,26 @@
-import Application from '../app';
-import Ember from 'ember';
+import Application from 'ember-inspector/app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
-const { generateGuid } = Ember;
-
-setApplication(Application.create(config.APP));
-window.NO_EMBER_DEBUG = true;
-start();
 
 Application.instanceInitializer({
-  name: `${generateGuid()}-detectEmberApplication`,
+  name: '00-force-memory-storage-backend',
+  initialize(instance) {
+    let memory = instance.lookup('service:storage/memory');
+    let storage = instance.lookup('service:storage');
+    storage.backend = memory;
+  }
+});
+
+Application.instanceInitializer({
+  name: '01-detect-ember-application',
   initialize(instance) {
     instance.lookup('route:app-detected').reopen({
       model() { }
     });
   }
 });
+
+setApplication(Application.create(config.APP));
+window.NO_EMBER_DEBUG = true;
+start();


### PR DESCRIPTION
Ensure we are always using the in-memory storage service backend in tests, so that we aren't leaking test states into local storage, or otherwise change test behaviors due to existing items there.