### PR TITLE
Don't rely on Ember.EmberInspectorDebugger

### DIFF
--- a/app/services/adapters/basic.js
+++ b/app/services/adapters/basic.js
@@ -32,7 +32,7 @@ export default class Basic extends Service {
   }
 
   /**
-   * Listens to `EmberInspectorDebugger` message about
+   * Listens to Ember Inspector message about
    * Ember version mismatch. If a mismatch message is received
    * it means the current inspector app does not support the current
    * Ember version and needs to switch to an inspector version

--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -42,8 +42,9 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
       sendVersionMiss();
       return;
     }
+    
     // prevent from injecting twice
-    if (!Ember.EmberInspectorDebugger) {
+    if (!window.EmberInspector) {
       // Make sure we only work for the supported version
       define('ember-debug/config', function() {
         return {
@@ -52,8 +53,9 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
           }
         };
       });
-      window.EmberInspector = Ember.EmberInspectorDebugger = requireModule('ember-debug/main')['default'];
-      Ember.EmberInspectorDebugger.Adapter = requireModule('ember-debug/adapters/' + adapter)['default'];
+      
+      window.EmberInspector = requireModule('ember-debug/main')['default'];
+      window.EmberInspector.Adapter = requireModule('ember-debug/adapters/' + adapter)['default'];
 
       onApplicationStart(function appStarted(instance) {
         let app = instance.application;
@@ -71,15 +73,15 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
           instance.reopen({
             // Clean up on instance destruction
             willDestroy() {
-              if (Ember.EmberInspectorDebugger.get('owner') === instance) {
-                Ember.EmberInspectorDebugger.destroyContainer();
-                Ember.EmberInspectorDebugger.clear();
+              if (window.EmberInspector.get('owner') === instance) {
+                window.EmberInspector.destroyContainer();
+                window.EmberInspector.clear();
               }
               return this._super.apply(this, arguments);
             }
           });
 
-          if (!Ember.EmberInspectorDebugger._application) {
+          if (!window.EmberInspector._application) {
             bootEmberInspector(instance);
           }
         }
@@ -92,9 +94,9 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
     appInstance.__inspector__booted = true;
 
     // Boot the inspector (or re-boot if already booted, for example in tests)
-    Ember.EmberInspectorDebugger.set('_application', appInstance.application);
-    Ember.EmberInspectorDebugger.set('owner', appInstance);
-    Ember.EmberInspectorDebugger.start(true);
+    window.EmberInspector.set('_application', appInstance.application);
+    window.EmberInspector.set('owner', appInstance);
+    window.EmberInspector.start(true);
   }
 
   function onEmberReady(callback) {
@@ -153,7 +155,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
       }
 
       if (message.type === 'app-selected') {
-        let current = Ember.EmberInspectorDebugger._application;
+        let current = window.EmberInspector._application;
         let selected = getApplications().find(app => Ember.guidFor(app) === message.applicationId);
 
         if (current !== selected && selected.__deprecatedInstance__) {


### PR DESCRIPTION
Closes https://github.com/emberjs/ember-inspector/issues/1758

No idea if this is the best way of solving it.

But since we're moving away from the `Ember` global a change such as this seemed reasonable, and respects the existing code (this change is minimal), since `window.EmberInspector` already existed.

Deleted `Ember.EmberInspectorDebugger` altogether, since it's not used elsewhere and I cannot find any code in Github (across all projects) that rely on it.

https://github.com/search?q=EmberInspectorDebugger&type=code