### PR TITLE
Remove support for the TargetActionSupport mixin

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -35,7 +35,6 @@ const {
   MutableEnumerable,
   NativeArray,
   ObjectProxy,
-  TargetActionSupport,
 } = Ember;
 
 const GlimmerComponent = (() => {
@@ -92,12 +91,15 @@ const emberNames = new Map([
   [NativeArray, 'NativeArray Mixin'],
   [Observable, 'Observable Mixin'],
   [ControllerMixin, 'Controller Mixin'],
-  [TargetActionSupport, 'TargetActionSupport Mixin'],
   [ActionHandler, 'ActionHandler Mixin'],
   [CoreObject, 'CoreObject'],
   [EmberObject, 'EmberObject'],
   [Component, 'Component'],
 ]);
+
+if (compareVersion(VERSION, '3.27.0') === -1) {
+  emberNames.set(Ember.TargetActionSupport, 'TargetActionSupport Mixin');
+}
 
 try {
   const Views = Ember.__loader.require('@ember/-internals/views');


### PR DESCRIPTION

## Description
This mixin triggers a deprecation warning in Ember 3.28 applications.

Closes #1939 