### PR TITLE
Reset internal test helper state for EmberDebug tests.

### DIFF
--- a/tests/helpers/setup-destroy-ei-app.js
+++ b/tests/helpers/setup-destroy-ei-app.js
@@ -1,6 +1,7 @@
 import Application from '@ember/application';
 import EmberRouter from '@ember/routing/router';
 import {
+  getApplication,
   setApplication,
   setupApplicationContext,
   setupContext,
@@ -9,7 +10,6 @@ import {
 } from '@ember/test-helpers';
 import { assert } from '@ember/debug';
 import { run } from '@ember/runloop';
-
 
 export async function setupEIApp(EmberDebug, routes) {
   assert('setupEIApp requires `EmberDebug` to be passed.', EmberDebug !== undefined);
@@ -28,6 +28,7 @@ export async function setupEIApp(EmberDebug, routes) {
   });
   App.register('router:main', Router);
 
+  this._originalApp = getApplication();
   await setApplication(App);
   await setupContext(this);
   await setupApplicationContext(this);
@@ -50,5 +51,8 @@ export async function destroyEIApp(EmberDebug, App) {
   EmberDebug.destroyContainer();
   await teardownApplicationContext(this);
   await teardownContext(this);
-  return run(App, 'destroy');
+
+  run(App, 'destroy');
+
+  setApplication(this._originalApp);
 }

--- a/tests/integration/components/basic-test.js
+++ b/tests/integration/components/basic-test.js
@@ -1,0 +1,14 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | basic', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('generally works', async function(assert) {
+    await render(hbs`Hello world!`);
+
+    assert.equal(this.element.textContent.trim(), 'Hello world!');
+  });
+});


### PR DESCRIPTION
Prior to this change we could not run any tests that leveraged the `@ember/test-helpers` setup methods that ran _after_ the files in `tests/ember_debug/**/*-test.js`. This was because the `setupEIApp`/`destroyEIApp` helper functions would call `setApplication` (to get a pristine state for their own tests), but would not clean up after themselves (calling `setApplication` with the original value).

This change is a minimal patch to fix the fundamental issue (and adding a single integration test to the mix to ensure it doesn't regress), but a larger refactor is in order to simplify these setupEI/destroyEI test helpers.

Related to #1201 