### PR TITLE
WIP: in-element support

### DIFF
--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -2,7 +2,8 @@ import { click, find, triggerEvent, visit } from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { A } from '@ember/array';
 import { run } from '@ember/runloop';
-import EmberComponent from '@ember/component';
+import EmberComponent, { setComponentTemplate } from '@ember/component';
+import GlimmerComponent from '@glimmer/component';
 import EmberRoute from '@ember/routing/route';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
@@ -354,6 +355,26 @@ module('Ember Debug - View', function (hooks) {
           return 'App.TestBarComponent';
         },
       })
+    );
+
+    this.owner.register(
+      'component:test-in-element',
+      setComponentTemplate(
+        hbs`
+        {{#-in-element this.element}}
+          <p>
+            this text is in the target div
+          </p>
+        {{/-in-element}}
+        `,
+        class TestInElement extends GlimmerComponent {
+          constructor(owner, args) {
+            super(owner, args);
+
+            this.element = document.querySelector('#target');
+          }
+        }
+      )
     );
 
     /*


### PR DESCRIPTION
## Description

Currently, as reported by  and reproduced in https://github.com/NullVoxPopuli/repro-repo-ember-inspector-1255,
when components are "portaled" to another part of the DOM, the inspector doesn't know how find them both with the pointer highlight toggle, and the right click menu -> Ember Inspect.

_This PR aims to fix that, *hopefully* meaning that *all* attempts to inspect a component "work"_

## Screenshots

TBD
