### PR TITLE
only boot inspector on HTML pages

### DIFF
--- a/skeletons/web-extension/boot.js
+++ b/skeletons/web-extension/boot.js
@@ -1,16 +1,18 @@
 // This script runs at document_start, avoid adding more stuff here!
 
 // TODO: make this conditional, only do it when requested.
+// only inject boot script when on an HTML page
+if (document.contentType === 'text/html') {
+  let id = `ember-inspector-boot-${(Math.random() * 100000000).toFixed(0)}`;
 
-let id = `ember-inspector-boot-${(Math.random() * 100000000).toFixed(0)}`;
+  let script = document.createElement('script');
 
-let script = document.createElement('script');
+  script.setAttribute('id', id);
 
-script.setAttribute('id', id);
-
-script.appendChild(document.createTextNode(`
+  script.appendChild(document.createTextNode(`
   window.EmberENV = { _DEBUG_RENDER_TREE: true };
   document.getElementById(${JSON.stringify(id)}).remove();
 `));
 
-document.documentElement.appendChild(script);
+  document.documentElement.appendChild(script);
+}


### PR DESCRIPTION
Fix #1136.
I chose to whitelist the [HTML mime
type](https://www.iana.org/assignments/media-types/media-types.xhtml#text) only since it is simpler.
Per Godfrey's comment, we could declare [matching in the manifest](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns) but it does so by URL or protocol. Because of that I think checking the mime type in the document is simpler and more readable.
