### PR TITLE
fix get class name

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -772,7 +772,7 @@ function getClassName(object) {
       (emberNames.get(object.constructor) || object.constructor.name)) ||
     '';
 
-  if ('toString' in object && object.toString !== Function.prototype.toString) {
+  if ('toString' in object && object.toString !== Object.prototype.toString) {
     name = object.toString();
   }
 


### PR DESCRIPTION
I guess this should have been Object.prototype.toString
to check if an object defines its own toString or not.
Now we get `[Object object]` for glimmer components