### PR TITLE
Use computed macro

### DIFF
--- a/app/components/object-inspector.js
+++ b/app/components/object-inspector.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { action, computed, get } from '@ember/object';
+import { gt } from '@ember/object/computed';
 
 export default Component.extend({
   tagName: '',
@@ -20,9 +21,7 @@ export default Component.extend({
     return `.${nested.mapBy('property').join('.')}`;
   }),
 
-  isNested: computed('model.[]', function () {
-    return this.get('model.length') > 1;
-  }),
+  isNested: gt('model.length', 1),
 
   setPropDisplay: action(function (type) {
     // The custom filter is only working for the "all" table yet

--- a/ember_debug/container-debug.js
+++ b/ember_debug/container-debug.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
+import { reads } from '@ember/object/computed';
+
 const Ember = window.Ember;
 const { Object: EmberObject, computed } = Ember;
 const { readOnly } = computed;
@@ -9,10 +11,8 @@ export default EmberObject.extend(PortMixin, {
 
   objectInspector: readOnly('namespace.objectInspector'),
 
-  container: computed('namespace.owner', function () {
-    // should update this to use real owner API
-    return this.get('namespace.owner.__container__');
-  }),
+  // should update this to use real owner API
+  container: reads('namespace.owner.__container__'),
 
   portNamespace: 'container',
 

--- a/ember_debug/models/promise.js
+++ b/ember_debug/models/promise.js
@@ -1,4 +1,5 @@
 import { typeOf } from '../utils/type-check';
+import { equal, or } from '@ember/object/computed';
 
 const Ember = window.Ember;
 const { Object: EmberObject, computed, A } = Ember;
@@ -38,15 +39,9 @@ export default EmberObject.extend({
     return parent.get('level') + 1;
   }),
 
-  isSettled: computed('state', function () {
-    return this.get('isFulfilled') || this.get('isRejected');
-  }),
+  isSettled: or('isFulfilled', 'isRejected'),
 
-  isFulfilled: computed('state', function () {
-    return this.get('state') === 'fulfilled';
-  }),
+  isFulfilled: equal('state', 'fulfilled'),
 
-  isRejected: computed('state', function () {
-    return this.get('state') === 'rejected';
-  }),
+  isRejected: equal('state', 'rejected'),
 });


### PR DESCRIPTION
## Description

This MR aims to fix the future linter error while [upgrading eslint-plugin-ember from 7.13.0 to 8.5.1](https://github.com/emberjs/ember-inspector/pull/1211)

See related issue: https://github.com/emberjs/ember-inspector/issues/1197

And the rule documentation: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-computed-macros.md