### PR TITLE
ember inspects hangs up the app

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -220,6 +220,12 @@ export default EmberObject.extend(PortMixin, {
   currentObject: null,
 
   updateCurrentObject() {
+    if (this.updateCurrentObjectTimeout) {
+      return;
+    }
+    this.updateCurrentObjectTimeout = setTimeout(() => {
+      this.updateCurrentObjectTimeout = null;
+    }, 350);
     if (this.currentObject) {
       const { object, mixinDetails, objectId } = this.currentObject;
       mixinDetails.forEach((mixin, mixinIndex) => {

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -221,10 +221,15 @@ export default EmberObject.extend(PortMixin, {
 
   updateCurrentObject() {
     if (this.updateCurrentObjectTimeout) {
+      this.scheduleUpdateCurrentObject = true
       return;
     }
     this.updateCurrentObjectTimeout = setTimeout(() => {
       this.updateCurrentObjectTimeout = null;
+      if (this.scheduleUpdateCurrentObject) {
+        this.scheduleUpdateCurrentObject = false;
+        this.updateCurrentObject();
+      }
     }, 350);
     if (this.currentObject) {
       const { object, mixinDetails, objectId } = this.currentObject;


### PR DESCRIPTION
updateCurrentObject is called many many times per second...
not sure about the correct solution here.

I guess this can also happen if a getter or CP of the current object calls a Ember.set or Ember.run?