### PR TITLE
component-tree: make left/right arrow nav in certain conditions (fixes #1537)

### DIFF
--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -200,15 +200,31 @@ export default class ComponentTreeController extends Controller {
       case KEYS.up:
         this.pinned = this.previousItem.id;
         break;
-      case KEYS.right:
-        this.findItem(this.pinned).expand();
+      case KEYS.right: {
+        const pinnedItem = this.findItem(this.pinned);
+
+        if (pinnedItem.isExpanded) {
+          this.pinned = this.nextItem.id;
+        } else {
+          pinnedItem.expand();
+        }
+
         break;
+      }
       case KEYS.down:
         this.pinned = this.nextItem.id;
         break;
-      case KEYS.left:
-        this.findItem(this.pinned).collapse();
+      case KEYS.left: {
+        const pinnedItem = this.findItem(this.pinned);
+
+        if (pinnedItem.isExpanded) {
+          pinnedItem.collapse();
+        } else {
+          this.pinned = pinnedItem.parentItem.id;
+        }
+
         break;
+      }
     }
   }
 
@@ -251,12 +267,14 @@ function arrowKeyPressed(keyCode) {
 }
 
 class RenderItem {
-  @tracked isExpanded = true;
+  @tracked isExpanded;
 
   constructor(controller, parentItem, renderNode) {
     this.controller = controller;
     this.parentItem = parentItem;
     this.renderNode = renderNode;
+
+    this.isExpanded = this.isExpandable;
   }
 
   get id() {
@@ -341,6 +359,10 @@ class RenderItem {
     return children;
   }
 
+  get isExpandable() {
+    return this.hasChildren;
+  }
+
   get isVisible() {
     if (this.isRoot) {
       return true;
@@ -420,18 +442,22 @@ class RenderItem {
   }
 
   expand(deep = false) {
-    this.isExpanded = true;
+    if (this.isExpandable) {
+      this.isExpanded = true;
 
-    if (deep === true) {
-      this.childItems.forEach((child) => child.expand(true));
+      if (deep === true) {
+        this.childItems.forEach((child) => child.expand(true));
+      }
     }
   }
 
   collapse(deep = false) {
-    this.isExpanded = false;
+    if (this.isExpandable) {
+      this.isExpanded = false;
 
-    if (deep === true) {
-      this.childItems.forEach((child) => child.collapse(true));
+      if (deep === true) {
+        this.childItems.forEach((child) => child.collapse(true));
+      }
     }
   }
 

--- a/tests/acceptance/component-tree-test.js
+++ b/tests/acceptance/component-tree-test.js
@@ -113,6 +113,7 @@ function getRenderTree() {
               id: 4,
               name: 'todo-item',
               args: Args({ names: ['subTasks'], positionals: 0 }),
+              instance: Serialized('ember789'),
             })
           )
         )
@@ -209,7 +210,7 @@ module('Component Tab', function (hooks) {
   });
 
   test('It allows users to navigate nodes with arrow keys', async function (assert) {
-    assert.expect(3);
+    assert.expect(6);
 
     await visit('/component-tree');
 
@@ -229,10 +230,34 @@ module('Component Tab', function (hooks) {
     });
     await triggerKeyEvent(document, 'keydown', 40);
 
+    // select next node with right arrow key
+    respondWith('view:showInspection', false);
+    respondWith('objectInspector:inspectById', ({ objectId }) => {
+      assert.equal(objectId, 'ember456');
+      return false;
+    });
+    await triggerKeyEvent(document, 'keydown', 39);
+
+    // select next node with right arrow key
+    respondWith('view:showInspection', false);
+    respondWith('objectInspector:inspectById', ({ objectId }) => {
+      assert.equal(objectId, 'ember789');
+      return false;
+    });
+    await triggerKeyEvent(document, 'keydown', 39);
+
+    // select previous node with left arrow key
+    respondWith('view:showInspection', false);
+    respondWith('objectInspector:inspectById', ({ objectId }) => {
+      assert.equal(objectId, 'ember456');
+      return false;
+    });
+    await triggerKeyEvent(document, 'keydown', 37);
+
     // select previous node with up arrow key
     respondWith('view:showInspection', false);
     respondWith('objectInspector:inspectById', ({ objectId }) => {
-      assert.equal(objectId, 'ember123');
+      assert.equal(objectId, 'ember2');
       return false;
     });
     await triggerKeyEvent(document, 'keydown', 38);


### PR DESCRIPTION
## Description

Right now, the left and right arrow keyboard shortcuts will collapse and
expand the currently selected node in the component tree respectively.

It would be nice (and more consistent with devtools) if:
- the left arrow keyboard shortcut would jump to the parent node if the
  currently selected node is already collapsed
- the right arrow keyboard shortcut would jump to the child node if the
  currently selected node is already expanded
