### PR TITLE
Ensure renderDebug is properly unregistered.

### DIFF
--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -29,7 +29,7 @@ export default EmberObject.extend(PortMixin, {
     };
 
     this.profileManager.offProfilesAdded(this, this.sendAdded);
-    this.profileManager.offProfilesAdded(this, this._updateRenderPerformanceAndComponentTree);
+    this.profileManager.offProfilesAdded(this, this._updateComponentTree);
   },
 
   sendAdded(profiles) {

--- a/tests/ember_debug/container-debug-test.js
+++ b/tests/ember_debug/container-debug-test.js
@@ -2,17 +2,15 @@ import { settled, visit } from '@ember/test-helpers';
 import { A as emberA } from '@ember/array';
 
 import { module, test } from 'qunit';
-import require from 'require';
 
+import EmberDebug from 'ember-debug/main';
 import { destroyEIApp, setupEIApp } from '../helpers/setup-destroy-ei-app';
 
-let EmberDebug;
 let port, name, message;
 let App;
 
 module('Ember Debug - Container', function(hooks) {
   hooks.beforeEach(async function() {
-    EmberDebug = require('ember-debug/main').default;
     EmberDebug.Port = EmberDebug.Port.extend({
       init() {},
       send(n, m) {

--- a/tests/ember_debug/deprecation-debug-test.js
+++ b/tests/ember_debug/deprecation-debug-test.js
@@ -4,10 +4,8 @@ import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
-import require from 'require';
 import { setupEIApp, destroyEIApp } from '../helpers/setup-destroy-ei-app';
-
-const EmberDebug = require('ember-debug/main').default;
+import EmberDebug from 'ember-debug/main';
 
 let port;
 let App;

--- a/tests/ember_debug/ember-debug-test.js
+++ b/tests/ember_debug/ember-debug-test.js
@@ -1,18 +1,16 @@
 import EmberObject from '@ember/object';
 let name;
 import { module, test } from 'qunit';
-import require from 'require';
 import { setupEIApp, destroyEIApp } from '../helpers/setup-destroy-ei-app';
+import EmberDebug from 'ember-debug/main';
 import { settled } from '@ember/test-helpers';
 
-let EmberDebug;
 let port, adapter;
 let App;
 let EmberInspector;
 
 module("Ember Debug", function(hooks) {
   hooks.beforeEach(async function() {
-    EmberDebug = require('ember-debug/main').default;
     EmberDebug.Port = EmberDebug.Port.extend({
       init() {},
       send(n/*, m*/) {

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -17,6 +17,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import require from 'require';
 import { destroyEIApp, setupEIApp } from '../helpers/setup-destroy-ei-app';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
+import EmberDebug from 'ember-debug/main';
+import { compareVersion } from 'ember-debug/utils/version';
 
 const GlimmerComponent = (function() {
   try {
@@ -26,7 +28,6 @@ const GlimmerComponent = (function() {
   }
 })();
 
-let EmberDebug;
 let port;
 let App;
 let objectInspector;
@@ -80,7 +81,6 @@ async function inspectObject(object) {
 module('Ember Debug - Object Inspector', function(hooks) {
   // eslint-disable-next-line object-shorthand
   hooks.beforeEach(async function() {
-    EmberDebug = require('ember-debug/main').default;
     EmberDebug.Port = EmberDebug.Port.extend({
       init() { },
       send() { }
@@ -164,7 +164,6 @@ module('Ember Debug - Object Inspector', function(hooks) {
   });
 
   test('An ES6 Class is correctly transformed into an inspection hash', async function(assert) {
-    const compareVersion = require('ember-debug/utils/version').compareVersion;
     if (compareVersion(VERSION, '3.9.0') === -1) {
       assert.expect(0);
       return;

--- a/tests/ember_debug/promise-debug-test.js
+++ b/tests/ember_debug/promise-debug-test.js
@@ -2,11 +2,9 @@ import { run, later } from '@ember/runloop';
 import { A as emberA } from '@ember/array';
 import RSVP from 'rsvp';
 import { module, skip, test } from 'qunit';
-import require from 'require';
 import { setupEIApp, destroyEIApp } from '../helpers/setup-destroy-ei-app';
 import { settled } from '@ember/test-helpers';
-
-const EmberDebug = require('ember-debug/main').default;
+import EmberDebug from 'ember-debug/main';
 
 let port, name, message;
 let App;

--- a/tests/ember_debug/render-debug-test.js
+++ b/tests/ember_debug/render-debug-test.js
@@ -2,10 +2,9 @@ import { settled, visit } from '@ember/test-helpers';
 import Ember from 'ember';
 import { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import require from 'require';
 import { setupEIApp, destroyEIApp } from '../helpers/setup-destroy-ei-app';
+import EmberDebug from 'ember-debug/main';
 
-const EmberDebug = require('ember-debug/main').default;
 let port, App;
 
 module('Ember Debug - Render Debug', function(hooks) {

--- a/tests/ember_debug/route-debug-test.js
+++ b/tests/ember_debug/route-debug-test.js
@@ -3,10 +3,9 @@ import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import Route from '@ember/routing/route';
 import { module, test } from 'qunit';
-import require from 'require';
 import { destroyEIApp, setupEIApp } from '../helpers/setup-destroy-ei-app';
+import EmberDebug from 'ember-debug/main';
 
-const EmberDebug = require('ember-debug/main').default;
 let port;
 let App;
 

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -13,10 +13,9 @@ import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
 import QUnit, { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
-import require from 'require';
 import { destroyEIApp, setupEIApp } from '../helpers/setup-destroy-ei-app';
+import EmberDebug from 'ember-debug/main';
 
-const EmberDebug = require('ember-debug/main').default;
 let port;
 let App;
 

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,6 +3,7 @@ import config from 'ember-inspector/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 import TestAdapter from './test-adapter';
+import 'ember-debug/main';
 
 Application.initializer({
   name: `00-override-adapter`,


### PR DESCRIPTION
Adds a side effecting import to `tests/test-helper.js` to ensure that `ember-debug/main` can be imported/required eagerly in the test suite (and is not broken by a cycle).

Updates all lazy requires for `ember-debug` modules to ES module import statements.
