### PR TITLE
Side docked inspector ergonimics

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -32,7 +32,6 @@ export default Controller.extend({
   isEmberApplication: false,
 
   navWidth: 180,
-  inspectorWidth: 360,
   isChrome: equal('port.adapter.name', 'chrome'),
 
   deprecationCount: 0,

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { equal } from '@ember/object/computed';
-import { schedule } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 
 export default Controller.extend({
@@ -13,6 +12,14 @@ export default Controller.extend({
    * @type {Service}
    */
   layoutService: service('layout'),
+
+  /**
+   * Service used to control the object inspector toggling
+   *
+   * @property objectInspectorService
+   * @type {Service}
+   */
+  objectInspectorService: service('object-inspector'),
 
   isDragging: false,
   contentHeight: null,
@@ -32,8 +39,6 @@ export default Controller.extend({
 
   // Indicates that the extension window is focused,
   active: true,
-
-  inspectorExpanded: false,
 
   init() {
     this._super(...arguments);
@@ -64,34 +69,6 @@ export default Controller.extend({
     let item = mixinStack.popObject();
     this.set('mixinDetails', mixinStack.get('lastObject'));
     this.port.send('objectInspector:releaseObject', { objectId: item.objectId });
-  }),
-
-  showInspector: action(function() {
-    if (this.inspectorExpanded === false) {
-      this.set('inspectorExpanded', true);
-      // Broadcast that tables have been resized (used by `x-list`).
-      schedule('afterRender', () => {
-        this.layoutService.trigger('resize', { source: 'object-inspector' });
-      });
-    }
-  }),
-
-  hideInspector: action(function() {
-    if (this.inspectorExpanded === true) {
-      this.set('inspectorExpanded', false);
-      // Broadcast that tables have been resized (used by `x-list`).
-      schedule('afterRender', () => {
-        this.layoutService.trigger('resize', { source: 'object-inspector' });
-      });
-    }
-  }),
-
-  toggleInspector: action(function() {
-    if (this.inspectorExpanded) {
-      this.hideInspector();
-    } else {
-      this.showInspector();
-    }
   }),
 
   setActive: action(function(bool) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -66,7 +66,7 @@ export default Route.extend({
       controller.activateMixinDetails(name, objectId, details, errors);
     }
 
-    this.controller.showInspector();
+    this.objectInspectorService.showInspector();
   },
 
   setDeprecationCount(message) {
@@ -106,6 +106,14 @@ export default Route.extend({
    * @type {Service}
    */
   layoutService: service('layout'),
+
+  /**
+   * Service used to control the object inspector toggling
+   *
+   * @property objectInspectorService
+   * @type {Service}
+   */
+  objectInspectorService: service('object-inspector'),
 
   actions: {
     inspectObject(objectId) {

--- a/app/services/object-inspector.js
+++ b/app/services/object-inspector.js
@@ -13,6 +13,7 @@ export default class ObjectInspectorService extends Service {
   showInspector() {
     if (this.inspectorExpanded === false) {
       this.inspectorExpanded = true;
+      // Broadcast that tables have been resized (used by `x-list`).
       schedule("afterRender", () => {
         this.layoutService.trigger("resize", { source: "object-inspector" });
       });
@@ -23,6 +24,7 @@ export default class ObjectInspectorService extends Service {
   hideInspector() {
     if (this.inspectorExpanded === true) {
       this.inspectorExpanded = false;
+      // Broadcast that tables have been resized (used by `x-list`).
       schedule("afterRender", () => {
         this.layoutService.trigger("resize", { source: "object-inspector" });
       });

--- a/app/services/object-inspector.js
+++ b/app/services/object-inspector.js
@@ -1,0 +1,40 @@
+import Service, { inject as service } from "@ember/service";
+import { action } from "@ember/object";
+import { tracked } from "@glimmer/tracking";
+import { schedule } from "@ember/runloop";
+
+export default class ObjectInspectorService extends Service {
+  @service("layout") layoutService;
+
+  @tracked inspectorWidth = 360;
+  @tracked inspectorExpanded = false;
+
+  @action
+  showInspector() {
+    if (this.inspectorExpanded === false) {
+      this.inspectorExpanded = true;
+      schedule("afterRender", () => {
+        this.layoutService.trigger("resize", { source: "object-inspector" });
+      });
+    }
+  }
+
+  @action
+  hideInspector() {
+    if (this.inspectorExpanded === true) {
+      this.inspectorExpanded = false;
+      schedule("afterRender", () => {
+        this.layoutService.trigger("resize", { source: "object-inspector" });
+      });
+    }
+  }
+
+  @action
+  toggleInspector() {
+    if (this.inspectorExpanded) {
+      this.hideInspector();
+    } else {
+      this.showInspector();
+    }
+  }
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -29,12 +29,9 @@
           <div class="split__panel">
             <div class="split__panel__hd">
               {{outlet "toolbar"}}
-              <button
-                class="sidebar-toggle toolbar__icon-button {{if this.inspectorExpanded "flip"}}"
-                {{on "click" this.toggleInspector}}
-              >
-                {{svg-jar "sidebar-toggle" width="16" height="16"}}
-              </button>
+              {{#if (not this.objectInspectorService.inspectorExpanded)}}
+                <Ui::ToolbarToggleButton />
+              {{/if}}
             </div>
 
             <MonitorContentHeight class="split__panel__bd">
@@ -43,8 +40,7 @@
           </div>
         </div>
       </div>
-
-      {{#if this.inspectorExpanded}}
+      {{#if this.objectInspectorService.inspectorExpanded}}
         <Ui::DraggableColumn
           @classes="split__panel"
           @side="right"

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -44,7 +44,7 @@
         <Ui::DraggableColumn
           @classes="split__panel"
           @side="right"
-          @width={{this.inspectorWidth}}
+          @width={{this.objectInspectorService.inspectorWidth}}
         >
           <ObjectInspector
             @popMixinDetails={{this.popMixinDetails}}

--- a/app/templates/components/object-inspector.hbs
+++ b/app/templates/components/object-inspector.hbs
@@ -1,5 +1,6 @@
 {{#if @model.length}}
   <div class="split__panel__hd">
+    <Ui::ToolbarToggleButton />
     <div class="toolbar">
       <button
         class="toolbar__icon-button {{if this.isNested "enabled" "disabled"}} js-object-inspector-back"
@@ -7,13 +8,10 @@
       >
         {{svg-jar "arrow-back" width="21px" height="21px"}}
       </button>
-
       <Ui::ToolbarDivider />
-
       <code class="object-inspector-object-name js-object-name">
         {{@model.firstObject.name}}
       </code>
-
       <button
         class="send-to-console js-send-object-to-console-btn"
         title="Send to Console"
@@ -22,16 +20,17 @@
         {{svg-jar "send-with-text" width="20px" height="10px"}}
       </button>
     </div>
-
     {{#if this.trail}}
-      <code class="object-trail js-object-trail">{{this.trail}}</code>
+      <code class="object-trail js-object-trail">
+        {{this.trail}}
+      </code>
     {{/if}}
   </div>
-
   <div class="split__panel__bd">
     <div class="toolbar object-inspector-toolbar">
       <button
-        class="toolbar__radio toolbar__radio--first js-object-display-type-grouped {{if (eq this.propDisplayType "grouped") "active"}}"
+        class="toolbar__radio toolbar__radio--first js-object-display-type-grouped
+          {{if (eq this.propDisplayType "grouped") "active"}}"
         {{on "click" (fn this.setPropDisplay "grouped")}}
       >
         Grouped
@@ -43,14 +42,12 @@
         All
       </button>
     </div>
-
     {{#if @mixinDetails.errors.length}}
       <ObjectInspector::Errors
         @errors={{@mixinDetails.errors}}
         @traceErrors={{fn this.traceErrors @mixinDetails.objectId}}
       />
     {{/if}}
-
     {{#if (eq this.propDisplayType "all")}}
       <ObjectInspector::PropertiesAll @model={{@mixinDetails}} />
     {{else if (eq this.propDisplayType "grouped")}}
@@ -58,6 +55,9 @@
     {{/if}}
   </div>
 {{else}}
+  <div class="split__panel__hd">
+    <Ui::ToolbarToggleButton />
+  </div>
   <div class="split__panel__bd">
     <Ui::EmptyMessage>
       No object selected

--- a/lib/ui/addon/components/toolbar-toggle-button.hbs
+++ b/lib/ui/addon/components/toolbar-toggle-button.hbs
@@ -1,0 +1,3 @@
+<button class="sidebar-toggle toolbar__icon-button {{if this.objectInspectorService.inspectorExpanded "flip"}}" {{on "click" this.objectInspectorService.toggleInspector}}>
+  {{svg-jar "sidebar-toggle" width="16" height="16"}}
+</button>

--- a/lib/ui/addon/components/toolbar-toggle-button.js
+++ b/lib/ui/addon/components/toolbar-toggle-button.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import { inject as service } from '@ember/service';
+
+export default class ToolbarToggleButton extends Component {
+	@service('object-inspector') objectInspectorService;
+}

--- a/lib/ui/addon/styles/_sidebar-toggle.scss
+++ b/lib/ui/addon/styles/_sidebar-toggle.scss
@@ -11,8 +11,13 @@
   right: 0;
   top: 0;
 
-  &.flip .sidebar-toggle-triangle {
-    transform: rotate(180deg) translateX(3px);
-    transform-origin: center;
+  &.flip {
+    background-color: var(--base00);
+    left: -28px;
+
+    & .sidebar-toggle-triangle {
+      transform: rotate(180deg) translateX(3px);
+      transform-origin: center;
+    }
   }
 }

--- a/lib/ui/addon/styles/_sidebar-toggle.scss
+++ b/lib/ui/addon/styles/_sidebar-toggle.scss
@@ -12,7 +12,6 @@
   top: 0;
 
   &.flip {
-    background-color: var(--base00);
     left: -28px;
 
     & .sidebar-toggle-triangle {

--- a/lib/ui/addon/styles/_split.scss
+++ b/lib/ui/addon/styles/_split.scss
@@ -24,6 +24,7 @@
   flex: auto;
   flex-direction: column;
   position: relative;
+  z-index: 0;
 }
 
 .split__panel__hd,
@@ -51,7 +52,7 @@
 .split__panel__bd {
   background: var(--base00);
   flex: auto;
-  overflow: auto;
+  overflow: scroll;
 }
 
 .split__panel__ft {

--- a/lib/ui/addon/styles/_split.scss
+++ b/lib/ui/addon/styles/_split.scss
@@ -52,7 +52,7 @@
 .split__panel__bd {
   background: var(--base00);
   flex: auto;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .split__panel__ft {

--- a/lib/ui/addon/styles/toolbar/_icon-button.scss
+++ b/lib/ui/addon/styles/toolbar/_icon-button.scss
@@ -20,6 +20,7 @@
   }
 
   &:active {
+    background: transparent;
     transform: translate(1px, 1px);
   }
 }

--- a/lib/ui/addon/styles/toolbar/_icon-button.scss
+++ b/lib/ui/addon/styles/toolbar/_icon-button.scss
@@ -30,6 +30,7 @@
   SVG colors
 */
 .toolbar__icon-button {
+  background-color: var(--base00);
   .svg-stroke { stroke: var(--base11); }
   .svg-fill { fill: var(--base11); }
 

--- a/lib/ui/app/components/ui/toolbar-toggle-button.js
+++ b/lib/ui/app/components/ui/toolbar-toggle-button.js
@@ -1,0 +1,1 @@
+export { default } from 'ui/components/toolbar-toggle-button';


### PR DESCRIPTION
## Issue and Steps to Reproduce
There are a few css improvements that can bump dev experience while using the inspector docked at right/left

1. z-index for records lists / tables
2. the sidebar toggling button hides pretty easily.

## Your environment

Chrome, Ember version 3.15, inspector >= 3.13

## Screenshots

### 1. z-index for records lists / tables
![Screen Shot 2019-12-26 at 12 07 49 AM](https://user-images.githubusercontent.com/9092644/71461286-ee8b0800-2774-11ea-972a-e1b273ccc953.png)

### 2. the sidebar toggling button hides pretty easily
![Screen Shot 2019-12-26 at 12 11 54 AM](https://user-images.githubusercontent.com/9092644/71461293-f77bd980-2774-11ea-977c-bb988089d279.png)


Not sure if this would be the best way to solve it, but since we ideally want the toggler "show/hide" always visible, I placed the button inside the object-inspector panel too, using absolute positioning. 

Tests are missing, but first I wanted to get feedback, thanks

