### PR TITLE
Base font size and utility classes

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,23 +1,3 @@
-/**
- APP
- ===
- The layout of the entire
- application.
-*/
-
-.app {
-  bottom: 0;
-  display: flex;
-  flex: auto;
-  flex-direction: column;
-  font-size: 12px;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
-  z-index: 0;
-}
-
 @import "base";
 @import "colors";
 @import "utils";

--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -17,16 +17,12 @@
   --unit12: calc(var(--unit1) * 12);
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-size: 12px;
-  font-weight: normal;
-  margin: 0;
-  padding: 0;
+html {
+  font-size: 62.5%;
+}
+
+body {
+  font-size: 1.2rem;
 }
 
 html,
@@ -43,6 +39,18 @@ input {
 body,
 div,
 nav {
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: 1.2rem;
+  font-weight: normal;
   margin: 0;
   padding: 0;
 }

--- a/app/styles/component_tree.scss
+++ b/app/styles/component_tree.scss
@@ -1,6 +1,6 @@
 .component-tree-item {
   color: var(--base12);
-  font-size: 12px;
+  font-size: 1.2rem;
   min-height: 22px;
 
   &__actions {

--- a/app/styles/deprecations.scss
+++ b/app/styles/deprecations.scss
@@ -1,6 +1,6 @@
 .deprecation-item {
   border-bottom: 1px solid var(--base01);
-  font-size: 14px;
+  font-size: 1.4rem;
 
   .send-to-console {
     font-size: inherit;

--- a/app/styles/dropdown.scss
+++ b/app/styles/dropdown.scss
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   color: var(--base13);
   display: block;
-  font-size: 12px;
+  font-size: 1.2rem;
   height: 100%;
   margin: 0;
   padding: 0 16px 0 5px;

--- a/app/styles/ember-table.scss
+++ b/app/styles/ember-table.scss
@@ -69,7 +69,7 @@ $red: #ff2717;
   .et-sort-indicator:before {
     content: '\25be';
     display: inline-block;
-    font-size: 1rem;
+    font-size: 1.4rem;
     line-height: 1;
     transform: rotate(0);
   }

--- a/app/styles/mixin.scss
+++ b/app/styles/mixin.scss
@@ -55,7 +55,7 @@ $mixin-left-padding: 22px;
 .mixin__properties {
   border-bottom: 1px solid var(--base03);
   font-family: var(--font-monospace);
-  font-size: 12px;
+  font-size: 1.2rem;
   list-style-type: none;
   margin: 0;
   padding: 3px 0 5px;
@@ -162,7 +162,7 @@ $mixin-left-padding: 22px;
   border: 1px solid var(--base09);
   color: var(--base14);
   flex: 1;
-  font-size: 12px;
+  font-size: 1.2rem;
   outline: none;
 }
 

--- a/app/styles/object_inspector.scss
+++ b/app/styles/object_inspector.scss
@@ -53,7 +53,7 @@
 
 .mixin__property-dependency-item {
   color: var(--base12);
-  font-size: 11px;
+  font-size: 1.1rem;
   margin-bottom: 2px;
   margin-left: 55px;
   position: relative;
@@ -94,7 +94,7 @@
   color: var(--white);
   display: inline-block;
   font-family: var(--font-monospace);
-  font-size: 13px;
+  font-size: 1.3rem;
   height: 17px;
   line-height: 17px;
   text-align: center;

--- a/app/styles/utils.scss
+++ b/app/styles/utils.scss
@@ -15,6 +15,13 @@ $units: 0, 1, 2, 3, 4, 5, 6;
 .bottom-0 { bottom: 0; }
 .left-0 { left: 0; }
 
+.inset-0 {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+}
+
 .overflow-auto { overflow: auto; }
 .overflow-hidden { overflow: hidden; }
 
@@ -110,6 +117,7 @@ $units: 0, 1, 2, 3, 4, 5, 6;
 .cursor-pointer { cursor: pointer; }
 .cursor-col-resize { cursor: col-resize; }
 
+.z-0 { z-index: 0; }
 .z-10 { z-index: 10; }
 
 .appearance-none {

--- a/app/styles/utils.scss
+++ b/app/styles/utils.scss
@@ -145,6 +145,13 @@ $units: 0, 1, 2, 3, 4, 5, 6;
 .text-base11 { color: var(--base11); }
 .text-base13 { color: var(--base13); }
 
-.text-12 { font-size: 1.2rem; }
-.text-13 { font-size: 1.3rem; }
-.text-18 { font-size: 1.8rem; }
+.text-xs { font-size: 1rem; }
+.text-sm { font-size: 1.1rem; }
+.text-base { font-size: 1.2rem; }
+.text-md { font-size: 1.3rem; }
+.text-lg { font-size: 1.4rem; }
+.text-xl { font-size: 1.5rem; }
+.text-2xl { font-size: 1.6rem; }
+.text-3xl { font-size: 1.7rem; }
+.text-4xl { font-size: 1.8rem; }
+.text-5xl { font-size: 1.9rem; }

--- a/app/styles/utils.scss
+++ b/app/styles/utils.scss
@@ -145,6 +145,6 @@ $units: 0, 1, 2, 3, 4, 5, 6;
 .text-base11 { color: var(--base11); }
 .text-base13 { color: var(--base13); }
 
-.text-12 { font-size: 12px; }
-.text-13 { font-size: 13px; }
-.text-18 { font-size: 18px; }
+.text-12 { font-size: 1.2rem; }
+.text-13 { font-size: 1.3rem; }
+.text-18 { font-size: 1.8rem; }

--- a/app/styles/whats-new.scss
+++ b/app/styles/whats-new.scss
@@ -2,14 +2,14 @@
   padding: 30px 40px;
 
   h1 {
-    font-size: 34px;
+    font-size: 3.4rem;
     font-weight: 700;
     margin-bottom: 0.25rem;
   }
 
   h2 {
     border-bottom: 1px solid var(--base02);
-    font-size: 21px;
+    font-size: 2.1rem;
     margin-bottom: 1rem;
     padding-bottom: 1rem;
   }
@@ -21,7 +21,7 @@
 
   li,
   p {
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: 120%;
     margin-bottom: 0.5rem;
   }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,5 +1,5 @@
 <div
-  class="ember-view app {{if this.active "" "inactive"}}"
+  class="ember-view app absolute inset-0 z-0 {{if this.active "" "inactive"}}"
   tabindex="1"
   {{on "focusin" (fn this.setActive true)}}
   {{on "focusout" (fn this.setActive false)}}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -98,6 +98,7 @@ module.exports = function(defaults) {
   app.import('node_modules/basiccontext/dist/themes/default.min.css');
   app.import('node_modules/basiccontext/dist/basicContext.min.js');
   app.import('node_modules/compare-versions/index.js');
+  app.import('node_modules/normalize.css/normalize.css');
 
   // Ember Debug
 

--- a/lib/ui/addon/components/empty-message.hbs
+++ b/lib/ui/addon/components/empty-message.hbs
@@ -1,4 +1,4 @@
-<div class="empty-message flex flex-col items-center justify-center h-full text-center text-base11 text-18" ...attributes>
+<div class="empty-message flex flex-col items-center justify-center h-full text-center text-base11 text-4xl" ...attributes>
   {{svg-jar "ember-icon-empty" width="129px" height="129px"}}
   <div class="empty-message__content pt-4 px-6">{{yield}}</div>
 </div>

--- a/lib/ui/addon/components/error-page.hbs
+++ b/lib/ui/addon/components/error-page.hbs
@@ -1,4 +1,4 @@
-<div class="error-page box-border overflow-auto absolute top-0 left-0 w-full h-full flex text-base13 text-13 bg-base02">
+<div class="error-page box-border overflow-auto absolute inset-0 flex text-base13 text-13 bg-base02">
   <div class="error-page__content box-border relative m-auto px-6 pb-6 rounded bg-base00">
     <div class="error-page__header overflow-hidden relative flex items-center font-bold text-18">
       <div class="flex-grow pt-6">

--- a/lib/ui/addon/components/error-page.hbs
+++ b/lib/ui/addon/components/error-page.hbs
@@ -1,6 +1,6 @@
-<div class="error-page box-border overflow-auto absolute inset-0 flex text-base13 text-13 bg-base02">
+<div class="error-page box-border overflow-auto absolute inset-0 flex text-base13 text-md bg-base02">
   <div class="error-page__content box-border relative m-auto px-6 pb-6 rounded bg-base00">
-    <div class="error-page__header overflow-hidden relative flex items-center font-bold text-18">
+    <div class="error-page__header overflow-hidden relative flex items-center font-bold text-4xl">
       <div class="flex-grow pt-6">
         {{@description}}
       </div>

--- a/lib/ui/addon/components/toolbar-search-field.hbs
+++ b/lib/ui/addon/components/toolbar-search-field.hbs
@@ -4,7 +4,7 @@
     @type="text"
     @value={{@value}}
     placeholder="Search"
-    class="box-border m-0 rounded pt-0 pr-4 pb-0 pl-1 text-12 leading-none outline-none bg-base00"
+    class="box-border m-0 rounded pt-0 pr-4 pb-0 pl-1 text-base leading-none outline-none bg-base00"
   />
 
   {{#if @value}}

--- a/lib/ui/addon/components/warning-message.hbs
+++ b/lib/ui/addon/components/warning-message.hbs
@@ -1,4 +1,4 @@
-<div class="warning flex flex-row items-center justify-start py-1 px-2 text-12 bg-spec00">
+<div class="warning flex flex-row items-center justify-start py-1 px-2 text-base bg-spec00">
   {{svg-jar "warning" width="18px" height="18px" class="inline-block flex-shrink-0 mr-1 fill-current"}}
 
   <p class="flex-grow m-0 p-0">

--- a/lib/ui/addon/styles/_list.scss
+++ b/lib/ui/addon/styles/_list.scss
@@ -1,7 +1,7 @@
 .list {
   background: var(--base00);
   box-sizing: border-box;
-  font-size: 11px;
+  font-size: 1.1rem;
   height: 100%;
   overflow: hidden;
   position: relative;

--- a/lib/ui/addon/styles/_nav.scss
+++ b/lib/ui/addon/styles/_nav.scss
@@ -1,7 +1,7 @@
 .nav__title {
   color: var(--base09);
   cursor: default;
-  font-size: 12px;
+  font-size: 1.2rem;
   height: 22px;
   line-height: 22px;
   margin: 2px 0 0;
@@ -57,7 +57,7 @@
 
 .nav__item-label {
   flex-grow: 1;
-  font-size: 13px;
+  font-size: 1.3rem;
 }
 
 .nav__item-icon {

--- a/lib/ui/addon/styles/_pill.scss
+++ b/lib/ui/addon/styles/_pill.scss
@@ -4,7 +4,7 @@
   cursor: inherit;
   display: inline-block;
   font-family: var(--font-monospace);
-  font-size: 12px;
+  font-size: 1.2rem;
   line-height: 12px;
   margin: 0 2px;
   padding: 2px 6px;
@@ -17,7 +17,7 @@
 }
 
 .pill--small {
-  font-size: 10px;
+  font-size: 1.0rem;
   padding: 2px 4px;
 }
 

--- a/lib/ui/addon/styles/toolbar/_radio.scss
+++ b/lib/ui/addon/styles/toolbar/_radio.scss
@@ -5,7 +5,7 @@
   color: var(--base14);
   cursor: default;
   display: inline-block;
-  font-size: 12px;
+  font-size: 1.2rem;
   line-height: 18px;
   margin-left: 2px;
   margin-right: 2px;

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "js-string-escape": "^1.0.0",
     "loader.js": "^4.7.0",
     "mkdirp": "^0.5.1",
+    "normalize.css": "8.0.1",
     "pretender": "^3.0.4",
     "qunit-dom": "^1.0.0",
     "rimraf": "^3.0.0",

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -145,7 +145,12 @@ function setupApp() {
     }
   }));
 
-  setTemplate.call(this, 'application', hbs`<div class="application">{{outlet}}</div>`);
+  /*
+    Setting line-height to normal because normalize.css sets the
+    html line-height to 1.15. This seems to cause a measurement
+    error with getBoundingClientRect
+  */
+  setTemplate.call(this, 'application', hbs`<div class="application" style="line-height: normal;">{{outlet}}</div>`);
   setTemplate.call(this, 'simple', hbs`Simple {{test-foo}} {{test-bar}}`);
   setTemplate.call(this, 'comments/index', hbs`{{#each this.comments as |comment|}}{{comment}}{{/each}}`);
   setTemplate.call(this, 'posts', hbs`Posts`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10820,6 +10820,11 @@ normalize-url@^4.1.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.5.0.tgz#453354087e6ca96957bd8f5baf753f5982142129"
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
+normalize.css@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/normalize.css/-/normalize.css-8.0.1.tgz#9b98a208738b9cc2634caacbc42d131c97487bf3"
+  integrity sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==
+
 now-and-later@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/now-and-later/-/now-and-later-2.0.1.tgz#8e579c8685764a7cc02cb680380e94f43ccb1f7c"


### PR DESCRIPTION
- Tailwind uses normalize.css, we should too
- Set html font-size to `62.5%` so `1rem == ~10px`; makes rem sizes easier to grok
- I'll start using the new font-size utility classes in another PR

I've done a lot of clicking around and I don't see any visible changes to the text.