### PR TITLE
[FEAT] Add inspect store button to data pane in Ember Inspector

### DIFF
--- a/app/controllers/model-types.js
+++ b/app/controllers/model-types.js
@@ -1,5 +1,5 @@
 import Controller from '@ember/controller';
-import { get, computed } from '@ember/object';
+import { action, get, computed } from '@ember/object';
 import { sort } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
 
@@ -48,9 +48,14 @@ export default Controller.extend({
         return true;
       }
     });
-  })
-});
+  }),
 
+  getStore: action(function() {
+    this.port.send('objectInspector:inspectByContainerLookup', {
+      name: 'service:store'
+    });
+  }),
+});
 /**
  * Returns whether or not a given key has been set in storage.
  * @param {*} storage

--- a/app/templates/model-types-toolbar.hbs
+++ b/app/templates/model-types-toolbar.hbs
@@ -26,4 +26,7 @@
       Order Models By Record Count
     </label>
   </div>
+  <button class="toolbar__radio js-filter" {{on "click" this.getStore}} data-test-inspect-store>
+    Inspect Store
+  </button>
 </div>

--- a/tests/acceptance/data-test.js
+++ b/tests/acceptance/data-test.js
@@ -219,6 +219,22 @@ module('Data Tab', function(outer) {
 
       assert.dom('.js-model-type').exists({ count: 2 });
     });
+
+    test('Can inspect store in data pane', async function(assert) {
+      respondWith('data:getModelTypes', {
+        type: 'data:modelTypesAdded',
+        modelTypes: getModelTypes()
+      });
+
+      await visit('/data/model-types');
+
+      respondWith('objectInspector:inspectByContainerLookup', ({ name }) => {
+        assert.equal(name, 'service:store');
+        return false;
+      });
+
+      await click('[data-test-inspect-store]');
+    });
   });
 
   module('Records', function(inner) {


### PR DESCRIPTION
## Description
Add a button in data pane to enable user to inspect store and send it to console.

Would love some guidance as to what a good test would be since a lot of the end-to-end functionality seems to be stubbed out in other tests.

## Screenshots
![Data_Pane_Store](https://user-images.githubusercontent.com/10149117/77494101-1b959800-6e02-11ea-94ea-048b283bfb94.gif)
