### PR TITLE
Prevent future ember/no-mixins eslint error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
 
     // Best practice
     'no-duplicate-imports': 'error',
+    'ember/no-mixins': 'error',
   },
   overrides: [
     // node files

--- a/ember_debug/container-debug.js
+++ b/ember_debug/container-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 const Ember = window.Ember;
 const { Object: EmberObject, computed } = Ember;

--- a/ember_debug/data-debug.js
+++ b/ember_debug/data-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 
 const Ember = window.Ember;

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import SourceMap from 'ember-debug/libs/source-map';
 

--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -1,4 +1,5 @@
 /* eslint no-empty:0 */
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 const Ember = window.Ember;
 const { Object: EmberObject } = Ember;

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import bound from 'ember-debug/utils/bound-method';
 import {

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import PromiseAssembler from 'ember-debug/libs/promise-assembler';
 const Ember = window.Ember;

--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import ProfileManager from './models/profile-manager';
 

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import { compareVersion } from 'ember-debug/utils/version';
 

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -1,4 +1,5 @@
 /* eslint no-cond-assign:0 */
+// eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import RenderTree from 'ember-debug/libs/render-tree';
 import ViewInspection from 'ember-debug/libs/view-inspection';


### PR DESCRIPTION
## Description

This MR aims to fix the future `ember/no-mixins` error, while upgrading eslint-plugin-ember from 7.13.0 to 8.5.1.

Preferred to disable the lint on each occurence instead of disabling the rule globally, as we did for observers.

See related issue: https://github.com/emberjs/ember-inspector/issues/1197

And the rule documentation: https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-mixins.md