### PR TITLE
Change message type to switch to components route

### DIFF
--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -97,7 +97,7 @@
         onclick: function() {
           chrome.tabs.sendMessage(activeTabId, {
             from: 'devtools',
-            type: 'view:contextMenu'
+            type: 'view:inspectComponent'
           });
         }
       });


### PR DESCRIPTION
@chancancode I have been unable to determine a way to programmatically open the devtools when clicking this context menu item, but this gets us one step closer by actually switching routes in inspector. Any ideas on how to open devtools to the Ember Inspector panel? I haven't been able to find anything about it.