### PR TITLE
Fix canary build

### DIFF
--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -1,4 +1,4 @@
-import { classify } from '@ember/string';
+import classify from '../utils/classify';
 import bound from 'ember-debug/utils/bound-method';
 
 function makeHighlight(id) {

--- a/ember_debug/route-debug.js
+++ b/ember_debug/route-debug.js
@@ -1,7 +1,8 @@
-import { classify, dasherize } from '@ember/string';
 // eslint-disable-next-line ember/no-mixins
 import PortMixin from 'ember-debug/mixins/port-mixin';
 import { compareVersion } from 'ember-debug/utils/version';
+import classify from 'ember-debug/utils/classify';
+import dasherize from 'ember-debug/utils/dasherize';
 
 const Ember = window.Ember;
 const {

--- a/ember_debug/utils/classify.js
+++ b/ember_debug/utils/classify.js
@@ -1,0 +1,23 @@
+const STRING_CLASSIFY_REGEXP_1 = /^(\-|_)+(.)?/;
+const STRING_CLASSIFY_REGEXP_2 = /(.)(\-|\_|\.|\s)+(.)?/g;
+const STRING_CLASSIFY_REGEXP_3 = /(^|\/|\.)([a-z])/g;
+
+export default function classify(str) {
+  let replace1 = (_match, _separator, chr) =>
+    chr ? `_${chr.toUpperCase()}` : '';
+  let replace2 = (_match, initialChar, _separator, chr) =>
+    initialChar + (chr ? chr.toUpperCase() : '');
+  let parts = str.split('/');
+
+  for (let i = 0; i < parts.length; i++) {
+    parts[i] = parts[i]
+      .replace(STRING_CLASSIFY_REGEXP_1, replace1)
+      .replace(STRING_CLASSIFY_REGEXP_2, replace2);
+  }
+
+  return parts
+    .join('/')
+    .replace(STRING_CLASSIFY_REGEXP_3, (match /*, separator, chr */) =>
+      match.toUpperCase()
+    );
+}

--- a/ember_debug/utils/dasherize.js
+++ b/ember_debug/utils/dasherize.js
@@ -1,0 +1,5 @@
+const STRING_DASHERIZE_REGEXP = /[ _]/g;
+
+export default function dasherize(str) {
+  return str.replace(STRING_DASHERIZE_REGEXP, '-');
+}

--- a/tests/ember_debug/deprecation-debug-test.js
+++ b/tests/ember_debug/deprecation-debug-test.js
@@ -38,13 +38,25 @@ module('Ember Debug - Deprecation', function (hooks) {
       Route.extend({
         setupController() {
           EmberDebug.IGNORE_DEPRECATIONS = false;
-          deprecate('Deprecation 1', false, { id: 'dep-1', until: '1.0.0' });
+          deprecate('Deprecation 1', false, {
+            id: 'dep-1',
+            for: 'ember-inspector',
+            since: '0.1.0',
+            until: '1.0.0',
+          });
           deprecate('Deprecation 2', false, {
             id: 'dep-2',
+            for: 'ember-inspector',
+            since: '0.1.0',
             until: '1.0.0',
             url: 'http://www.emberjs.com',
           });
-          deprecate('Deprecation 1', false, { id: 'dep-1', until: '1.0.0' });
+          deprecate('Deprecation 1', false, {
+            id: 'dep-1',
+            for: 'ember-inspector',
+            since: '0.1.0',
+            until: '1.0.0',
+          });
           EmberDebug.IGNORE_DEPRECATIONS = true;
         },
       })
@@ -93,8 +105,18 @@ module('Ember Debug - Deprecation', function (hooks) {
       Route.extend({
         setupController() {
           EmberDebug.IGNORE_DEPRECATIONS = false;
-          deprecate('Deprecation 1', false, { id: 'dep-1', until: '1.0.0' });
-          deprecate('Deprecation 2', false, { id: 'dep-2', until: '1.0.0' });
+          deprecate('Deprecation 1', false, {
+            id: 'dep-1',
+            for: 'ember-inspector',
+            since: '0.1.0',
+            until: '1.0.0',
+          });
+          deprecate('Deprecation 2', false, {
+            id: 'dep-2',
+            for: 'ember-inspector',
+            since: '0.1.0',
+            until: '1.0.0',
+          });
           EmberDebug.IGNORE_DEPRECATIONS = true;
         },
       })


### PR DESCRIPTION
Due to the new deprecations introduced in the canary build, CI started failing.
This should address the problem.

This should unblock the open dependabot PRs.