### PR TITLE
Render the CHANGELOG for the current version

### DIFF
--- a/app/routes/whats-new.js
+++ b/app/routes/whats-new.js
@@ -1,7 +1,7 @@
 import TabRoute from 'ember-inspector/routes/tab';
 import fetch from 'fetch';
 
-const checkStatus = function(response) {
+function checkStatus(response) {
   if (response.status >= 200 && response.status < 300) {
     return response;
   } else {
@@ -9,19 +9,24 @@ const checkStatus = function(response) {
     error.response = response;
     throw error;
   }
-};
+}
 
-const getLatestEntry = function(doc) {
-  const regex = /^#{2} ?\[(v?[.\d]+)\]((?:[\s\S](?!^#{2}))+)/gm;
+function getLatestEntry(doc) {
+  const regex = /^#{2} ?\[(.+)\]((?:[\s\S](?!^#{2}))+)/gm;
   const matches = doc.match(regex);
   return matches ? matches[0] : '';
-};
+}
 
 export default TabRoute.extend({
   error: false,
 
   model() {
-    return fetch('https://raw.githubusercontent.com/emberjs/ember-inspector/master/CHANGELOG.md')
+    let { version } = this.config;
+
+    let ref = (version.indexOf('alpha') === -1) ? `v${version}` : 'master';
+    let url = `https://raw.githubusercontent.com/emberjs/ember-inspector/${encodeURIComponent(ref)}/CHANGELOG.md`;
+
+    return fetch(url)
       .then(checkStatus)
       .then((response) => response.text())
       .then((text) => getLatestEntry(text))

--- a/config/environment.js
+++ b/config/environment.js
@@ -8,6 +8,7 @@ module.exports = function(environment) {
     environment,
     rootURL: '',
     locationType: 'hash',
+    version: packageJson.version,
     emberVersionsSupported: packageJson.emberVersionsSupported,
     previousEmberVersionsSupported: packageJson.previousEmberVersionsSupported,
     EmberENV: {

--- a/tests/acceptance/whats-new-test.js
+++ b/tests/acceptance/whats-new-test.js
@@ -3,21 +3,32 @@ import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import Pretender from 'pretender';
 
-const CHANGELOG_URL = 'https://raw.githubusercontent.com/emberjs/ember-inspector/master/CHANGELOG.md';
-const CHANGELOG_RESPONSE = `
-# Changelog
+function urlFor(ref) {
+  return `https://raw.githubusercontent.com/emberjs/ember-inspector/${encodeURIComponent(ref)}/CHANGELOG.md`;
+}
 
+function generateContent(master = false) {
+  let content = [];
+
+  content.push(`# Changelog`);
+
+  if (master) {
+    content.push(`
 ## [Unreleased](https://github.com/emberjs/ember-inspector/tree/HEAD)
 
 **Merged pull requests:**
 
-- Stuff
+- Stuff`);
+  }
 
+  content.push(`
 ## [v3.3.0](https://github.com/emberjs/ember-inspector/tree/v3.3.0) (2018-08-02)
 
 [Full Changelog](https://emberjs.com)
 
 **Implemented enhancements:**
+
+- Stuff
 
 ## [v3.2.0](https://github.com/emberjs/ember-inspector/tree/v3.2.0) (2018-07-03)
 
@@ -25,41 +36,88 @@ const CHANGELOG_RESPONSE = `
 
 **Fixed bugs:**
 
-- Data
-`;
+- Data`);
 
-module('Whats New', function (hooks) {
-  setupApplicationTest(hooks);
+  return content.join('\n');
+}
 
-  hooks.afterEach(function() {
+module('Whats New', function(outer) {
+  setupApplicationTest(outer);
+
+  outer.beforeEach(function() {
+    this.config = this.owner.lookup('config:main');
+    this.originalVersion = this.config.version;
+  });
+
+  outer.afterEach(function() {
+    this.config.version = this.originalVersion;
+
     if (this.server) {
       this.server.shutdown();
     }
   });
 
-  test('Changelog is parsed and displayed', async function(assert) {
-    this.server = new Pretender(function () {
-      this.get(CHANGELOG_URL, () => [200, { 'Content-Type': 'text/plain' }, CHANGELOG_RESPONSE]);
+  module('Released version', function(inner) {
+    inner.beforeEach(function() {
+      this.config.version = '3.3.0';
     });
 
-    await visit('/info/whats-new');
+    test('Changelog is parsed and displayed', async function(assert) {
+      this.server = new Pretender(function () {
+        this.get(urlFor('v3.3.0'), () => [200, { 'Content-Type': 'text/plain' }, generateContent()]);
+      });
 
-    assert.dom('.whats-new h2').exists({ count: 1 }, 'correct section of markdown is rendered');
+      await visit('/info/whats-new');
 
-    assert.equal(
-      find('.whats-new h2 a').text,
-      'v3.3.0',
-      'correct section of markdown is rendered'
-    );
+      assert.dom('.whats-new h2').exists({ count: 1 }, 'correct section of markdown is rendered');
+
+      assert.equal(
+        find('.whats-new h2 a').text,
+        'v3.3.0',
+        'correct section of markdown is rendered'
+      );
+    });
+
+    test('Error message is displayed on request failure', async function(assert) {
+      this.server = new Pretender(function () {
+        this.get(urlFor('v3.3.0'), () => [404, {}, '']);
+      });
+
+      await visit('/info/whats-new');
+
+      assert.dom('.whats-new p').exists({ count: 1 }, 'Changelog could not be loaded');
+    });
   });
 
-  test('Error message is displayed on request failure', async function(assert) {
-    this.server = new Pretender(function () {
-      this.get(CHANGELOG_URL, () => [404, {}, '']);
+  module('Nightly version', function(inner) {
+    inner.beforeEach(function() {
+      this.config.version = '3.4.0-alpha.1';
     });
 
-    await visit('/info/whats-new');
+    test('Changelog is parsed and displayed', async function(assert) {
+      this.server = new Pretender(function () {
+        this.get(urlFor('master'), () => [200, { 'Content-Type': 'text/plain' }, generateContent(true)]);
+      });
 
-    assert.dom('.whats-new p').exists({ count: 1 }, 'Changelog could not be loaded');
+      await visit('/info/whats-new');
+
+      assert.dom('.whats-new h2').exists({ count: 1 }, 'correct section of markdown is rendered');
+
+      assert.equal(
+        find('.whats-new h2 a').text,
+        'Unreleased',
+        'correct section of markdown is rendered'
+      );
+    });
+
+    test('Error message is displayed on request failure', async function(assert) {
+      this.server = new Pretender(function () {
+        this.get(urlFor('master'), () => [404, {}, '']);
+      });
+
+      await visit('/info/whats-new');
+
+      assert.dom('.whats-new p').exists({ count: 1 }, 'Changelog could not be loaded');
+    });
   });
 });


### PR DESCRIPTION
There are a few cases where the CHANGELOG on master may not match the version you are actually running. For example, master can be behind the stable branch's CHANGELOGs, or you could be loading and running a nightly version. This patch try to fetch the CHANGELOG from the correct Git tag to ensure things matches up correctly.