### PR TITLE
Avoid errors when using older Ember versions.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -30,7 +30,7 @@ const options = {
     sourceDirs: [
       'public/assets/svg'
     ]
-  }
+  },
 };
 
 // Firefox requires non-minified assets for review :(
@@ -54,6 +54,26 @@ module.exports = function(defaults) {
 
   if (emberChecker.isAbove('3.0.0')) {
     options.vendorFiles = { 'jquery.js': null };
+  }
+
+  // When running ember-try on Ember < 3.13, colocation support is
+  // disabled in ember-cli-htmlbars and causes a build error. When
+  // running ember-try, we actually don't care about the "app" side
+  // at all – all we do is run the ember_debug tests (via a --filter
+  // option to ember test in the ember-try config). The only reason
+  // we are even building the app is to get the test harness (qunit
+  // and friends) to work. In the long run, we should split up the
+  // build and not run the app build in ember-try, but in the mean
+  // time, this drops all *.hbs files (but keeping everything else)
+  // to avoid the problem. The app will of course not work correctly
+  // at runtime, but it was never meant to work on old ember versions
+  // in the first place.
+  if (!emberChecker.gte('3.13.0')) {
+    options.trees = {
+      app: new Funnel('app', {
+        exclude: ['**/*.hbs'],
+      }),
+    };
   }
 
   let app = new EmberApp(defaults, options);

--- a/lib/ui/index.js
+++ b/lib/ui/index.js
@@ -1,7 +1,32 @@
 'use strict';
 
+const VersionChecker = require('ember-cli-version-checker');
+
 module.exports = {
   name: require('./package').name,
+
+  // When running ember-try on Ember < 3.13, colocation support is
+  // disabled in ember-cli-htmlbars and causes a build error. When
+  // running ember-try, we actually don't care about the "app" side
+  // at all – all we do is run the ember_debug tests (via a --filter
+  // option to ember test in the ember-try config). The only reason
+  // we are even building the app is to get the test harness (qunit
+  // and friends) to work. In the long run, we should split up the
+  // build and not run the app build in ember-try, but in the mean
+  // time, this drops all the addon files (since we don't need them)
+  // to avoid the problem. The app will of course not work correctly
+  // at runtime, but it was never meant to work on old ember versions
+  // in the first place.
+  treeForAddon() {
+    let checker = new VersionChecker(this.project);
+    let emberChecker = checker.forEmber();
+
+    if (emberChecker.gte('3.13.0') ) {
+      return this._super.treeForAddon.apply(this, arguments);
+    } else {
+      return null;
+    }
+  },
 
   isDevelopingAddon() {
     return true;

--- a/lib/ui/package.json
+++ b/lib/ui/package.json
@@ -7,6 +7,7 @@
     "ember-cli-babel": "*",
     "ember-cli-htmlbars": "*",
     "ember-cli-sass": "*",
+    "ember-cli-version-checker": "*",
     "ember-svg-jar": "*"
   }
 }


### PR DESCRIPTION
With ember-cli-htmlbars 4.2, there is a check to disable co-location support on old ember versions (which, even when compiled, would fail at runtime due to missing `setComponentTemplate`). This is causing build failures when running ember-try with old Ember versions. Since we don't actually run the app or its tests in ember-try, we can work around the problem by skipping template compilation for now.

Paired with @rwjblue