### PR TITLE
Run dependabot less often

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,4 +10,4 @@ update_configs:
   # other updates monthly, to cut down on repo noise.
   - package_manager: "javascript"
     directory: "/"
-    update_schedule: "monthly"
+    update_schedule: "weekly"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,13 +1,14 @@
-
-# Create Pull-Requests for NPM updates automatically
-# https://dependabot.com/docs/config-file/
-
 version: 1
 update_configs:
-  # Keep package.json (& lockfiles) up to date.
-  #
-  # Security updates will be created immediately,
-  # other updates monthly, to cut down on repo noise.
   - package_manager: "javascript"
     directory: "/"
     update_schedule: "weekly"
+    default_labels:
+      - "dependencies"
+    automerged_updates:
+      - match:
+          update_type: "in_range"
+    ignored_updates:
+      - match:
+          dependency_name: "ember-cli"
+    version_requirement_updates: "auto"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+
+# Create Pull-Requests for NPM updates automatically
+# https://dependabot.com/docs/config-file/
+
+version: 1
+update_configs:
+  # Keep package.json (& lockfiles) up to date.
+  #
+  # Security updates will be created immediately,
+  # other updates monthly, to cut down on repo noise.
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "monthly"


### PR DESCRIPTION
Running dependabot too often creates a lot of noise in the commit logs, making it nearly useless to track actual progress.

Running it less often would reduce this problem (security updates still running immediately).

*emberjs/ember.js has already made this change, though I think they configured it via the UI, which is obviously also an option (actually it's even better than doing it via a file IMO).*

See: https://github.com/emberjs/ember.js/pull/18979#issuecomment-631864842

![image](https://user-images.githubusercontent.com/122287/82212745-56eca880-9913-11ea-8315-6cfcf0fe1708.png)