### PR TITLE
Fix component list overflow

### DIFF
--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -14,6 +14,7 @@
   --unit10: calc(var(--unit1) * 10);
   --unit11: calc(var(--unit1) * 11);
   --unit12: calc(var(--unit1) * 12);
+  --transparent: transparent;
 }
 
 h1,

--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -14,7 +14,6 @@
   --unit10: calc(var(--unit1) * 10);
   --unit11: calc(var(--unit1) * 11);
   --unit12: calc(var(--unit1) * 12);
-  --transparent: transparent;
 }
 
 h1,

--- a/app/styles/colors.scss
+++ b/app/styles/colors.scss
@@ -35,7 +35,7 @@
   --component-name: #1171E8;
   --component-brackets-selected: rgba(255, 255, 255, 0.4);
   --component-attr: #DB00A9;
-  --component-highlighted-bg: rgba(0, 0, 0, 0.05);
+  --component-highlighted-bg: #F2F2F3;
   --pill-bg: rgba(0, 0, 0, 0.1);
   --pill-bg-active: rgba(255, 255, 255, 0.3);
   --warning-text: #735c0f;
@@ -79,7 +79,7 @@
   --component-name: #77BEFF;
   --component-brackets-selected: rgba(255, 255, 255, 0.4);
   --component-attr: #FE7AE9;
-  --component-highlighted-bg: rgba(255, 255, 255, 0.075);
+  --component-highlighted-bg: #333333;
   --pill-bg: rgba(255, 255, 255, 0.2);
   --pill-bg-active: rgba(255, 255, 255, 0.3);
   --warning-text: #8ca3f0;

--- a/app/styles/component_tree.scss
+++ b/app/styles/component_tree.scss
@@ -1,30 +1,36 @@
 .component-tree-item {
-  align-items: center;
-  border-radius: 4px;
   color: var(--base12);
-  display: flex;
   font-size: 12px;
-  margin: 0 3px;
   min-height: 22px;
-  position: relative;
+
+  &__actions {
+    min-height: 22px;
+    opacity: 0;
+    right: var(--unit1);
+
+    /**
+      * __actions is position:sticky so it is always visible.
+      * Due to margins and padding on various elements, it was
+      * difficult to keep the background of __actions on top
+      * of .tree-item text and align with the .tree-item background.
+      * This pseudo element is 100% of the width of __actions plus
+      * a little extra to guarantee alignment.
+    */
+    &:after {
+      border-bottom-right-radius: var(--unit1);
+      border-top-right-radius: var(--unit1);
+      bottom: 0;
+      content: '';
+      left: calc(var(--unit1) * -1);
+      position: absolute;
+      right: calc(var(--unit1) * -1);
+      top: 0;
+    }
+  }
 
   &__action {
-    align-items: center;
-    background: transparent;
-    border: 0;
-    cursor: pointer;
-    display: inline-flex;
-    height: 100%;
-    margin-left: 10px;
-    opacity: 0;
-    padding: 0;
-
     &:focus {
       outline: none;
-    }
-
-    &.disabled {
-      cursor: not-allowed;
     }
 
     polygon,
@@ -34,38 +40,37 @@
     }
   }
 
-  &:hover {
-    background-color: var(--base05);
+  /**
+    * This element helps with a visual bug.
+    * When an item overflows the bounds of the list,
+    * the item background color clips at the point of the overflow.
+    * This child of the item has the same background color
+    * and will extend past the overflow point.
+  */
+  .component-tree-item-background {
+    min-height: 22px;
+  }
 
-    .component-tree-item__action {
-      opacity: 1;
+  &:hover {
+    background-color: var(--component-highlighted-bg);
+
+    .component-tree-item-background {
+      background-color: var(--component-highlighted-bg);
     }
 
-    .component-tree-item__action.disabled {
-      opacity: 0.65;
+    .component-tree-item__actions {
+      opacity: 1;
+
+      &:after {
+        background-color: var(--component-highlighted-bg);
+      }
     }
   }
-}
-
-.component-tree-item__expand {
-  align-self: stretch;
-  cursor: pointer;
-  padding-left: 3px;
-  padding-right: 3px;
 }
 
 .component-tree-item__tag {
-  cursor: default;
-  display: flex;
-  white-space: nowrap;
-
   .component-name {
     color: var(--component-name);
-  }
-
-  .arg-token {
-    display: flex;
-    margin-left: 0.5rem;
   }
 
   .bracket-token {
@@ -79,10 +84,6 @@
   .value-token {
     color: var(--spec03);
   }
-}
-
-.component-tree-item--has-instance .component-tree-item__tag {
-  cursor: pointer;
 }
 
 .component-tree-item--selected .component-tree-item__tag {
@@ -123,17 +124,7 @@
 
 /**
  * Modifier
- * highlighted - children of selected component
- */
-
-.component-tree-item.component-tree-item--highlighted {
-  background-color: var(--component-highlighted-bg);
-  border-radius: 0;
-}
-
-/**
- * Modifier
- * selected
+ * selected - user clicked on component
  */
 
 .component-tree-item.component-tree-item--selected {
@@ -142,6 +133,18 @@
 
   &:hover {
     background: var(--focus);
+  }
+
+  .component-tree-item-background {
+    background: var(--focus);
+  }
+
+  .component-tree-item__actions {
+    opacity: 1;
+
+    &:after {
+      background: var(--focus);
+    }
   }
 
   .component-tree-item__bracket:before,
@@ -158,10 +161,6 @@
     path {
       fill: var(--focus-text);
     }
-  }
-
-  .component-tree-item__action.disabled {
-    opacity: 0.65;
   }
 }
 

--- a/app/styles/component_tree.scss
+++ b/app/styles/component_tree.scss
@@ -9,7 +9,7 @@
     right: var(--unit1);
 
     /**
-      * __actions is position:sticky so it is always visible.
+      * __actions is position:sticky so it is always visible and on top.
       * Due to margins and padding on various elements, it was
       * difficult to keep the background of __actions on top
       * of .tree-item text and align with the .tree-item background.
@@ -25,6 +25,19 @@
       position: absolute;
       right: calc(var(--unit1) * -1);
       top: 0;
+    }
+
+    /**
+      * __actions is position:sticky so it is always visible and on top.
+      * :before is a gradient to soften the edge when overlaying text.
+    */
+    &:before {
+      bottom: 0;
+      content: '';
+      left: calc(var(--unit3) * -1);
+      position: absolute;
+      top: 0;
+      width: var(--unit3);
     }
   }
 
@@ -63,6 +76,10 @@
 
       &:after {
         background-color: var(--component-highlighted-bg);
+      }
+
+      &:before {
+        background: linear-gradient(to right, var(--transparent), var(--component-highlighted-bg) 75%);
       }
     }
   }
@@ -144,6 +161,10 @@
 
     &:after {
       background: var(--focus);
+    }
+
+    &:before {
+      background: linear-gradient(to right, var(--transparent), var(--focus) 75%);
     }
   }
 

--- a/app/styles/utils.scss
+++ b/app/styles/utils.scss
@@ -1,6 +1,18 @@
 $units: 0, 1, 2, 3, 4;
 
+.relative { position: relative; }
+
+.sticky {
+  position: -webkit-sticky;
+  position: sticky;
+}
+
+.right-0 {
+  right: 0;
+}
+
 .flex { display: flex; }
+.inline-flex { display: inline-flex; }
 
 .flex-grow { flex-grow: 1; }
 .flex-grow-0 { flex-grow: 0; }
@@ -8,6 +20,7 @@ $units: 0, 1, 2, 3, 4;
 .flex-shrink-0 { flex-shrink: 0; }
 
 .items-center { align-items: center; }
+.self-stretch { align-self: stretch; }
 
 .w-5 { width: var(--unit5); }
 .w-6 { width: var(--unit6); }
@@ -18,10 +31,13 @@ $units: 0, 1, 2, 3, 4;
 .w-11 { width: var(--unit11); }
 .w-12 { width: var(--unit12); }
 
+.h-full { height: 100%; }
+
 @each $key in $units {
   .w-#{$key} { width: var(--unit#{$key}); }
   .h-#{$key} { height: var(--unit#{$key}); }
 
+  .p-#{$key} { padding: var(--unit#{$key}); }
   .pt-#{$key} { padding-top: var(--unit#{$key}); }
   .pr-#{$key} { padding-right: var(--unit#{$key}); }
   .pb-#{$key} { padding-bottom: var(--unit#{$key}); }
@@ -37,6 +53,7 @@ $units: 0, 1, 2, 3, 4;
     padding-top: var(--unit#{$key});
   }
 
+  .m-#{$key} { margin: var(--unit#{$key}); }
   .mt-#{$key} { margin-top: var(--unit#{$key}); }
   .mr-#{$key} { margin-right: var(--unit#{$key}); }
   .mb-#{$key} { margin-bottom: var(--unit#{$key}); }
@@ -53,10 +70,12 @@ $units: 0, 1, 2, 3, 4;
   }
 }
 
+.border-0 { border-width: 0; }
+
 .rounded-none { border-radius: 0; }
-.rounded-sm { border-radius: 0.125rem; }
-.rounded { border-radius: 0.25rem; }
-.rounded-lg { border-radius: 0.5rem; }
+.rounded-sm { border-radius: calc(var(--unit1) / 2); }
+.rounded { border-radius: var(--unit1); }
+.rounded-lg { border-radius: var(--unit2); }
 .rounded-full { border-radius: 9999px; }
 
 .font-bold { font-weight: bold; }
@@ -65,7 +84,14 @@ $units: 0, 1, 2, 3, 4;
 .text-left { text-align: left; }
 .text-center { text-align: center; }
 .text-right { text-align: right; }
+.whitespace-no-wrap { white-space: nowrap; }
 
+.bg-transparent { background-color: var(--transparent); }
 .bg-base00 { background-color: var(--base00); }
 .bg-base01 { background-color: var(--base01); }
 .bg-base02 { background-color: var(--base02); }
+
+.cursor-default { cursor: default; }
+.cursor-pointer { cursor: pointer; }
+
+.z-10 { z-index: 10; }

--- a/app/templates/components/component-tree-item.hbs
+++ b/app/templates/components/component-tree-item.hbs
@@ -1,106 +1,111 @@
 <div
   style={{@item.style}}
   class="
-    component-tree-item
+    component-tree-item relative flex items-center mx-1 rounded
+    {{if @item.hasInstance "cursor-pointer" "cursor-default"}}
     {{if @item.isComponent "component-tree-item--component"}}
-    {{if @item.hasInstance "component-tree-item--has-instance"}}
-    {{if @item.isSelected "component-tree-item--selected"}}
-    {{if @item.isHighlighted "component-tree-item--highlighted"}}"
+    {{if @item.isSelected "component-tree-item--selected"}}"
   {{on "click" @item.toggleInspection}}
   {{on "mouseenter" @item.showPreview}}
   {{on "mouseleave" @item.hidePreview}}
 >
-  {{#if @item.hasChildren}}
-    <Ui::DisclosureTriangle
-      class="component-tree-item__expand"
-      title="Click to toggle (alt/option click to toggle with children)"
-      @toggle={{@item.toggleExpansion}}
-      @expanded={{@item.isExpanded}}
-    />
-  {{/if}}
-
-  <code
-    class="component-tree-item__tag
-      {{if
-        @item.isComponent
-        (if
-          @item.isCurlyInvocation
-          "component-tree-item-classic__bracket"
-          (if
-            @item.hasChildren
-            "component-tree-item__bracket"
-            "component-tree-item__bracket component-tree-item__bracket--self-closing"
-          )
-        )
-      }}"
-  >
-    {{#if @item.isComponent}}
-      {{#if @item.args.positional}}
-        <span class="component-name">
-          {{@item.name}}
-        </span>
-
-        {{#each @item.args.positional as |value|}}
-          <div class="arg-token">
-            <span class="value-token">
-              {{component-argument value}}
-            </span>
-          </div>
-        {{/each}}
-
-        {{#each-in @item.args.named as |name value|}}
-          <div class="arg-token">
-            <span class="key-token">
-              {{name}}
-            </span>
-            =
-            <span class="value-token">
-              {{component-argument value}}
-            </span>
-          </div>
-        {{/each-in}}
-      {{else}}
-        <span class="component-name">
-          {{classify @item.name}}
-        </span>
-
-        {{#each-in @item.args.named as |name value|}}
-          <div class="arg-token">
-            <span class="key-token">
-              @{{name}}
-            </span>
-            ={{#if (is-string value)}}"{{else}}<span class="bracket-token">\{{</span>{{/if}}
-            <span class="value-token">
-              {{component-argument value}}
-            </span>
-            {{#if (is-string value)}}"{{else}}<span class="bracket-token">}}</span>{{/if}}
-          </div>
-        {{/each-in}}
-      {{/if}}
-    {{else if @item.isOutlet}}
-      \{{outlet "{{@item.name}}"}}
-    {{else if @item.isEngine}}
-      \{{mount "{{@item.name}}"}}
-    {{else if @item.isRouteTemplate}}
-      {{@item.name}} route
+  <div class="component-tree-item-background flex items-center pr-2 rounded">
+    {{#if @item.hasChildren}}
+      <Ui::DisclosureTriangle
+        class="component-tree-item__expand self-stretch px-1 cursor-pointer"
+        title="Click to toggle (alt/option click to toggle with children)"
+        @toggle={{@item.toggleExpansion}}
+        @expanded={{@item.isExpanded}}
+      />
     {{/if}}
-  </code>
+
+    <code
+      class="component-tree-item__tag flex whitespace-no-wrap
+        {{if
+          @item.isComponent
+          (if
+            @item.isCurlyInvocation
+            "component-tree-item-classic__bracket"
+            (if
+              @item.hasChildren
+              "component-tree-item__bracket"
+              "component-tree-item__bracket component-tree-item__bracket--self-closing"
+            )
+          )
+        }}"
+    >
+      {{#if @item.isComponent}}
+        {{#if @item.args.positional}}
+          <span class="component-name">
+            {{@item.name}}
+          </span>
+
+          {{#each @item.args.positional as |value|}}
+            <div class="arg-token flex ml-2">
+              <span class="value-token">
+                {{component-argument value}}
+              </span>
+            </div>
+          {{/each}}
+
+          {{#each-in @item.args.named as |name value|}}
+            <div class="arg-token flex ml-2">
+              <span class="key-token">
+                {{name}}
+              </span>
+              =
+              <span class="value-token">
+                {{component-argument value}}
+              </span>
+            </div>
+          {{/each-in}}
+        {{else}}
+          <span class="component-name">
+            {{classify @item.name}}
+          </span>
+
+          {{#each-in @item.args.named as |name value|}}
+            <div class="arg-token flex ml-2">
+              <span class="key-token">
+                @{{name}}
+              </span>
+              ={{#if (is-string value)}}"{{else}}<span class="bracket-token">\{{</span>{{/if}}
+              <span class="value-token">
+                {{component-argument value}}
+              </span>
+              {{#if (is-string value)}}"{{else}}<span class="bracket-token">}}</span>{{/if}}
+            </div>
+          {{/each-in}}
+        {{/if}}
+      {{else if @item.isOutlet}}
+        \{{outlet "{{@item.name}}"}}
+      {{else if @item.isEngine}}
+        \{{mount "{{@item.name}}"}}
+      {{else if @item.isRouteTemplate}}
+        {{@item.name}} route
+      {{/if}}
+    </code>
+  </div>
 
   {{#if @item.hasBounds}}
-    <button
-      class="component-tree-item__action js-scroll-into-view"
-      title="Scroll into view"
-      {{on "click" @item.scrollIntoView}}
-    >
-      {{svg-jar "eye" width="20px" height="20px"}}
-    </button>
+    <div class="component-tree-item__actions sticky flex items-center pr-1 whitespace-no-wrap">
+      <button
+        class="component-tree-item__action inline-flex items-center h-full ml-2 p-0 border-0 cursor-pointer bg-transparent z-10"
+        title="Scroll into view"
+        data-test="scroll-into-view"
+        {{on "click" @item.scrollIntoView}}
+      >
+        {{svg-jar "eye" width="20px" height="20px"}}
+      </button>
 
-    <button
-      class="component-tree-item__action js-view-dom-element"
-      title="View in Elements panel"
-      {{on "click" @item.inspectElement}}
-    >
-      {{svg-jar "code-line" width="20px" height="20px"}}
-    </button>
+      <button
+        class="component-tree-item__action inline-flex items-center h-full ml-2 p-0 border-0 cursor-pointer bg-transparent z-10"
+        title="View in Elements panel"
+        data-test="view-dom-element"
+        {{on "click" @item.inspectElement}}
+      >
+        {{svg-jar "code-line" width="20px" height="20px"}}
+      </button>
+    </div>
   {{/if}}
 </div>

--- a/app/templates/components/component-tree-item.hbs
+++ b/app/templates/components/component-tree-item.hbs
@@ -90,7 +90,7 @@
   {{#if @item.hasBounds}}
     <div class="component-tree-item__actions sticky flex items-center pr-1 whitespace-no-wrap">
       <button
-        class="component-tree-item__action inline-flex items-center h-full ml-2 p-0 border-0 cursor-pointer bg-transparent z-10"
+        class="component-tree-item__action inline-flex items-center h-full p-0 border-0 cursor-pointer bg-transparent z-10"
         title="Scroll into view"
         data-test="scroll-into-view"
         {{on "click" @item.scrollIntoView}}

--- a/tests/acceptance/component-tree-test.js
+++ b/tests/acceptance/component-tree-test.js
@@ -246,7 +246,7 @@ module('Component Tab', function (hooks) {
       return false;
     });
 
-    await click('.js-scroll-into-view');
+    await click('[data-test="scroll-into-view"]');
   });
 
   test('View DOM element in Elements panel', async function (assert) {
@@ -257,7 +257,7 @@ module('Component Tab', function (hooks) {
       return false;
     });
 
-    await click('.js-view-dom-element');
+    await click('[data-test="view-dom-element"]');
   });
 
   test('Inspects the component in the object inspector on click and shows tooltip', async function (assert) {


### PR DESCRIPTION
This PR addresses two issues:

1. Clipping of a component background color that extends past the list bounds
    - This is addressed by adding a child element that has the same background color as the item
1. Component actions being hidden when the component extends past the list bounds
    - This is addressed by using `position: sticky` on the actions to pin them to the right side.

![2020-01-09 12 53 50](https://user-images.githubusercontent.com/3692/72104011-467e4e80-32df-11ea-9de4-7dd8be60af6b.gif)

---

ℹ️ All additions to `app/styles/utils.scss ` are based off of Tailwind.