### PR TITLE
No duplicate imports lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,7 +31,10 @@ module.exports = {
     // Temporarily turn these off
     'ember/avoid-leaking-state-in-ember-objects': 'off',
     'ember/no-observers': 'off',
-    'ember/use-brace-expansion': 'off'
+    'ember/use-brace-expansion': 'off',
+
+    // Best practice
+    'no-duplicate-imports': 'error',
   },
   overrides: [
     // node files

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -11,10 +11,9 @@ import EmberComponent from '@ember/component';
 import EmberRoute from '@ember/routing/route';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
-import { module, test } from 'qunit';
+import QUnit, { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import require from 'require';
-import QUnit from 'qunit';
 import { destroyEIApp, setupEIApp } from '../helpers/setup-destroy-ei-app';
 
 const EmberDebug = require('ember-debug/main').default;


### PR DESCRIPTION
Enable the no-duplicate-imports rule.
https://eslint.org/docs/rules/no-duplicate-imports