### PR TITLE
object-inspector: migrate to glimmer component

### DIFF
--- a/app/components/object-inspector.js
+++ b/app/components/object-inspector.js
@@ -1,70 +1,69 @@
-import Component from '@ember/component';
-import { action, computed, get } from '@ember/object';
+import Component from '@glimmer/component';
+import { action, get } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { gt } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
 
-export default Component.extend({
-  port: service(),
+export default class ObjectInspector extends Component {
+  @service port;
 
-  tagName: '',
+  @tracked propDisplayType = 'grouped';
+  @tracked customFilter = '';
 
-  propDisplayType: 'grouped',
-  customFilter: '',
-
-  init() {
-    this._super(...arguments);
+  constructor() {
+    super(...arguments);
     this.searchInputId = 'custom-filter-input';
-  },
+  }
 
-  trail: computed('model.[]', function () {
-    let nested = this.model.slice(1);
+  get trail() {
+    let nested = this.args.model.slice(1);
     if (nested.length === 0) {
       return '';
     }
     return `.${nested.mapBy('property').join('.')}`;
-  }),
+  }
 
-  isNested: gt('model.length', 1),
+  get isNested() {
+    return this.args.model.length > 1;
+  }
 
-  setPropDisplay: action(function (type) {
+  @action setPropDisplay(type) {
     // The custom filter is only working for the "all" table yet
     // Otherwise, we reset the customFilter input value
     if (type !== 'all') {
-      this.set('customFilter', '');
+      this.customFilter = '';
     }
 
-    this.set('propDisplayType', type);
-  }),
+    this.propDisplayType = type;
+  }
 
-  setCustomFilter: action(function (event) {
+  @action setCustomFilter(event) {
     let { value } = event.target;
-    this.setProperties({
-      propDisplayType: 'all',
-      customFilter: value,
-    });
-  }),
 
-  clearCustomFilter: action(function () {
+    this.propDisplayType = 'all';
+    this.customFilter = value;
+  }
+
+  @action clearCustomFilter() {
     document.querySelector('#' + this.searchInputId).focus();
-    this.set('customFilter', '');
-  }),
+    this.customFilter = '';
+  }
 
-  sendObjectToConsole: action(function (obj) {
+  @action sendObjectToConsole(obj) {
     let objectId = get(obj, 'objectId');
     this.port.send('objectInspector:sendToConsole', {
       objectId,
     });
-  }),
+  }
 
-  popStack: action(function () {
+  @action popStack() {
     if (this.isNested) {
-      this.popMixinDetails();
+      this.args.popMixinDetails();
     }
-  }),
+  }
 
-  traceErrors: action(function (objectId) {
+  @action traceErrors(objectId) {
     this.port.send('objectInspector:traceErrors', {
       objectId,
     });
-  }),
-});
+  }
+}


### PR DESCRIPTION
Let's upgrade the object-inspector component to extend '@glimmer/component'
rather than '@ember/component'. While we're here, let's also upgrade the
component to use native JS syntax.