### PR TITLE
Update eslint-plugin-ember, fix lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
 
     // Temporarily turn these off
     'ember/avoid-leaking-state-in-ember-objects': 'off',
+    'ember/no-get': 'off',
+    'ember/no-test-import-export': 'off',
 
     // Best practice
     'no-duplicate-imports': 'error',

--- a/app/components/object-inspector.js
+++ b/app/components/object-inspector.js
@@ -20,9 +20,7 @@ export default Component.extend({
     return `.${nested.mapBy('property').join('.')}`;
   }),
 
-  isNested: computed('model.[]', function () {
-    return this.get('model.length') > 1;
-  }),
+  isNested: computed.gt('model.length', 1),
 
   setPropDisplay: action(function (type) {
     // The custom filter is only working for the "all" table yet

--- a/app/components/object-inspector/properties-all.js
+++ b/app/components/object-inspector/properties-all.js
@@ -18,7 +18,7 @@ export default PropertiesBase.extend({
     });
   }),
 
-  flatPropertyList: computed('model', 'customFilter', function () {
+  flatPropertyList: computed('customFilter', 'model.mixins', function () {
     const props = this.get('model.mixins').map(function (mixin) {
       return mixin.properties.filter(function (p) {
         let shoulApplyCustomFilter = this.customFilter

--- a/app/components/object-inspector/property.js
+++ b/app/components/object-inspector/property.js
@@ -48,9 +48,10 @@ export default Component.extend({
   showDependentKeys: and('isDepsExpanded', 'hasDependentKeys'),
 
   canCalculate: computed(
-    'model',
     'isCalculated',
     'isComputedProperty',
+    'isOverridden',
+    'model.{isExpensive,isGetter}',
     function () {
       if (this.get('isOverridden')) return false;
       if (
@@ -65,9 +66,10 @@ export default Component.extend({
   ),
 
   iconInfo: computed(
+    'isFunction', // eslint-disable-line ember/use-brace-expansion
     'isService',
-    'isFunction',
-    'model.{inspect.value,isTracked,isProperty,isGetter}',
+    'model.inspect.value',
+    'model.{isComputed,isGetter,isProperty,isTracked}',
     function () {
       if (this.get('isService')) {
         return { type: 'service', title: 'Service' };

--- a/app/components/object-inspector/sort-properties.js
+++ b/app/components/object-inspector/sort-properties.js
@@ -7,7 +7,7 @@ export default Component.extend({
   tagName: '',
 
   isArray: computed('properties', function () {
-    const props = A(this.get('properties') || []);
+    const props = A(this.properties || []);
     return props.findBy('name', 'length') && props.findBy('name', 0);
   }),
 
@@ -17,20 +17,20 @@ export default Component.extend({
    * @property sortedProperties
    * @type {Array<Object>}
    */
-  sortedProperties: computed('sorted.length', function () {
+  sortedProperties: computed('isArray', 'sorted.length', function () {
     // limit arrays
-    if (this.get('isArray') && this.get('sorted.length') > 100) {
+    if (this.isArray && this.get('sorted.length') > 100) {
       const indicator = {
         name: '...',
         value: {
           inspect: 'there are more items, send to console to see all',
         },
       };
-      const props = this.get('sorted').slice(0, 100);
+      const props = this.sorted.slice(0, 100);
       props.push(indicator);
       return props;
     }
-    return this.get('sorted');
+    return this.sorted;
   }),
 
   sorted: sort('props', 'sortProperties'),
@@ -64,7 +64,7 @@ export default Component.extend({
       'name',
     ];
     // change order for arrays, if the array doesnt have items, then the order does not need to be changed
-    if (this.get('isArray')) {
+    if (this.isArray) {
       const i = order.indexOf('isProperty:desc');
       order.splice(i, 1);
       order.splice(order.length - 1, 0, 'isProperty:desc');

--- a/app/components/render-item.js
+++ b/app/components/render-item.js
@@ -9,7 +9,7 @@ import { gt } from '@ember/object/computed';
 export default Component.extend({
   tagName: '',
 
-  searchMatch: computed('search', 'name', function () {
+  searchMatch: computed('model.name', 'name', 'search', function () {
     let search = this.search;
     if (isEmpty(search)) {
       return true;

--- a/app/controllers/render-tree.js
+++ b/app/controllers/render-tree.js
@@ -56,16 +56,21 @@ export default Controller.extend({
     return escapeRegExp(this.search.toLowerCase());
   }),
 
-  filtered: computed('model.@each.name', 'search', function () {
-    if (isEmpty(this.escapedSearch)) {
-      return this.model;
-    }
+  filtered: computed(
+    'escapedSearch',
+    'model.@each.name',
+    'search',
+    function () {
+      if (isEmpty(this.escapedSearch)) {
+        return this.model;
+      }
 
-    return this.model.filter((item) => {
-      const regExp = new RegExp(this.escapedSearch);
-      return recursiveMatch(item, regExp);
-    });
-  }),
+      return this.model.filter((item) => {
+        const regExp = new RegExp(this.escapedSearch);
+        return recursiveMatch(item, regExp);
+      });
+    }
+  ),
 
   closeWarning: action(function () {
     this.set('isWarningClosed', true);

--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -96,7 +96,7 @@ export default EmberObject.extend({
    * @param {Error} error
    */
   handleError(error) {
-    if (this.get('environment') === 'production') {
+    if (this.environment === 'production') {
       if (error && error instanceof Error) {
         error = `Error message: ${error.message}\nStack trace: ${error.stack}`;
       }
@@ -148,7 +148,7 @@ export default EmberObject.extend({
     if (this._isReady) {
       this.sendMessage(...arguments);
     } else {
-      this.get('_pendingMessages').push(options);
+      this._pendingMessages.push(options);
     }
   },
 
@@ -158,7 +158,7 @@ export default EmberObject.extend({
   */
   onConnectionReady() {
     // Flush pending messages
-    const messages = this.get('_pendingMessages');
+    const messages = this._pendingMessages;
     messages.forEach((options) => this.sendMessage(options));
     messages.clear();
     this._isReady = true;

--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -15,7 +15,7 @@ export default BasicAdapter.extend({
   },
 
   connect() {
-    const channel = this.get('_channel');
+    const channel = this._channel;
     return this._super(...arguments).then(
       () => {
         window.postMessage('debugger-client', '*', [channel.port2]);
@@ -32,7 +32,7 @@ export default BasicAdapter.extend({
     // "clone" them through postMessage unless they are converted to a
     // native array.
     options = deepClone(options);
-    this.get('_chromePort').postMessage(options);
+    this._chromePort.postMessage(options);
   },
 
   /**
@@ -68,7 +68,7 @@ export default BasicAdapter.extend({
   },
 
   _listen() {
-    let chromePort = this.get('_chromePort');
+    let chromePort = this._chromePort;
 
     chromePort.addEventListener('message', (event) => {
       const message = event.data;

--- a/ember_debug/adapters/websocket.js
+++ b/ember_debug/adapters/websocket.js
@@ -9,7 +9,7 @@ import { onReady } from '../utils/on-ready';
 
 export default BasicAdapter.extend({
   sendMessage(options = {}) {
-    this.get('socket').emit('emberInspectorMessage', options);
+    this.socket.emit('emberInspectorMessage', options);
   },
 
   socket: computed(function () {
@@ -17,7 +17,7 @@ export default BasicAdapter.extend({
   }),
 
   _listen() {
-    this.get('socket').on('emberInspectorMessage', (message) => {
+    this.socket.on('emberInspectorMessage', (message) => {
       // We should generally not be run-wrapping here. Starting a runloop in
       // ember-debug will cause the inspected app to revalidate/rerender. We
       // are generally not intending to cause changes to the rendered output
@@ -40,7 +40,7 @@ export default BasicAdapter.extend({
   },
 
   _disconnect() {
-    this.get('socket').removeAllListeners('emberInspectorMessage');
+    this.socket.removeAllListeners('emberInspectorMessage');
   },
 
   connect() {

--- a/ember_debug/container-debug.js
+++ b/ember_debug/container-debug.js
@@ -9,10 +9,7 @@ export default EmberObject.extend(PortMixin, {
 
   objectInspector: readOnly('namespace.objectInspector'),
 
-  container: computed('namespace.owner', function () {
-    // should update this to use real owner API
-    return this.get('namespace.owner.__container__');
-  }),
+  container: computed.reads('namespace.owner.__container__'),
 
   portNamespace: 'container',
 
@@ -34,13 +31,13 @@ export default EmberObject.extend(PortMixin, {
   },
 
   shouldHide(type) {
-    return type[0] === '-' || this.get('TYPES_TO_SKIP').indexOf(type) !== -1;
+    return type[0] === '-' || this.TYPES_TO_SKIP.indexOf(type) !== -1;
   },
 
   instancesByType() {
     let key;
     let instancesByType = {};
-    let cache = this.get('container').cache;
+    let cache = this.container.cache;
     // Detect if InheritingDict (from Ember < 1.8)
     if (
       typeof cache.dict !== 'undefined' &&
@@ -82,7 +79,7 @@ export default EmberObject.extend(PortMixin, {
     return instances.map((item) => ({
       name: this.nameFromKey(item.fullName),
       fullName: item.fullName,
-      inspectable: this.get('objectInspector').canSend(item.instance),
+      inspectable: this.objectInspector.canSend(item.instance),
     }));
   },
 
@@ -106,8 +103,8 @@ export default EmberObject.extend(PortMixin, {
       }
     },
     sendInstanceToConsole(message) {
-      const instance = this.get('container').lookup(message.name);
-      this.get('objectToConsole').sendValueToConsole(instance);
+      const instance = this.container.lookup(message.name);
+      this.objectToConsole.sendValueToConsole(instance);
     },
   },
 });

--- a/ember_debug/data-debug.js
+++ b/ember_debug/data-debug.js
@@ -93,9 +93,7 @@ export default EmberObject.extend(PortMixin, {
     this.sentRecords[objectId] = record;
     // make objects clonable
     for (let i in record.columnValues) {
-      columnValues[i] = this.get('objectInspector').inspect(
-        record.columnValues[i]
-      );
+      columnValues[i] = this.objectInspector.inspect(record.columnValues[i]);
     }
     // make sure keywords can be searched and clonable
     searchKeywords = A(record.searchKeywords).filter(
@@ -134,12 +132,12 @@ export default EmberObject.extend(PortMixin, {
 
   messages: {
     checkAdapter() {
-      this.sendMessage('hasAdapter', { hasAdapter: !!this.get('adapter') });
+      this.sendMessage('hasAdapter', { hasAdapter: !!this.adapter });
     },
 
     getModelTypes() {
       this.releaseTypes();
-      this.releaseTypesMethod = this.get('adapter').watchModelTypes(
+      this.releaseTypesMethod = this.adapter.watchModelTypes(
         (types) => {
           this.modelTypesAdded(types);
         },
@@ -163,7 +161,7 @@ export default EmberObject.extend(PortMixin, {
         typeOrName = type.name;
       }
 
-      let releaseMethod = this.get('adapter').watchRecords(
+      let releaseMethod = this.adapter.watchRecords(
         typeOrName,
         (recordsReceived) => {
           this.recordsAdded(recordsReceived);
@@ -183,14 +181,14 @@ export default EmberObject.extend(PortMixin, {
     },
 
     inspectModel(message) {
-      this.get('objectInspector').sendObject(
+      this.objectInspector.sendObject(
         this.sentRecords[message.objectId].object
       );
     },
 
     getFilters() {
       this.sendMessage('filters', {
-        filters: this.get('adapter').getFilters(),
+        filters: this.adapter.getFilters(),
       });
     },
   },

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -37,34 +37,32 @@ export default EmberObject.extend(PortMixin, {
    */
   fetchSourceMap(stackStr) {
     if (
-      this.get('emberCliConfig') &&
+      this.emberCliConfig &&
       this.get('emberCliConfig.environment') === 'development'
     ) {
-      return this.get('sourceMap')
-        .map(stackStr)
-        .then(
-          (mapped) => {
-            if (mapped && mapped.length > 0) {
-              let source = mapped.find(
-                (item) =>
-                  item.source &&
-                  !!item.source.match(
-                    new RegExp(this.get('emberCliConfig.modulePrefix'))
-                  )
-              );
+      return this.sourceMap.map(stackStr).then(
+        (mapped) => {
+          if (mapped && mapped.length > 0) {
+            let source = mapped.find(
+              (item) =>
+                item.source &&
+                !!item.source.match(
+                  new RegExp(this.get('emberCliConfig.modulePrefix'))
+                )
+            );
 
-              if (source) {
-                source.found = true;
-              } else {
-                source = mapped.get('firstObject');
-                source.found = false;
-              }
-              return source;
+            if (source) {
+              source.found = true;
+            } else {
+              source = mapped.get('firstObject');
+              source.found = false;
             }
-          },
-          null,
-          'ember-inspector'
-        );
+            return source;
+          }
+        },
+        null,
+        'ember-inspector'
+      );
     } else {
       return resolve(null, 'ember-inspector');
     }
@@ -78,11 +76,11 @@ export default EmberObject.extend(PortMixin, {
     let deprecations = A();
 
     let promises = all(
-      this.get('deprecationsToSend').map((deprecation) => {
+      this.deprecationsToSend.map((deprecation) => {
         let obj;
         let promise = resolve(undefined, 'ember-inspector');
-        let grouped = this.get('groupedDeprecations');
-        this.get('deprecations').pushObject(deprecation);
+        let grouped = this.groupedDeprecations;
+        this.deprecations.pushObject(deprecation);
         const id = guidFor(deprecation.message);
         obj = grouped[id];
         if (obj) {
@@ -123,7 +121,7 @@ export default EmberObject.extend(PortMixin, {
     promises.then(
       () => {
         this.sendMessage('deprecationsAdded', { deprecations });
-        this.get('deprecationsToSend').clear();
+        this.deprecationsToSend.clear();
         this.sendCount();
       },
       null,
@@ -145,7 +143,7 @@ export default EmberObject.extend(PortMixin, {
   messages: {
     watch() {
       this._watching = true;
-      let grouped = this.get('groupedDeprecations');
+      let grouped = this.groupedDeprecations;
       let deprecations = [];
       for (let i in grouped) {
         if (!grouped.hasOwnProperty(i)) {
@@ -167,7 +165,7 @@ export default EmberObject.extend(PortMixin, {
         stack.unshift(
           `Ember Inspector (Deprecation Trace): ${deprecation.message || ''}`
         );
-        this.get('adapter').log(stack.join('\n'));
+        this.adapter.log(stack.join('\n'));
       });
     },
 
@@ -177,7 +175,7 @@ export default EmberObject.extend(PortMixin, {
 
     clear() {
       run.cancel(this.debounce);
-      this.get('deprecations').clear();
+      this.deprecations.clear();
       this.set('groupedDeprecations', {});
       this.sendCount();
     },
@@ -242,7 +240,7 @@ export default EmberObject.extend(PortMixin, {
 
       // For ember-debug testing we usually don't want
       // to catch deprecations
-      if (!this.get('namespace').IGNORE_DEPRECATIONS) {
+      if (!this.namespace.IGNORE_DEPRECATIONS) {
         this.deprecationsToSend.pushObject(deprecation);
         run.cancel(this.debounce);
         if (this._watching) {
@@ -251,7 +249,7 @@ export default EmberObject.extend(PortMixin, {
           this.debounce = run.debounce(this, 'sendCount', 100);
         }
         if (!this._warned) {
-          this.get('adapter').warn(
+          this.adapter.warn(
             'Deprecations were detected, see the Ember Inspector deprecations tab for more details.'
           );
           this._warned = true;

--- a/ember_debug/libs/promise-assembler.js
+++ b/ember_debug/libs/promise-assembler.js
@@ -59,7 +59,7 @@ let PromiseAssembler = EmberObject.extend(Evented, {
       this.RSVP.off('fulfilled', this.promiseFulfilled);
       this.RSVP.off('created', this.promiseCreated);
 
-      this.get('all').forEach((item) => {
+      this.all.forEach((item) => {
         item.destroy();
       });
       this.set('all', A());
@@ -82,19 +82,19 @@ let PromiseAssembler = EmberObject.extend(Evented, {
     let promise = Promise.create(props);
     let index = this.get('all.length');
 
-    this.get('all').pushObject(promise);
-    this.get('promiseIndex')[promise.get('guid')] = index;
+    this.all.pushObject(promise);
+    this.promiseIndex[promise.get('guid')] = index;
     return promise;
   },
 
   find(guid) {
     if (guid) {
-      const index = this.get('promiseIndex')[guid];
+      const index = this.promiseIndex[guid];
       if (index !== undefined) {
-        return this.get('all').objectAt(index);
+        return this.all.objectAt(index);
       }
     } else {
-      return this.get('all');
+      return this.all;
     }
   },
 

--- a/ember_debug/libs/source-map.js
+++ b/ember_debug/libs/source-map.js
@@ -30,7 +30,7 @@ export default EmberObject.extend({
     let array = A();
     let lastPromise = null;
     parsed.forEach((item) => {
-      lastPromise = this.get('_lastPromise')
+      lastPromise = this._lastPromise
         .then(() => this.getSourceMap(item.url), null, 'ember-inspector')
         .then(
           (smc) => {
@@ -62,7 +62,7 @@ export default EmberObject.extend({
   }),
 
   getSourceMap(url) {
-    let sourceMaps = this.get('sourceMapCache');
+    let sourceMaps = this.sourceMapCache;
     if (sourceMaps[url] !== undefined) {
       return resolve(sourceMaps[url], 'ember-inspector');
     }

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -52,10 +52,10 @@ const EmberDebug = EmberObject.extend({
    * @type {String}
    */
   applicationId: computed('_application', 'isTesting', 'owner', function () {
-    if (!this.get('isTesting')) {
-      return guidFor(this.get('_application'));
+    if (!this.isTesting) {
+      return guidFor(this._application);
     }
-    return guidFor(this.get('owner'));
+    return guidFor(this.owner);
   }),
 
   // Using object shorthand syntax here is somehow having strange side effects.
@@ -64,26 +64,26 @@ const EmberDebug = EmberObject.extend({
   Adapter: BasicAdapter,
 
   start($keepAdapter) {
-    if (this.get('started')) {
+    if (this.started) {
       this.reset($keepAdapter);
       return;
     }
-    if (!this.get('_application') && !this.get('isTesting')) {
+    if (!this._application && !this.isTesting) {
       this.set('_application', getApplication());
     }
     this.set('started', true);
 
     this.reset();
 
-    this.get('adapter').debug('Ember Inspector Active');
-    this.get('adapter').sendMessage({
+    this.adapter.debug('Ember Inspector Active');
+    this.adapter.sendMessage({
       type: 'inspectorLoaded',
     });
   },
 
   destroyContainer() {
-    if (this.get('generalDebug')) {
-      this.get('generalDebug').sendReset();
+    if (this.generalDebug) {
+      this.generalDebug.sendReset();
     }
     [
       'dataDebug',
@@ -115,18 +115,18 @@ const EmberDebug = EmberObject.extend({
   },
 
   reset($keepAdapter) {
-    if (!this.get('isTesting') && !this.get('owner')) {
-      this.set('owner', getOwner(this.get('_application')));
+    if (!this.isTesting && !this.owner) {
+      this.set('owner', getOwner(this._application));
     }
     this.destroyContainer();
     run(() => {
       // Adapters don't have state depending on the application itself.
       // They also maintain connections with the inspector which we will
       // lose if we destroy.
-      if (!this.get('adapter') || !$keepAdapter) {
+      if (!this.adapter || !$keepAdapter) {
         this.startModule('adapter', this.Adapter);
       }
-      if (!this.get('port') || !$keepAdapter) {
+      if (!this.port || !$keepAdapter) {
         this.startModule('port', this.Port);
       }
 
@@ -146,8 +146,8 @@ const EmberDebug = EmberObject.extend({
   },
 
   inspect(obj) {
-    this.get('objectInspector').sendObject(obj);
-    this.get('adapter').log('Sent to the Object Inspector');
+    this.objectInspector.sendObject(obj);
+    this.adapter.log('Sent to the Object Inspector');
     return obj;
   },
 

--- a/ember_debug/mixins/port-mixin.js
+++ b/ember_debug/mixins/port-mixin.js
@@ -24,13 +24,13 @@ export default Mixin.create({
   },
 
   sendMessage(name, message) {
-    this.get('port').send(this.messageName(name), message);
+    this.port.send(this.messageName(name), message);
   },
 
   messageName(name) {
     let messageName = name;
-    if (this.get('portNamespace')) {
-      messageName = `${this.get('portNamespace')}:${messageName}`;
+    if (this.portNamespace) {
+      messageName = `${this.portNamespace}:${messageName}`;
     }
     return messageName;
   },
@@ -40,8 +40,8 @@ export default Mixin.create({
    * @param {String} onOrOff 'on' or 'off' the functions to call i.e. port.on or port.off for adding or removing listeners
    */
   setupOrRemovePortListeners(onOrOff) {
-    let port = this.get('port');
-    let messages = this.get('messages');
+    let port = this.port;
+    let messages = this.messages;
 
     for (let name in messages) {
       if (messages.hasOwnProperty(name)) {

--- a/ember_debug/models/promise.js
+++ b/ember_debug/models/promise.js
@@ -31,22 +31,16 @@ export default EmberObject.extend({
   }),
 
   level: computed('parent.level', function () {
-    const parent = this.get('parent');
+    const parent = this.parent;
     if (!parent) {
       return 0;
     }
     return parent.get('level') + 1;
   }),
 
-  isSettled: computed('state', function () {
-    return this.get('isFulfilled') || this.get('isRejected');
-  }),
+  isSettled: computed.or('isFulfilled', 'isRejected'),
 
-  isFulfilled: computed('state', function () {
-    return this.get('state') === 'fulfilled';
-  }),
+  isFulfilled: computed.equal('state', 'fulfilled'),
 
-  isRejected: computed('state', function () {
-    return this.get('state') === 'rejected';
-  }),
+  isRejected: computed.equal('state', 'rejected'),
 });

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -374,7 +374,7 @@ export default EmberObject.extend(PortMixin, {
       }
       this.sendMessage('updateErrors', {
         objectId: message.objectId,
-        errors: errorsToSend(this.get('_errorsFor')[message.objectId]),
+        errors: errorsToSend(this._errorsFor[message.objectId]),
       });
     },
     saveProperty(message) {
@@ -434,7 +434,7 @@ export default EmberObject.extend(PortMixin, {
       this.sendObject(container.lookup(message.name));
     },
     traceErrors(message) {
-      let errors = this.get('_errorsFor')[message.objectId];
+      let errors = this._errorsFor[message.objectId];
       toArray(errors).forEach((error) => {
         let stack = error.error;
         if (stack && stack.stack) {
@@ -442,10 +442,7 @@ export default EmberObject.extend(PortMixin, {
         } else {
           stack = error;
         }
-        this.get('adapter').log(
-          `Object Inspector error for ${error.property}`,
-          stack
-        );
+        this.adapter.log(`Object Inspector error for ${error.property}`, stack);
       });
     },
   },
@@ -487,7 +484,7 @@ export default EmberObject.extend(PortMixin, {
     if (value instanceof EmberObject) {
       args.unshift(inspect(value));
     }
-    this.get('adapter').log('Ember Inspector ($E): ', ...args);
+    this.adapter.log('Ember Inspector ($E): ', ...args);
   },
 
   digIntoObject(objectId, property) {
@@ -582,7 +579,7 @@ export default EmberObject.extend(PortMixin, {
       this.currentObject = null;
     }
 
-    delete this.get('_errorsFor')[objectId];
+    delete this._errorsFor[objectId];
 
     this.sendMessage('droppedObject', { objectId });
   },
@@ -722,7 +719,7 @@ export default EmberObject.extend(PortMixin, {
 
     let objectId = this.retainObject(object);
 
-    let errorsForObject = (this.get('_errorsFor')[objectId] = {});
+    let errorsForObject = (this._errorsFor[objectId] = {});
     const tracked = (this.trackedTags[objectId] =
       this.trackedTags[objectId] || {});
     calculateCPs(
@@ -749,7 +746,7 @@ export default EmberObject.extend(PortMixin, {
       value = calculateCP(
         object,
         { name: property },
-        this.get('_errorsFor')[objectId]
+        this._errorsFor[objectId]
       );
     }
 

--- a/ember_debug/port.js
+++ b/ember_debug/port.js
@@ -31,11 +31,8 @@ export default EmberObject.extend(Ember.Evented, {
      */
     this.now = Date.now();
 
-    this.get('adapter').onMessageReceived((message) => {
-      if (
-        this.get('uniqueId') === message.applicationId ||
-        !message.applicationId
-      ) {
+    this.adapter.onMessageReceived((message) => {
+      if (this.uniqueId === message.applicationId || !message.applicationId) {
         this.messageReceived(message.type, message);
       }
     });
@@ -69,9 +66,9 @@ export default EmberObject.extend(Ember.Evented, {
   send(messageType, options = {}) {
     options.type = messageType;
     options.from = 'inspectedWindow';
-    options.applicationId = this.get('uniqueId');
-    options.applicationName = this.get('applicationName');
-    this.get('adapter').send(options);
+    options.applicationId = this.uniqueId;
+    options.applicationName = this.applicationName;
+    this.adapter.send(options);
   },
 
   /**
@@ -95,7 +92,7 @@ export default EmberObject.extend(Ember.Evented, {
       try {
         return fn();
       } catch (error) {
-        this.get('adapter').handleError(error);
+        this.adapter.handleError(error);
       }
     });
   },

--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -19,7 +19,7 @@ export default EmberObject.extend(PortMixin, {
     this._super();
 
     this.profileManager.wrapForErrors = (context, callback) =>
-      this.get('port').wrap(() => callback.call(context));
+      this.port.wrap(() => callback.call(context));
     this.profileManager.onProfilesAdded(this, this._updateComponentTree);
   },
 

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -56,7 +56,7 @@ export default EmberObject.extend(PortMixin, {
   }),
 
   routeTree: computed('router', function () {
-    const router = this.get('router');
+    const router = this.router;
     const routerLib = router._routerMicrolib || router.router;
     let routeNames = routerLib.recognizer.names;
     let routeTree = {};
@@ -71,7 +71,7 @@ export default EmberObject.extend(PortMixin, {
   }),
 
   sendTree() {
-    const routeTree = this.get('routeTree');
+    const routeTree = this.routeTree;
     this.sendMessage('routeTree', { tree: routeTree });
   },
 
@@ -154,7 +154,7 @@ function buildSubTree(routeTree, route) {
     if (subTree[handler] === undefined) {
       routeClassName = this.getClassName(handler, 'route');
 
-      const router = this.get('router');
+      const router = this.router;
       const routerLib = router._routerMicrolib || router.router;
       // 3.9.0 removed intimate APIs from router
       // https://github.com/emberjs/ember.js/pull/17843

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -134,7 +134,7 @@ export default EmberObject.extend(PortMixin, {
    * @param  {Node} node The DOM node to inspect
    */
   inspectNode(node) {
-    this.get('adapter').inspectNode(node);
+    this.adapter.inspectNode(node);
   },
 
   sendTree(immediate = false) {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "2.7.0"
   ],
   "devDependencies": {
+    "@babel/helper-call-delegate": "^7.10.1",
     "@ember/edition-utils": "^1.2.0",
     "@ember/optional-features": "^1.3.0",
     "@ember/render-modifiers": "^1.0.2",
@@ -60,7 +61,7 @@
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.18.0",
     "ember-cli-app-version": "^3.2.0",
-    "ember-cli-babel": "^7.20.4",
+    "ember-cli-babel": "^7.20.5",
     "ember-cli-code-coverage": "^1.0.0-beta.9",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-htmlbars": "^5.1.2",
@@ -91,7 +92,7 @@
     "ensure-posix-path": "^1.1.1",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
-    "eslint-plugin-ember": "^7.13.0",
+    "eslint-plugin-ember": "^8.6.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "fstream": "^1.0.12",

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -101,7 +101,7 @@ module('Ember Debug - Object Inspector', function (hooks) {
     let inspected = Parent.create({
       id: 1,
       toString() {
-        return `Object:${this.get('name')}`;
+        return `Object:${this.name}`;
       },
       nullVal: null,
       dateVal: date,
@@ -180,7 +180,7 @@ module('Ember Debug - Object Inspector', function (hooks) {
     let inspected = new Parent({
       id: 1,
       toString() {
-        return `Object:${this.get('name')}`;
+        return `Object:${this.name}`;
       },
       nullVal: null,
       dateVal: date,
@@ -813,7 +813,7 @@ module('Ember Debug - Object Inspector', function (hooks) {
 
   test('Computed property dependent keys and code should be successfully serialized', async function (assert) {
     let computedFn = function () {
-      return this.get('foo') + this.get('bar');
+      return this.foo + this.bar;
     };
 
     let inspected = EmberObject.extend({

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.1.tgz#d5481c5095daa1c57e16e54c6f9198443afb49ff"
+  integrity sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==
+  dependencies:
+    "@babel/highlight" "^7.10.1"
+
 "@babel/compat-data@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.9.6.tgz#3f604c40e420131affe6f2c8052e9a275ae2049b"
@@ -38,6 +45,16 @@
     lodash "^4.17.13"
     resolve "^1.3.2"
     semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.10.1":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
+  integrity sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==
+  dependencies:
+    "@babel/types" "^7.10.2"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
     source-map "^0.5.0"
 
 "@babel/generator@^7.4.0", "@babel/generator@^7.8.4":
@@ -74,6 +91,15 @@
   dependencies:
     "@babel/helper-explode-assignable-expression" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-call-delegate@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-call-delegate/-/helper-call-delegate-7.10.1.tgz#8a74d2ba691944874e44f71e53fa97616d683a6a"
+  integrity sha512-usMFX7TASNtz4eUMQ4GoQhkKS5R69SRWIzin2wk52wbP6/yT7K5QA4PKovhlZKU+cCwRIgXW+ZbkC3zVIx8Lyw==
+  dependencies:
+    "@babel/helper-hoist-variables" "^7.10.1"
+    "@babel/traverse" "^7.10.1"
+    "@babel/types" "^7.10.1"
 
 "@babel/helper-compilation-targets@^7.8.7", "@babel/helper-compilation-targets@^7.9.6":
   version "7.9.6"
@@ -144,6 +170,15 @@
     "@babel/traverse" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-function-name@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz#92bd63829bfc9215aca9d9defa85f56b539454f4"
+  integrity sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.1"
+    "@babel/template" "^7.10.1"
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -162,12 +197,26 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.9.5"
 
+"@babel/helper-get-function-arity@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz#7303390a81ba7cb59613895a192b93850e373f7d"
+  integrity sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==
+  dependencies:
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
   integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-hoist-variables@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.10.1.tgz#7e77c82e5dcae1ebf123174c385aaadbf787d077"
+  integrity sha512-vLm5srkU8rI6X3+aQ1rQJyfjvCBLXP8cAGeuw04zeAM2ItKb1e7pmVmLyHb4sDaAYnLL13RHOZPLEtcGZ5xvjg==
+  dependencies:
+    "@babel/types" "^7.10.1"
 
 "@babel/helper-hoist-variables@^7.8.3":
   version "7.8.3"
@@ -261,12 +310,24 @@
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
 
+"@babel/helper-split-export-declaration@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz#c6f4be1cbc15e3a868e4c64a17d5d31d754da35f"
+  integrity sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==
+  dependencies:
+    "@babel/types" "^7.10.1"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz#5770b0c1a826c4f53f5ede5e153163e0318e94b5"
+  integrity sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==
 
 "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
@@ -292,6 +353,15 @@
     "@babel/traverse" "^7.9.6"
     "@babel/types" "^7.9.6"
 
+"@babel/highlight@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.1.tgz#841d098ba613ba1a427a2b383d79e35552c38ae0"
+  integrity sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.1"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
@@ -300,6 +370,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.10.1":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.2.tgz#871807f10442b92ff97e4783b9b54f6a0ca812d0"
+  integrity sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ==
 
 "@babel/parser@^7.3.4", "@babel/parser@^7.4.3", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0", "@babel/parser@^7.8.3", "@babel/parser@^7.8.4":
   version "7.8.4"
@@ -894,6 +969,15 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/template@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.1.tgz#e167154a94cb5f14b28dc58f5356d2162f539811"
+  integrity sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==
+  dependencies:
+    "@babel/code-frame" "^7.10.1"
+    "@babel/parser" "^7.10.1"
+    "@babel/types" "^7.10.1"
+
 "@babel/template@^7.4.0", "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
@@ -927,6 +1011,21 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.10.1":
+  version "7.10.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.1.tgz#bbcef3031e4152a6c0b50147f4958df54ca0dd27"
+  integrity sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.1"
+    "@babel/generator" "^7.10.1"
+    "@babel/helper-function-name" "^7.10.1"
+    "@babel/helper-split-export-declaration" "^7.10.1"
+    "@babel/parser" "^7.10.1"
+    "@babel/types" "^7.10.1"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.9.6":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
@@ -948,6 +1047,15 @@
   integrity sha512-jBD+G8+LWpMBBWvVcdr4QysjUE4mU/syrhN17o1u3gx0/WzJB1kwiVZAXRtWbsIPOwW8pF/YJV5+nmetPzepXg==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.1", "@babel/types@^7.10.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.2.tgz#30283be31cad0dbf6fb00bd40641ca0ea675172d"
+  integrity sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.1"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -2345,6 +2453,13 @@ babel-plugin-ember-modules-api-polyfill@^2.13.3, babel-plugin-ember-modules-api-
   version "2.13.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.3.tgz#f076c655e9f17cd19d1a92e62f1e9118a0e383e8"
   integrity sha512-p108ELYtaLyPkGUoLzx7S0BR4QcWwgpJGSv68C93nvldH8o87eegwPhomNfLLYyfhbpQ23DWTTE3dX6DJGKInw==
+  dependencies:
+    ember-rfc176-data "^0.3.13"
+
+babel-plugin-ember-modules-api-polyfill@^2.13.4:
+  version "2.13.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.13.4.tgz#cf62bc9bfd808c48d810d5194f4329e9453bd603"
+  integrity sha512-uxQPkEQAzCYdwhZk16O9m1R4xtCRNy4oEUTBrccOPfzlIahRZJic/JeP/ZEL0BC6Mfq6r55eOg6gMF/zdFoCvA==
   dependencies:
     ember-rfc176-data "^0.3.13"
 
@@ -5306,7 +5421,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0,
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.4, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember-cli-babel@^7.13.2, ember-cli-babel@^7.17.2, ember-cli-babel@^7.18.0, ember-cli-babel@^7.19.0, ember-cli-babel@^7.7.3:
   version "7.20.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.20.4.tgz#6f7bd275ac7532cf6dc1826f350aea32a3c81b06"
   integrity sha512-LcE2PMKkozLxJDibyidH5uUuRORVo+b6Mub95MdF6anWNTR72FtNtXANSJaMqtP8ELhLglapUgLC3ylfdyGa8A==
@@ -5325,6 +5440,38 @@ ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.12.0, ember
     babel-plugin-debug-macros "^0.3.0"
     babel-plugin-ember-data-packages-polyfill "^0.1.2"
     babel-plugin-ember-modules-api-polyfill "^2.13.3"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.4.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.0"
+    ember-cli-version-checker "^4.1.0"
+    ensure-posix-path "^1.0.2"
+    fixturify-project "^1.10.0"
+    rimraf "^3.0.1"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.20.5:
+  version "7.20.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.20.5.tgz#ab60dcf7371f4d86d41c2596c6d050470e283074"
+  integrity sha512-lWvKqJPQ1KJigWKmxREqFbXgZd2/nFKMg3chiiNejpsAIgGLPXGFLwpMQ7QYCRrlims7D/bnDgFvXuOLkw0fcQ==
+  dependencies:
+    "@babel/core" "^7.9.0"
+    "@babel/helper-compilation-targets" "^7.8.7"
+    "@babel/plugin-proposal-class-properties" "^7.8.3"
+    "@babel/plugin-proposal-decorators" "^7.8.3"
+    "@babel/plugin-transform-modules-amd" "^7.9.0"
+    "@babel/plugin-transform-runtime" "^7.9.0"
+    "@babel/plugin-transform-typescript" "^7.9.0"
+    "@babel/polyfill" "^7.8.7"
+    "@babel/preset-env" "^7.9.0"
+    "@babel/runtime" "^7.9.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.0"
+    babel-plugin-ember-data-packages-polyfill "^0.1.2"
+    babel-plugin-ember-modules-api-polyfill "^2.13.4"
     babel-plugin-module-resolver "^3.1.1"
     broccoli-babel-transpiler "^7.4.0"
     broccoli-debug "^0.6.4"
@@ -5931,7 +6078,7 @@ ember-resolver@^8.0.0:
     ember-cli-version-checker "^5.0.2"
     resolve "^1.15.1"
 
-ember-rfc176-data@^0.3.1, ember-rfc176-data@^0.3.12:
+ember-rfc176-data@^0.3.1:
   version "0.3.12"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.12.tgz#90d82878e69e2ac9a5438e8ce14d12c6031c5bd2"
   integrity sha512-g9HeZj/gU5bfIIrGXkP7MhS2b3Vu5DfNUrYr14hy99TgIvtZETO+96QF4WOEUXGjIJdfTRjerVnQlqngPQSv1g==
@@ -6350,13 +6497,14 @@ eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-plugin-ember@^7.13.0:
-  version "7.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-7.13.0.tgz#a1df7794f06cdc6e1b8acfe6c59db5cf861f53dc"
-  integrity sha512-qIbw4uP0qUJoiWF4+7MTJWqwEN86RGmBNId0cwSoHoVNWtcw50R1ajYgxM1Q5FVUdoisVeSl9lKVRh5zkDFl+g==
+eslint-plugin-ember@^8.6.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-8.6.0.tgz#9099a222325aa57fd0c9782e0a7ea12b1b6552c9"
+  integrity sha512-qd/JmdRe180WR7Yc62+Wl9dSGA90vQsuZ92xIP8nL4a16752rUCpKxVeNi0p2tAieB06yFZBWd8C2JZsBC08/g==
   dependencies:
     "@ember-data/rfc395-data" "^0.0.4"
-    ember-rfc176-data "^0.3.12"
+    ember-rfc176-data "^0.3.13"
+    lodash.kebabcase "^4.1.1"
     snake-case "^3.0.3"
 
 eslint-plugin-es@^3.0.0:
@@ -9362,6 +9510,11 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
   integrity sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=
+
+lodash.kebabcase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"
+  integrity sha1-hImxyw0p/4gZXM7KRI/21swpXDY=
 
 lodash.keys@^3.0.0:
   version "3.1.2"


### PR DESCRIPTION
This was basically just updating to latest eslint-plugin-ember and running `yarn lint:js --fix`. I did disable `no-get` for now because they didn't all fix, and I figured we could incrementally fix those later.

Closes #1197 
Closes #1216 
Closes #1217 