### PR TITLE
docs(readme): change order of installation hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ OR:
 
 - Clone the repository
 - cd into the repo directory
-- run `yarn install`
 - run `yarn global add ember-cli`
+- run `yarn install`
 - run `yarn build` to build the `dist` directory
 - Visit `chrome://extensions` in Chrome
 - Make sure `Developer mode` is checked
@@ -30,8 +30,8 @@ OR:
 
 - Clone the repository
 - cd into the repo directory
-- run `yarn install`
 - run `yarn global add ember-cli`
+- run `yarn install`
 - run `yarn build` to build the `dist` directory
 - Visit `about:debugging` in Firefox
 - Click on 'Load Temporary Addon-on'
@@ -41,8 +41,8 @@ OR:
 
 - Clone the repository
 - cd into the repo directory
-- run `yarn install`
 - run `yarn global add ember-cli`
+- run `yarn install`
 - run `yarn build` to build the `dist` directory
 - Visit `chrome://extensions` in Opera
 - Make sure `Developer mode` is checked


### PR DESCRIPTION
## Description
Comming from a clean slate (fresh OS) I had to install `ember-cli` first, then run `yarn install` and finally I could `yarn build`. Otherwise this error occures:
```bash
❯ yarn build
yarn run v1.22.17
$ ember build
Cannot find module 'ember-cli-version-checker'
Require stack:
- /home/username/Dev/ember-inspector/lib/ui/index.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/models/package-info-cache/package-info.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/models/package-info-cache/index.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/models/project.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/utilities/get-config.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/utilities/instrumentation.js
- /home/username/.config/yarn/global/node_modules/ember-cli/lib/cli/index.js
- /home/username/.config/yarn/global/node_modules/ember-cli/bin/ember


Stack Trace and Error Report: /tmp/error.dump.7828ebcdefdbb5e72f037ecce04b2d34.log
error Command failed with exit code 1.
```
This behavior makes sense, since the `ember-cli-version-checker` depends on `ember-cli` which is existing in the `devDependencies` but I will miss the link to the global `ember-cli` when we run `yarn global add ember-cli` after `yarn install`.
