### PR TITLE
Fix inspecting Glimmer components w/ obj inspector

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -13,21 +13,28 @@ const {
 const { oneWay } = computed;
 const { backburner, join } = run;
 
-let glimmer;
-let metal;
+const GlimmerComponent = (() => {
+  try {
+    return window.require('@glimmer/component').default;
+  } catch(e) {
+    // ignore, return undefined
+  }
+})();
+
+let GlimmerReference = null;
+let metal = null;
 let HAS_GLIMMER_TRACKING = false;
 try {
-  glimmer = Ember.__loader.require('@glimmer/reference');
+  GlimmerReference = Ember.__loader.require('@glimmer/reference');
   metal = Ember.__loader.require('@ember/-internals/metal');
-  HAS_GLIMMER_TRACKING = glimmer &&
-                         glimmer.value &&
-                         glimmer.validate &&
+  HAS_GLIMMER_TRACKING = GlimmerReference &&
+                         GlimmerReference.value &&
+                         GlimmerReference.validate &&
                          metal &&
                          metal.track &&
                          metal.tagForProperty;
 } catch (e) {
-  glimmer = null;
-  metal = null;
+  // ignore
 }
 
 const keys = Object.keys || Ember.keys;
@@ -237,12 +244,12 @@ export default EmberObject.extend(PortMixin, {
               let tagInfo = tracked[item.name] || { tag: metal.tagForProperty(object, item.name), revision: 0 };
               if (!tagInfo.tag) return;
 
-              changed = !glimmer.validate(tagInfo.tag, tagInfo.revision);
+              changed = !GlimmerReference.validate(tagInfo.tag, tagInfo.revision);
               if (changed) {
                 tagInfo.tag = metal.track(() => {
                   value = get(object, item.name);
                 });
-                tagInfo.revision = glimmer.value(object, item.name);
+                tagInfo.revision = GlimmerReference.value(object, item.name);
               }
               tracked[item.name] = tagInfo;
             } else {
@@ -972,7 +979,7 @@ function calculateCPs(object, mixinDetails, errorsForObject, expensiveProperties
                 item.isTracked = true;
               }
             }
-            tagInfo.revision = glimmer.value(object, item.name);
+            tagInfo.revision = GlimmerReference.value(object, item.name);
             item.dependentKeys = getTrackedDependencies(object, item.name, tagInfo.tag);
           } else {
             value = calculateCP(object, item, errorsForObject);
@@ -1106,8 +1113,7 @@ function getDebugInfo(object) {
     if (object instanceof Ember.ObjectProxy && object.content) {
       object = object.content;
     }
-    // We have to bind to object here to make sure the `this` context is correct inside _debugInfo when we call it
-    debugInfo = objectDebugInfo.bind(object)();
+    debugInfo = objectDebugInfo.call(object);
   }
   debugInfo = debugInfo || {};
   let propertyInfo = debugInfo.propertyInfo || (debugInfo.propertyInfo = {});
@@ -1131,6 +1137,17 @@ function getDebugInfo(object) {
       'states',
       'element',
       'targetObject'
+    );
+  } else if (GlimmerComponent && object instanceof GlimmerComponent) {
+    // These properties don't really exist on Glimmer Components, but
+    // reading their values trigger a development mode assertion. The
+    // more correct long term fix is to make getters lazy (shows "..."
+    // in the UI and only computed them when requested (when the user
+    // clicked on the "..." in the UI).
+    skipProperties.push(
+      'bounds',
+      'debugName',
+      'element'
     );
   }
   return debugInfo;

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -251,15 +251,14 @@ module('Ember Debug - View', function(hooks) {
 
   test('Supports applications that don\'t have the ember-application CSS class', async function t(assert) {
     let name, message;
-    let rootElement = document.body;
 
     await visit('/simple');
 
-    assert.dom(rootElement).hasClass(
+    assert.dom(this.element).hasClass(
       'ember-application',
       'The rootElement has the .ember-application CSS class'
     );
-    rootElement.classList.remove('ember-application');
+    this.element.classList.remove('ember-application');
 
     // Restart the inspector
     EmberDebug.start();

--- a/tests/helpers/setup-destroy-ei-app.js
+++ b/tests/helpers/setup-destroy-ei-app.js
@@ -22,7 +22,10 @@ export async function setupEIApp(EmberDebug, routes) {
     Router.map(routes);
   }
 
-  let App = Application.create({ autoboot: false });
+  let App = Application.create({
+    autoboot: false,
+    rootElement: document.getElementById('ember-testing'),
+  });
   App.register('router:main', Router);
 
   await setApplication(App);


### PR DESCRIPTION
Glimmer components instead dev mode assertion getters to warn about mismatches between the Ember.js vs legacy Glimmer.js APIs. Skip these properties when inspecting them to avoid tripping them.

Split from #1088. I'll rebase that PR once this lands.