### PR TITLE
Ensure vendored loader does not cache missing modules.

### DIFF
--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -17,13 +17,13 @@ if (typeof define !== 'function' || typeof requireModule !== 'function') {
       if (seen[name]) {
         return seen[name];
       }
-      seen[name] = {};
 
       let mod = registry[name];
-
       if (!mod) {
         throw new Error(`Module: '${name}' not found.`);
       }
+
+      seen[name] = {};
 
       let deps = mod.deps;
       let callback = mod.callback;


### PR DESCRIPTION
Prior to this change, calling `requireModule('foo')` would **create** a `foo` module (with no exports) due to eager caching in the list of "seen" modules.

This means that code like this:

```js
let Ember;
try {
  Ember = requireModule('ember')['default'];
} catch {
  Ember = window.Ember;
}
return Ember;
```

Will properly fallback to `window.Ember` the first time, but all subsequent runs will end up finding a module and returning `{}`.

This addresses at least _part_ of https://github.com/emberjs/ember-inspector/issues/1595 (cannot confirm if it is fully resolved, due to raciness and testing timing).
