### PR TITLE
update CI to use environment files instead of set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,16 @@ jobs:
           GIT_COMMIT_SHA: ${{ github.sha }}
           GIT_BRANCH: ${{ github.ref }}
         run: |
-          echo "::set-env name=GIT_COMMIT_SHA::${GIT_COMMIT_SHA}"
-          echo "::set-env name=GIT_BRANCH::${GIT_BRANCH/refs\/heads\//}"
+          echo "GIT_COMMIT_SHA=${GIT_COMMIT_SHA}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GIT_BRANCH/refs\/heads\//}" >> $GITHUB_ENV
       - name: Set up commit metadata
         if: github.event_name == 'pull_request'
         env:
           GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
           GIT_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          echo "::set-env name=GIT_COMMIT_SHA::${GIT_COMMIT_SHA}"
-          echo "::set-env name=GIT_BRANCH::${GIT_BRANCH}"
+          echo "GIT_COMMIT_SHA=${GIT_COMMIT_SHA}" >> $GITHUB_ENV
+          echo "GIT_BRANCH=${GIT_BRANCH}" >> $GITHUB_ENV
       - name: Set up Volta
         uses: rwjblue/setup-volta@v1
       - name: Install dependencies (yarn)
@@ -99,7 +99,7 @@ jobs:
         run: yarn install
       - name: Set NO_EXTEND_PROTOTYPES
         if: matrix.scenario == 'default-no-prototype-extensions'
-        run: echo "::set-env name=NO_EXTEND_PROTOTYPES,::true"
+        run: echo "NO_EXTEND_PROTOTYPES==true" >> .GITHUB_ENV
       - name: Setup ember-try scenario
         run: yarn ember try:one ember-${{ matrix.scenario }} --skip-cleanup --- cat package.json
       - name: Build
@@ -184,10 +184,10 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
       - name: Set EMBER_INSPECTOR_TAB (nightly)
         if: github.event_name == 'schedule'
-        run: echo "::set-env name=EMBER_INSPECTOR_TAB,::Nightly"
+        run: echo "EMBER_INSPECTOR_TAB=Nightly" >> $GITHUB_ENV
       - name: Set EMBER_INSPECTOR_TAB (pull request)
         if: github.event_name == 'pull_request'
-        run: echo "::set-env name=EMBER_INSPECTOR_TAB,::PR \#$PR"
+        run: echo "EMBER_INSPECTOR_TAB=PR \#$PR" >> $GITHUB_ENV
         env:
           PR: ${{ github.event.pull_request.number }}
       - name: Build


### PR DESCRIPTION
Fixes https://github.com/emberjs/ember-inspector/issues/1406.

beta/canary are failing because of the deprecations addressed by https://github.com/emberjs/ember-inspector/pull/1405 and https://github.com/emberjs/ember-inspector/pull/1400.
Since I have those PRs up I thought I'd keep them separate and rebase once this goes in. What do you think?