### PR TITLE
Possible fix for ember 3.26+

### DIFF
--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -19,6 +19,8 @@ if (typeof env !== 'undefined') {
   currentEnv = env;
 }
 
+let Ember;
+
 // @formatter:off
 var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
 // @formatter:on
@@ -97,7 +99,6 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
         return;
       }
 
-      let Ember;
       try {
         Ember = requireModule('ember')['default'];
       } catch {


### PR DESCRIPTION
## Description
Not sure if this is the best way to do this. However, since Ember doesn't appear to have global scope any more on ember 3.26+. This moves the variable to global scope, so it works within onApplicationStart again.

## Screenshots
![image](https://user-images.githubusercontent.com/4670493/133851188-87fab234-4f3b-413b-970a-0082642dde9c.png)

closes #1634