### PR TITLE
[INTERNAL] Remove unsafe-eval in manifest.json (again)

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -20,6 +20,9 @@ const packageJson = require('./package.json');
 const { map, mv } = stew;
 
 const options = {
+  autoImport: {
+    forbidEval: true,
+  },
   fingerprint: {
     enabled: false,
   },

--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -18,7 +18,7 @@
     "contextMenus"
   ],
 
-  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+  "content_security_policy": "script-src 'self'; object-src 'self'",
   "devtools_page": "devtools.html",
 
   "content_scripts": [{


### PR DESCRIPTION
We got an email from mozilla that disabled the recent versions of the addon due to the inclusion of 'unsafe-eval' in the manifest. It was added in 9022a02 and my best guess is it's to workaround CSP issues in development since ember-auto-import's webpack config uses eval in dev mode by default (it doesn't do it in prod) and the commit didn't materially changed the way we use imports in the extension itself.

Turns out, the last time this came up, we just removed it from the manifest (#737) because the conclusion was that the way we use eval and more importantly the places we uses eval is not subject to the CSP anyway, so we don't actually need to add it in the manifest.


I don't have time to fully investigate this so in the meantime I disabled the use of eval in development just in case. If this is too slow, we can re-enable it and just make the declaration in the manifest conditional based on EMBER_ENV.