### PR TITLE
properties-base, properties-grouped, properties-all: octane/glimmer upgrade 

### DIFF
--- a/app/components/object-inspector/properties-all.js
+++ b/app/components/object-inspector/properties-all.js
@@ -1,4 +1,4 @@
-import { action, computed } from '@ember/object';
+import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import PropertiesBase from 'ember-inspector/components/object-inspector/properties-base';
 
@@ -8,31 +8,30 @@ const findMixin = function (mixins, property) {
   });
 };
 
-export default PropertiesBase.extend({
-  port: service(),
+export default class PropertiesAll extends PropertiesBase {
+  @service port;
 
-  tagName: '',
-
-  calculate: action(function (property) {
-    const mixin = findMixin(this.get('model.mixins'), property);
+  @action calculate(property) {
+    const mixin = findMixin(this.args.model.mixins, property);
 
     this.port.send('objectInspector:calculate', {
-      objectId: this.model.objectId,
-      mixinIndex: this.get('model.mixins').indexOf(mixin),
+      objectId: this.args.model.objectId,
+      mixinIndex: this.args.model.mixins.indexOf(mixin),
       property: property.name,
     });
-  }),
+  }
 
-  flatPropertyList: computed('customFilter', 'model.mixins', function () {
-    const props = this.get('model.mixins').map(function (mixin) {
+  get flatPropertyList() {
+    const props = this.args.model.mixins.map(function (mixin) {
       return mixin.properties.filter(function (p) {
-        let shoulApplyCustomFilter = this.customFilter
-          ? p.name.toLowerCase().indexOf(this.customFilter.toLowerCase()) > -1
+        let shoulApplyCustomFilter = this.args.customFilter
+          ? p.name.toLowerCase().indexOf(this.args.customFilter.toLowerCase()) >
+            -1
           : true;
         return !p.hasOwnProperty('overridden') && shoulApplyCustomFilter;
       }, this);
     }, this);
 
     return props.flat();
-  }),
-});
+  }
+}

--- a/app/components/object-inspector/properties-all.js
+++ b/app/components/object-inspector/properties-all.js
@@ -24,11 +24,11 @@ export default class PropertiesAll extends PropertiesBase {
   get flatPropertyList() {
     const props = this.args.model.mixins.map(function (mixin) {
       return mixin.properties.filter(function (p) {
-        let shoulApplyCustomFilter = this.args.customFilter
+        let shouldApplyCustomFilter = this.args.customFilter
           ? p.name.toLowerCase().indexOf(this.args.customFilter.toLowerCase()) >
             -1
           : true;
-        return !p.hasOwnProperty('overridden') && shoulApplyCustomFilter;
+        return !p.hasOwnProperty('overridden') && shouldApplyCustomFilter;
       }, this);
     }, this);
 

--- a/app/components/object-inspector/properties-base.js
+++ b/app/components/object-inspector/properties-base.js
@@ -1,35 +1,33 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { action } from '@ember/object';
 
-export default Component.extend({
-  port: service(),
+export default class PropertiesBase extends Component {
+  @service port;
 
-  tagName: '',
-
-  sendToConsole: action(function ({ name }) {
+  @action sendToConsole({ name }) {
     const data = {
-      objectId: this.model.objectId,
+      objectId: this.args.model.objectId,
     };
     if (name !== '...') {
       data.property = name;
     }
     this.port.send('objectInspector:sendToConsole', data);
-  }),
+  }
 
-  digDeeper: action(function ({ name }) {
+  @action digDeeper({ name }) {
     this.port.send('objectInspector:digDeeper', {
-      objectId: this.model.objectId,
+      objectId: this.args.model.objectId,
       property: name,
     });
-  }),
+  }
 
-  saveProperty: action(function (property, value, dataType) {
+  @action saveProperty(property, value, dataType) {
     this.port.send('objectInspector:saveProperty', {
-      objectId: this.model.objectId,
+      objectId: this.args.model.objectId,
       property,
       value,
       dataType,
     });
-  }),
-});
+  }
+}

--- a/app/components/object-inspector/properties-grouped.js
+++ b/app/components/object-inspector/properties-grouped.js
@@ -2,16 +2,14 @@ import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import PropertiesBase from 'ember-inspector/components/object-inspector/properties-base';
 
-export default PropertiesBase.extend({
-  port: service(),
+export default class PropertiesGrouped extends PropertiesBase {
+  @service port;
 
-  tagName: '',
-
-  calculate: action(function ({ name }, mixin) {
+  @action calculate({ name }, mixin) {
     this.port.send('objectInspector:calculate', {
-      objectId: this.model.objectId,
-      mixinIndex: this.get('model.mixins').indexOf(mixin),
+      objectId: this.args.model.objectId,
+      mixinIndex: this.args.model.mixins.indexOf(mixin),
       property: name,
     });
-  }),
-});
+  }
+}


### PR DESCRIPTION
## Description

object-inspector: update prop classes to glimmer
    
    Let's update the PropertiesBase component to extend from
    @glimmer/component rather than @ember/component. While we're here, let's
    update PropertiesBase and its child classes PropertiesAll and
    PropertiesGrouped to use native JS syntax.

properties-all: fixup misspelling in var name
    
    Let's rename 'shoulApplyCustomFilter' to 'shouldApplyCustomFilter' as
    'shoul' is just a typo for 'should'.