### PR TITLE
Update `inspectNode` implementation

### DIFF
--- a/app/adapters/web-extension.js
+++ b/app/adapters/web-extension.js
@@ -80,10 +80,13 @@ export default BasicAdapter.extend({
    * Open the devtools "Elements" tab and select a specific DOM node.
    *
    * @method inspectDOMNode
-   * @param  {String} selector XPath selector
+   * @param {String} name
    */
-  inspectDOMNode(selector) {
-    chrome.devtools.inspectedWindow.eval(`inspect($x('${selector}')[0])`);
+  inspectDOMNode(name) {
+    chrome.devtools.inspectedWindow.eval(`
+      inspect(window[${JSON.stringify(name)}]);
+      delete window[${JSON.stringify(name)}];
+    `);
   },
 
   /**

--- a/app/routes/component-tree.js
+++ b/app/routes/component-tree.js
@@ -58,8 +58,8 @@ export default TabRoute.extend({
     this.set('controller.inspectingViews', false);
   },
 
-  inspectDOMNode({ selector }) {
-    this.get('port.adapter').inspectDOMNode(selector);
+  inspectDOMNode({ name }) {
+    this.port.adapter.inspectDOMNode(name);
   },
 
   actions: {

--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -60,17 +60,17 @@ export default EmberObject.extend({
   },
 
   /**
-    Inspect a specific element.  This usually
+    Inspect a specific DOM node. This usually
     means using the current environment's tools
-    to inspect the element in the DOM.
+    to inspect the node in the DOM.
 
-    For example, in chrome, `inspect(elem)`
+    For example, in chrome, `inspect(node)`
     will open the Elements tab in dev tools
-    and highlight the element.
+    and highlight the DOM node.
 
-    @param {DOM Element} elem
+    @param {Node} node
   */
-  inspectElement(/* elem */) {},
+  inspectNode(/* node */) {},
 
   _messageReceived(message) {
     this._messageCallbacks.forEach(callback => {

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -168,7 +168,7 @@ export default EmberObject.extend(PortMixin, {
    * @param  {Element} element The element to inspect
    */
   inspectElement(element) {
-    this.get('adapter').inspectElement(element);
+    this.get('adapter').inspectNode(element);
   },
 
   sendTree() {


### PR DESCRIPTION
A while ago we discovered the reason this dance was needed, so we documented the reason and simplified the implementation a little bit while we are at it.

Split from #1088. I'll rebase that PR once this lands.