### PR TITLE
Move changelog heading to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## v4.4.1 (2021-05-25)
 
 #### :bug: Bug Fix
@@ -74,8 +76,6 @@
 - Robert Wagner ([@rwwagner90](https://github.com/rwwagner90))
 - [@dependabot-preview[bot]](https://github.com/apps/dependabot-preview)
 - [@patricklx](https://github.com/patricklx)
-
-# Changelog
 
 ## [v4.1.0](https://github.com/emberjs/ember-inspector/tree/v4.1.0) (2020-05-12)
 


### PR DESCRIPTION
Format also changed, so that each changelog entry sub-heading is no longer a link. But I think that makes sense actually, so I haven't modified that.

There is a separate PR that has updated the regex to detect this new sub-heading format.

Somewhat related: https://github.com/emberjs/ember-inspector/pull/1578

