### PR TITLE
Fix require-computed-property-dependencies lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
 
     // Best practice
     'no-duplicate-imports': 'error',
+    'ember/require-computed-property-dependencies': 'error',
   },
   overrides: [
     // node files

--- a/app/components/object-inspector/properties-all.js
+++ b/app/components/object-inspector/properties-all.js
@@ -18,7 +18,7 @@ export default PropertiesBase.extend({
     });
   }),
 
-  flatPropertyList: computed('model', 'customFilter', function () {
+  flatPropertyList: computed('model.mixins', 'customFilter', function () {
     const props = this.get('model.mixins').map(function (mixin) {
       return mixin.properties.filter(function (p) {
         let shoulApplyCustomFilter = this.customFilter

--- a/app/components/object-inspector/property.js
+++ b/app/components/object-inspector/property.js
@@ -48,9 +48,10 @@ export default Component.extend({
   showDependentKeys: and('isDepsExpanded', 'hasDependentKeys'),
 
   canCalculate: computed(
-    'model',
+    'model.{isExpensive,isGetter}',
     'isCalculated',
     'isComputedProperty',
+    'isOverridden',
     function () {
       if (this.get('isOverridden')) return false;
       if (
@@ -67,7 +68,7 @@ export default Component.extend({
   iconInfo: computed(
     'isService',
     'isFunction',
-    'model.{inspect.value,isTracked,isProperty,isGetter}',
+    'model.{inspect.value,isComputed,isTracked,isProperty,isGetter}',
     function () {
       if (this.get('isService')) {
         return { type: 'service', title: 'Service' };

--- a/app/components/object-inspector/sort-properties.js
+++ b/app/components/object-inspector/sort-properties.js
@@ -17,7 +17,7 @@ export default Component.extend({
    * @property sortedProperties
    * @type {Array<Object>}
    */
-  sortedProperties: computed('sorted.length', function () {
+  sortedProperties: computed('isArray', 'sorted.length', function () {
     // limit arrays
     if (this.get('isArray') && this.get('sorted.length') > 100) {
       const indicator = {

--- a/app/components/promise-item.js
+++ b/app/components/promise-item.js
@@ -18,7 +18,7 @@ export default Component.extend({
 
   isError: equal('model.reason.type', 'type-error'),
 
-  style: computed('model.state', function () {
+  style: computed('model.{isFulfilled,isRejected}', function () {
     let color = '';
     if (this.get('model.isFulfilled')) {
       color = 'green';
@@ -30,30 +30,35 @@ export default Component.extend({
     return htmlSafe(`background-color: ${COLOR_MAP[color]}; color: white;`);
   }),
 
-  nodeStyle: computed('model.state', 'filter', 'effectiveSearch', function () {
-    let relevant;
-    switch (this.filter) {
-      case 'pending':
-        relevant = this.get('model.isPending');
-        break;
-      case 'rejected':
-        relevant = this.get('model.isRejected');
-        break;
-      case 'fulfilled':
-        relevant = this.get('model.isFulfilled');
-        break;
-      default:
-        relevant = true;
+  nodeStyle: computed(
+    'model.{isFulfilled,isPending,isRejected}',
+    'filter',
+    'effectiveSearch',
+    function () {
+      let relevant;
+      switch (this.filter) {
+        case 'pending':
+          relevant = this.get('model.isPending');
+          break;
+        case 'rejected':
+          relevant = this.get('model.isRejected');
+          break;
+        case 'fulfilled':
+          relevant = this.get('model.isFulfilled');
+          break;
+        default:
+          relevant = true;
+      }
+      if (relevant && !isEmpty(this.effectiveSearch)) {
+        relevant = this.model.matchesExactly(this.effectiveSearch);
+      }
+      if (!relevant) {
+        return 'opacity: 0.3;';
+      } else {
+        return '';
+      }
     }
-    if (relevant && !isEmpty(this.effectiveSearch)) {
-      relevant = this.model.matchesExactly(this.effectiveSearch);
-    }
-    if (!relevant) {
-      return 'opacity: 0.3;';
-    } else {
-      return '';
-    }
-  }),
+  ),
 
   labelStyle: computed('model.level', 'nodeStyle', function () {
     return htmlSafe(
@@ -75,26 +80,29 @@ export default Component.extend({
 
   hasChildren: gt('model.children.length', 0),
 
-  settledValue: computed('model.value', function () {
-    if (this.get('model.isFulfilled')) {
-      return this.get('model.value');
-    } else if (this.get('model.isRejected')) {
-      return this.get('model.reason');
-    } else {
-      return '--';
+  settledValue: computed(
+    'model.{isFulfilled,isRejected,reason,value}',
+    function () {
+      if (this.get('model.isFulfilled')) {
+        return this.get('model.value');
+      } else if (this.get('model.isRejected')) {
+        return this.get('model.reason');
+      } else {
+        return '--';
+      }
     }
-  }),
+  ),
 
   isValueInspectable: notEmpty('settledValue.objectId'),
 
-  hasValue: computed('settledValue', 'model.isSettled', function () {
+  hasValue: computed('settledValue.type', 'model.isSettled', function () {
     return (
       this.get('model.isSettled') &&
       this.get('settledValue.type') !== 'type-undefined'
     );
   }),
 
-  label: computed('model.label', function () {
+  label: computed('model.{label,parent}', function () {
     return (
       this.get('model.label') ||
       (!!this.get('model.parent') && 'Then') ||
@@ -102,20 +110,23 @@ export default Component.extend({
     );
   }),
 
-  state: computed('model.state', function () {
-    if (this.get('model.isFulfilled')) {
-      return 'Fulfilled';
-    } else if (this.get('model.isRejected')) {
-      return 'Rejected';
-    } else if (
-      this.get('model.parent') &&
-      !this.get('model.parent.isSettled')
-    ) {
-      return 'Waiting for parent';
-    } else {
-      return 'Pending';
+  state: computed(
+    'model.{isFulfilled,isRejected,parent.isSettled}',
+    function () {
+      if (this.get('model.isFulfilled')) {
+        return 'Fulfilled';
+      } else if (this.get('model.isRejected')) {
+        return 'Rejected';
+      } else if (
+        this.get('model.parent') &&
+        !this.get('model.parent.isSettled')
+      ) {
+        return 'Waiting for parent';
+      } else {
+        return 'Pending';
+      }
     }
-  }),
+  ),
 
   timeToSettle: computed(
     'model.{createdAt,settledAt,parent.settledAt}',

--- a/app/components/render-item.js
+++ b/app/components/render-item.js
@@ -9,7 +9,7 @@ import { gt } from '@ember/object/computed';
 export default Component.extend({
   tagName: '',
 
-  searchMatch: computed('search', 'name', function () {
+  searchMatch: computed('search', 'model.name', function () {
     let search = this.search;
     if (isEmpty(search)) {
       return true;

--- a/app/controllers/render-tree.js
+++ b/app/controllers/render-tree.js
@@ -56,16 +56,21 @@ export default Controller.extend({
     return escapeRegExp(this.search.toLowerCase());
   }),
 
-  filtered: computed('model.@each.name', 'search', function () {
-    if (isEmpty(this.escapedSearch)) {
-      return this.model;
-    }
+  filtered: computed(
+    'escapedSearch',
+    'model.@each.name',
+    'search',
+    function () {
+      if (isEmpty(this.escapedSearch)) {
+        return this.model;
+      }
 
-    return this.model.filter((item) => {
-      const regExp = new RegExp(this.escapedSearch);
-      return recursiveMatch(item, regExp);
-    });
-  }),
+      return this.model.filter((item) => {
+        const regExp = new RegExp(this.escapedSearch);
+        return recursiveMatch(item, regExp);
+      });
+    }
+  ),
 
   closeWarning: action(function () {
     this.set('isWarningClosed', true);

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -82,7 +82,7 @@ export default EmberObject.extend(PortMixin, {
     },
   },
 
-  instrumentWithStack: computed({
+  instrumentWithStack: computed('session', {
     get() {
       return !!this.get('session').getItem('promise:stack');
     },


### PR DESCRIPTION
## Description

This MR aims to fix the future `ember/require-computed-property-dependencies` rule, while upgrading eslint-plugin-ember from 7.13.0 to 8.5.1.

See related issue: https://github.com/emberjs/ember-inspector/issues/1197

And the rule documentation: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/require-computed-property-dependencies.md

Note that some error occurence from this build error list has been omitted: https://github.com/emberjs/ember-inspector/pull/1211/checks?check_run_id=672333609
They will be fixed by this PR: https://github.com/emberjs/ember-inspector/pull/1216