### PR TITLE
Bring back Node 8 support (for now)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,10 @@
     "basiccontext": "^3.5.1",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-babel-transpiler": "^7.3.0",
-    "broccoli-concat": "^4.2.0",
+    "broccoli-concat": "^3.7.5",
     "broccoli-file-creator": "^2.1.1",
-    "broccoli-funnel": "3.0.0",
-    "broccoli-merge-trees": "^4.0.0",
+    "broccoli-funnel": "^2.0.2",
+    "broccoli-merge-trees": "^3.0.0",
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",
     "codeclimate-test-reporter": "^0.5.1",
@@ -107,7 +107,7 @@
     "yauzl": "^2.10.0"
   },
   "engines": {
-    "node": ">= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember": {
     "edition": "octane"
@@ -118,7 +118,7 @@
     ]
   },
   "volta": {
-    "node": "12.13.0",
+    "node": "8.17.0",
     "yarn": "1.19.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3633,22 +3633,23 @@ broccoli-concat@^3.2.2, broccoli-concat@^3.7.1, broccoli-concat@^3.7.4:
     lodash.uniq "^4.2.0"
     walk-sync "^0.3.2"
 
-broccoli-concat@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-4.2.0.tgz#0118934be80b80d1de52c5b2ee9a7091a5befe07"
-  integrity sha512-tAZ+GQdOt1l+x8nDFkrzDeKdSFxFWe75sUHsGZglkIkOlG2PczWHGnfr6yuZx7DBpOYfrnasCowj+BIJm7hoKw==
+broccoli-concat@^3.7.5:
+  version "3.7.5"
+  resolved "https://registry.yarnpkg.com/broccoli-concat/-/broccoli-concat-3.7.5.tgz#223beda8c1184252cf08ae020a3d45ffa6a48218"
+  integrity sha512-rDs1Mej3Ej0Cy5yIO9oIQq5+BCv0opAwS2NW7M0BeCsAMeFM42Z/zacDUC6jKc5OV5wiHvGTyCPLnZkMe0h6kQ==
   dependencies:
     broccoli-debug "^0.6.5"
     broccoli-kitchen-sink-helpers "^0.3.1"
-    broccoli-plugin "^3.1.0"
+    broccoli-plugin "^1.3.0"
     ensure-posix-path "^1.0.2"
     fast-sourcemap-concat "^1.4.0"
     find-index "^1.1.0"
-    fs-extra "^8.1.0"
-    fs-tree-diff "^2.0.1"
+    fs-extra "^4.0.3"
+    fs-tree-diff "^0.5.7"
     lodash.merge "^4.6.2"
     lodash.omit "^4.1.0"
     lodash.uniq "^4.2.0"
+    walk-sync "^0.3.2"
 
 broccoli-config-loader@^1.0.1:
   version "1.0.1"
@@ -3714,24 +3715,6 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
   integrity sha1-ETZbKnha7JsXlyo234fu8kxcwOo=
-
-broccoli-funnel@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-3.0.0.tgz#46fa8b570eccdfa9f66c71e85ce4a5dc68ec2ad6"
-  integrity sha512-BzqVvCXQt/d0Lk9fmT8Z/34rt2BB1OjQe1+e5w29ZXkg7pBlvRIYiPq3M+1Hy0E6jJ/ASB6m/d7TBl7cTHjEFQ==
-  dependencies:
-    array-equal "^1.0.0"
-    blank-object "^1.0.1"
-    broccoli-plugin "^3.0.0"
-    debug "^4.1.1"
-    fast-ordered-set "^1.0.0"
-    fs-tree-diff "^2.0.1"
-    heimdalljs "^0.2.0"
-    minimatch "^3.0.0"
-    path-posix "^1.0.0"
-    rimraf "^3.0.0"
-    symlink-or-copy "^1.0.0"
-    walk-sync "^0.3.1"
 
 broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0:
   version "1.2.0"
@@ -3823,14 +3806,6 @@ broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1, broccoli-merge-trees@^
     broccoli-plugin "^1.3.0"
     merge-trees "^2.0.0"
 
-broccoli-merge-trees@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-4.0.0.tgz#57c7993cc74bf16efed8df7a5188a0202a70216d"
-  integrity sha512-FJ1dTqxzDmpqbQFxuhicPbA6URV0D1XCKHFIvKwi6Y70pxuYLMpyRfjNv6iNSwSq/juxGubunKiLb8U2dM+a2A==
-  dependencies:
-    broccoli-plugin "^3.1.0"
-    merge-trees "^2.0.0"
-
 broccoli-middleware@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-2.1.0.tgz#cbb458cb6360bdd79aa75a54057f10fe918157e6"
@@ -3860,7 +3835,7 @@ broccoli-module-unification-reexporter@^1.0.0:
     mkdirp "^0.5.1"
     walk-sync "^0.3.2"
 
-broccoli-node-api@^1.6.0, broccoli-node-api@^1.7.0:
+broccoli-node-api@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-api/-/broccoli-node-api-1.7.0.tgz#391aa6edecd2a42c63c111b4162956b2fa288cb6"
   integrity sha512-QIqLSVJWJUVOhclmkmypJJH9u9s/aWH4+FH6Q6Ju5l+Io4dtwqdPUNmDfw40o6sxhbZHhqGujDJuHTML1wG8Yw==
@@ -3879,13 +3854,6 @@ broccoli-node-info@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-node-info/-/broccoli-node-info-2.0.0.tgz#652a7940ede40630b84ad009c6236f4bc548b556"
   integrity sha512-xfnzPYdf8Uu3mfhEPkh3CX1suGHNNW4k3f730llzr4Dl7UXvI5T8RUb7X04BSvJfvqYTekM/JTmYrjB01WAsCg==
-
-broccoli-output-wrapper@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/broccoli-output-wrapper/-/broccoli-output-wrapper-2.0.0.tgz#f1e0b9b2f259a67fd41a380141c3c20b096828e6"
-  integrity sha512-V/ozejo+snzNf75i/a6iTmp71k+rlvqjE3+jYfimuMwR1tjNNRdtfno+NGNQB2An9bIAeqZnKhMDurAznHAdtA==
-  dependencies:
-    heimdalljs-logger "^0.1.10"
 
 broccoli-persistent-filter@^1.1.5, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.3:
   version "1.4.6"
@@ -3952,19 +3920,6 @@ broccoli-plugin@^3.0.0:
   integrity sha512-aEtobBvzAlUIAaY5z+LwW2W3IJ9pruJtrT571CyfjoDFTGa8LZx0qjQG97Z7Guk5YzuxDoDNlM3hGsgBnnReTw==
   dependencies:
     broccoli-node-api "^1.6.0"
-    promise-map-series "^0.2.1"
-    quick-temp "^0.1.3"
-    rimraf "^2.3.4"
-    symlink-or-copy "^1.1.8"
-
-broccoli-plugin@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-3.1.0.tgz#54ba6dd90a42ec3db5624063292610e326b1e542"
-  integrity sha512-7w7FP8WJYjLvb0eaw27LO678TGGaom++49O1VYIuzjhXjK5kn2+AMlDm7CaUFw4F7CLGoVQeZ84d8gICMJa4lA==
-  dependencies:
-    broccoli-node-api "^1.6.0"
-    broccoli-output-wrapper "^2.0.0"
-    fs-merger "^3.0.1"
     promise-map-series "^0.2.1"
     quick-temp "^0.1.3"
     rimraf "^2.3.4"
@@ -8038,18 +7993,6 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-merger@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fs-merger/-/fs-merger-3.0.2.tgz#bf111334b89b8d65b95580d33c587dc79620a4e3"
-  integrity sha512-63wmgjPDClP5XcTSKdIXz66X5paYy/m2Ymq5c5YpGxRQEk1HFZ8rtti3LMNSOSw1ketbBMGbSFFcQeEnpnzDpQ==
-  dependencies:
-    broccoli-node-api "^1.7.0"
-    broccoli-node-info "^2.1.0"
-    fs-extra "^8.0.1"
-    fs-tree-diff "^2.0.1"
-    rimraf "^2.6.3"
-    walk-sync "^2.0.2"
 
 fs-minipass@^1.2.5:
   version "1.2.7"


### PR DESCRIPTION
Revert some dependencies bump from #1096 because `ember-electron` (probably the only npm consumer?) still support Node 8. This is mostly a technicality, since they don't actually run the build and only consume the artifacts in `dist` (included in the npm package).

We should probably find a better way for them to consume the app, but in the mean time, this will allow them to consume the latest inspector until Node 8 is officially EOL in a few weeks. We can try this again when Ember CLI drops Node 8 support (likely 3.17).