### PR TITLE
Ensure `valueForTag` is passed an actual `Tag`

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -288,7 +288,7 @@ export default EmberObject.extend(PortMixin, {
                 tagInfo.tag = track(() => {
                   value = get(object, item.name);
                 });
-                tagInfo.revision = tagValue(object, item.name);
+                tagInfo.revision = tagValue(tagInfo.tag);
               }
               tracked[item.name] = tagInfo;
             } else {
@@ -1093,7 +1093,7 @@ function calculateCPs(
                 item.isTracked = true;
               }
             }
-            tagInfo.revision = tagValue(object, item.name);
+            tagInfo.revision = tagValue(tagInfo.tag);
             item.dependentKeys = getTrackedDependencies(
               object,
               item.name,


### PR DESCRIPTION
`@glimmer/validator` only accepts a `Tag` instance as an argument but we are passing the object + property name (basically we are treating it like `tagForProperty`). Recent versions of ember-source
(that have updated versions of glimmer-vm) actually use the passed in arguments to return the revision so we are hitting an error (since the `object` we pass is not a `Tag`).

Fixes https://github.com/emberjs/ember-inspector/issues/1298