### PR TITLE
No observers lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,6 @@ module.exports = {
 
     // Temporarily turn these off
     'ember/avoid-leaking-state-in-ember-objects': 'off',
-    'ember/no-observers': 'off',
 
     // Best practice
     'no-duplicate-imports': 'error'

--- a/app/controllers/promise-tree.js
+++ b/app/controllers/promise-tree.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-observers
 import { action, observer } from '@ember/object';
 import Controller from '@ember/controller';
 import { isEmpty } from '@ember/utils';
@@ -64,6 +65,7 @@ export default Controller.extend({
   searchValue: null,
   effectiveSearch: null,
 
+  // eslint-disable-next-line ember/no-observers
   searchChanged: observer('searchValue', function() {
     debounce(this, this.notifyChange, 500);
   }),

--- a/app/controllers/records.js
+++ b/app/controllers/records.js
@@ -1,4 +1,5 @@
 import { isEmpty } from '@ember/utils';
+// eslint-disable-next-line ember/no-observers
 import { action, observer, computed, get } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
 import escapeRegExp from "ember-inspector/utils/escape-reg-exp";
@@ -12,6 +13,7 @@ export default Controller.extend({
 
   filterValue: null,
 
+  // eslint-disable-next-line ember/no-observers
   modelChanged: observer('model', function() {
     this.set('searchValue', '');
   }),

--- a/app/models/promise.js
+++ b/app/models/promise.js
@@ -1,6 +1,7 @@
 import { assign } from '@ember/polyfills';
 import { once } from '@ember/runloop';
 import { typeOf, isEmpty } from '@ember/utils';
+// eslint-disable-next-line ember/no-observers
 import EmberObject, { computed, observer } from '@ember/object';
 import { not, equal, or } from '@ember/object/computed';
 import escapeRegExp from 'ember-inspector/utils/escape-reg-exp';
@@ -73,6 +74,7 @@ export default EmberObject.extend({
 
   // Need this observer because CP dependent keys do not support nested arrays
   // TODO: This can be so much better
+  // eslint-disable-next-line ember/no-observers
   stateChanged: observer('pendingBranch', 'fulfilledBranch', 'rejectedBranch', function() {
     if (!this.parent) {
       return;
@@ -88,6 +90,7 @@ export default EmberObject.extend({
     }
   }),
 
+  // eslint-disable-next-line ember/no-observers
   updateParentLabel: observer('label', 'parent', function() {
     this.addBranchLabel(this.label, true);
   }),
@@ -125,6 +128,7 @@ export default EmberObject.extend({
 
   isManuallyExpanded: undefined,
 
+  // eslint-disable-next-line ember/no-observers
   stateOrParentChanged: observer('isPending', 'isFulfilled', 'isRejected', 'parent', function() {
     let parent = this.parent;
     if (parent) {

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -42,6 +42,7 @@ export default EmberObject.extend(PortMixin, {
     }
   },
 
+  // eslint-disable-next-line ember/no-observers
   sendCurrentRoute: observer('currentURL', function() {
     const {
       currentPath: name,


### PR DESCRIPTION
This MR aims to enable the lint rule `no-observer` back, in order to prevent anyone to use observer in the future.

I would prefer to have this rule enabled by default and disable linter when needed, so anyone is aware that observer usage is avoided when using them WDYT ?