### PR TITLE
Update publish-chrome action to use node 14.X

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Set up Volta
         uses: volta-cli/action@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: Install dependencies (chrome-webstore-upload-cli)
         run: volta install chrome-webstore-upload-cli
       - name: Download artifacts (Chrome)


### PR DESCRIPTION
The latest version of chrome-webstore-upload-cli uses optional chaining (?. syntax), which is not supported until Node 14 (without polyfills). Updated the publish-chrome action to use node 14. Left the other actions on 12 for now because I'm not too comfortable with github actions or this repo.

Note: I was unable to test this locally - I am not sure how to run/test GitHub actions on local, but I fairly certain this should work. 

I just really want to get the Chrome extension updated so that I can update our apps to 3.28 :)
