### PR TITLE
Only deepClone when without prototype extensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
     strategy:
       matrix:
         scenario:
+          - default-no-prototype-extensions
           - release
           - beta
           - canary
@@ -77,6 +78,9 @@ jobs:
         uses: rwjblue/setup-volta@v1
       - name: Install dependencies (yarn)
         run: yarn install
+      - name: Set NO_EXTEND_PROTOTYPES
+        if: matrix.scenario == 'default-no-prototype-extensions'
+        run: echo "::set-env name=NO_EXTEND_PROTOTYPES,::true"
       - name: Setup ember-try scenario
         run: yarn ember try:one ember-${{ matrix.scenario }} --skip-cleanup --- cat package.json
       - name: Build

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -65,6 +65,12 @@ module.exports = function() {
           npm: {
             devDependencies: {}
           }
+        },
+        {
+          name: 'ember-default-no-prototype-extensions',
+          env: {
+            NO_EXTEND_PROTOTYPES: 'true'
+          }
         }
       ]
     };

--- a/config/environment.js
+++ b/config/environment.js
@@ -16,7 +16,7 @@ module.exports = function(environment) {
         // e.g. EMBER_MODULE_UNIFICATION: true
         EMBER_METAL_TRACKED_PROPERTIES: true
       },
-      EXTEND_PROTOTYPES: {
+      EXTEND_PROTOTYPES: process.env.NO_EXTEND_PROTOTYPES ? false : {
         // Prevent Ember Data from overriding Date.parse.
         Date: false
       }

--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -66,28 +66,36 @@ export default BasicAdapter.extend({
   }
 });
 
-/**
- * Recursively clones all arrays. Needed because Chrome
- * refuses to clone Ember Arrays when extend prototypes is disabled.
- *
- * If the item passed is an array, a clone of the array is returned.
- * If the item is an object or an array, or array properties/items are cloned.
- *
- * @param {Mixed} item The item to clone
- * @return {Mixed}
- */
-function deepClone(item) {
-  let clone = item;
-  if (isArray(item)) {
-    clone = new Array(item.length);
-    item.forEach((child, key) => {
-      clone[key] = deepClone(child);
-    });
-  } else if (item && typeOf(item) === 'object') {
-    clone = {};
-    keys(item).forEach(key => {
-      clone[key] = deepClone(item[key]);
-    });
-  }
-  return clone;
+let deepClone;
+
+if (Ember.ENV.EXTEND_PROTOTYPES.Array) {
+  deepClone = function deepClone(item) {
+    return item;
+  };
+} else {
+  /**
+   * Recursively clones all arrays. Needed because Chrome
+   * refuses to clone Ember Arrays when extend prototypes is disabled.
+   *
+   * If the item passed is an array, a clone of the array is returned.
+   * If the item is an object or an array, or array properties/items are cloned.
+   *
+   * @param {Mixed} item The item to clone
+   * @return {Mixed}
+   */
+  deepClone = function deepClone(item) {
+    let clone = item;
+    if (isArray(item)) {
+      clone = new Array(item.length);
+      item.forEach((child, key) => {
+        clone[key] = deepClone(child);
+      });
+    } else if (item && typeOf(item) === 'object') {
+      clone = {};
+      keys(item).forEach(key => {
+        clone[key] = deepClone(item[key]);
+      });
+    }
+    return clone;
+  };
 }


### PR DESCRIPTION
This adds a non-trivial amount of cost for each message (especially the complex ones like the view tree) that is not necessary in most apps.

Split from #1088. I'll rebase that PR once this lands.