### PR TITLE
Sort container instances alphabetically

### DIFF
--- a/app/controllers/container-type.js
+++ b/app/controllers/container-type.js
@@ -1,5 +1,5 @@
-import { action, get, computed } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
+import { action, computed, get, set } from '@ember/object';
 import debounceComputed from 'ember-inspector/computed/debounce';
 import searchMatch from 'ember-inspector/utils/search-match';
 
@@ -10,17 +10,9 @@ export default Controller.extend({
 
   search: null,
 
-  filtered: computed('model.@each.name', 'search', function() {
+  rows: computed('model.@each.name', 'search', function() {
     return this.model
-      .filter((item) => searchMatch(get(item, 'name'), this.search));
-  }),
-
-  rows: computed('filtered.[]', function() {
-    return this.filtered.map(function(item) {
-      return {
-        name: item
-      };
-    });
+      .filter((instance) => searchMatch(get(instance, 'name'), this.search));
   }),
 
   init() {
@@ -31,7 +23,13 @@ export default Controller.extend({
       name: 'Name'
     }];
 
-    this.sortProperties = ['name'];
+    // By default, sort alphabetically
+    this.sorts = [
+      {
+        valuePath: 'name',
+        isAscending: true
+      }
+    ]
   },
 
   /**
@@ -39,18 +37,38 @@ export default Controller.extend({
    * Called whenever an item in the list is clicked.
    *
    * @method inspectInstance
-   * @param {Object} obj
+   * @param {Object} instance
    */
-  inspectInstance: action(function(obj) {
-    if (!get(obj, 'inspectable')) {
+  inspectInstance: action(function(instance) {
+    if (!get(instance, 'inspectable')) {
       return;
     }
     this.port.send('objectInspector:inspectByContainerLookup', {
-      name: get(obj, 'fullName')
+      name: get(instance, 'fullName')
     });
   }),
 
   sendContainerToConsole: action(function() {
     this.port.send('objectInspector:sendContainerToConsole');
   }),
+
+  @action
+  updateSorts(sorts) {
+    let hasExistingSort = this.sorts && this.sorts.length;
+    let isDefaultSort = !sorts.length;
+
+    if (hasExistingSort && isDefaultSort) {
+      // override empty sorts with reversed previous sort
+      let newSorts = [
+        {
+          valuePath: this.sorts[0].valuePath,
+          isAscending: !this.sorts[0].isAscending,
+        },
+      ];
+      set(this, 'sorts', newSorts);
+      return;
+    }
+
+    set(this, 'sorts', sorts);
+  }
 });

--- a/app/templates/container-type.hbs
+++ b/app/templates/container-type.hbs
@@ -1,6 +1,8 @@
 <EmberTable as |t|>
   <t.head
     @columns={{columns}}
+    @sorts={{sorts}}
+    @onUpdateSorts={{this.updateSorts}}
     @enableReorder={{false}}
   />
   <t.body
@@ -8,19 +10,25 @@
   as |b|
   >
     <b.row
-      class={{concat "js-container-instance-list-item" (if (mod b.rowMeta.index 2) " striped")}}
+      class={{if (mod b.rowMeta.index 2) "striped"}}
+      data-test-instance-row
     as |r|
     >
-      <r.cell as |value|>
-        {{#if value.inspectable}}
+      <r.cell as |name column instance|>
+        {{#if instance.inspectable}}
           <div
-            class="is-link js-instance-name"
-            {{on "click" (fn this.inspectInstance value)}}
+            class="is-link"
+            data-test-instance={{name}}
+            {{on "click" (fn this.inspectInstance instance)}}
           >
-            {{value.name}}
+            {{instance.name}}
           </div>
         {{else}}
-          <span class="js-instance-name">{{value.name}}</span>
+          <span
+            data-test-instance={{name}}
+          >
+            {{instance.name}}
+          </span>
         {{/if}}
       </r.cell>
     </b.row>

--- a/app/templates/container-type.hbs
+++ b/app/templates/container-type.hbs
@@ -1,12 +1,12 @@
 <EmberTable as |t|>
   <t.head
-    @columns={{columns}}
-    @sorts={{sorts}}
+    @columns={{this.columns}}
+    @sorts={{this.sorts}}
     @onUpdateSorts={{this.updateSorts}}
     @enableReorder={{false}}
   />
   <t.body
-    @rows={{rows}}
+    @rows={{this.rows}}
   as |b|
   >
     <b.row
@@ -24,9 +24,7 @@
             {{instance.name}}
           </div>
         {{else}}
-          <span
-            data-test-instance={{name}}
-          >
+          <span data-test-instance={{name}}>
             {{instance.name}}
           </span>
         {{/if}}


### PR DESCRIPTION
## Description

This commit uses `<EmberTable>`'s sorting capabilities to sort container
instances alphabetically be default. A sort indicator is shown in the
column header, and the header can be clicked to reverse the sort.

This PR adds test coverage for sorting and converts the template and
tests to use `data-test-` selectors instead of `js-` css classes.

## See It In Action

![2020-05-09 at 1 37 PM](https://user-images.githubusercontent.com/353/81465159-6d4f8180-91fa-11ea-83dc-e78e2648af73.gif)
