### PR TITLE
deprecations: resolve instances of this-property-fallback

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -8,7 +8,6 @@ module.exports = {
 
     // TODO: enable these rules
     'no-action': false,
-    'no-implicit-this': false,
     'no-positive-tabindex': false,
     'table-groups': false,
   },

--- a/app/components/list-content.hbs
+++ b/app/components/list-content.hbs
@@ -2,11 +2,11 @@
   <div class="list__table-container">
     <table>
       <colgroup>
-        {{#each columns as |column|}}
+        {{#each this.columns as |column|}}
           <col style={{build-style width=(concat column.width "px")}} />
         {{/each}}
       </colgroup>
-      {{yield (hash rowEvents=rowEvents)}}
+      {{yield (hash rowEvents=this.rowEvents)}}
     </table>
   </div>
 </div>

--- a/app/components/list.hbs
+++ b/app/components/list.hbs
@@ -1,15 +1,15 @@
-{{#if schema.columns.length}}
+{{#if this.schema.columns.length}}
   <div class="list__header">
     <div class="list__table-container">
       <table>
         <colgroup>
-          {{#each columns key="id" as |column|}}
+          {{#each this.columns key="id" as |column|}}
             <col style={{build-style width=(concat column.width "px")}}>
           {{/each}}
         </colgroup>
         <tbody>
           <tr class="list__row">
-            {{#each columns key="id" as |column|}}
+            {{#each this.columns key="id" as |column|}}
               <ListCell
                 class="js-header-column"
                 @tagName="th"
@@ -40,8 +40,8 @@
   }}
 </ListContent>
 
-{{#each columns key="id" as |column|}}
-  {{#if (and column.visible (not-eq column columns.lastObject))}}
+{{#each this.columns key="id" as |column|}}
+  {{#if (and column.visible (not-eq column this.columns.lastObject))}}
     <Ui::DragHandle
       @faded={{true}}
       @left={{column.left}}

--- a/app/components/promise-item.hbs
+++ b/app/components/promise-item.hbs
@@ -45,7 +45,7 @@
         <span
           class="list__link js-promise-object-value"
           role="button"
-          {{on "click" (fn @inspectObject settledValue.objectId)}}
+          {{on "click" (fn @inspectObject this.settledValue.objectId)}}
         >
           {{this.settledValue.inspect}}
         </span>

--- a/app/components/promise-tree-toolbar.hbs
+++ b/app/components/promise-tree-toolbar.hbs
@@ -5,7 +5,7 @@
   />
 
   {{! if should refresh the refresh button will be in the middle of the of the tab }}
-  {{#unless shouldRefresh}}
+  {{#unless this.shouldRefresh}}
     <Ui::ToolbarDivider />
     <Ui::ToolbarReloadButton
       @action={{@refreshPage}}

--- a/app/components/render-item.hbs
+++ b/app/components/render-item.hbs
@@ -5,7 +5,7 @@
     style={{this.nodeStyle}}
     class="list__row js-render-profile-item"
   >
-    {{#list.cell
+    {{#@list.cell
       class="list__cell_main js-render-main-cell"
       on-click=disclosure.toggle
       style=this.nameStyle
@@ -17,17 +17,17 @@
       <span title={{@model.name}}>
         <span class="js-render-profile-name">{{@model.name}}</span>
       </span>
-    {{/list.cell}}
+    {{/@list.cell}}
 
-    {{#list.cell class="list__cell_value_numeric"}}
+    {{#@list.cell class="list__cell_value_numeric"}}
       <span class="pill js-render-profile-duration">
         {{ms-to-time @model.duration}}
       </span>
-    {{/list.cell}}
+    {{/@list.cell}}
 
-    {{#list.cell class="list__cell_value_numeric js-render-profile-timestamp"}}
+    {{#@list.cell class="list__cell_value_numeric js-render-profile-timestamp"}}
       {{this.readableTime}}
-    {{/list.cell}}
+    {{/@list.cell}}
   </tr>
 
   {{#if disclosure.isExpanded}}

--- a/app/templates/app-config.hbs
+++ b/app/templates/app-config.hbs
@@ -1,7 +1,7 @@
 <EmberTable as |t|>
-  <t.head @columns={{columns}} @enableReorder={{false}} />
+  <t.head @columns={{this.columns}} @enableReorder={{false}} />
 
-  <t.body @rows={{rows}} as |b|>
+  <t.body @rows={{this.rows}} as |b|>
     <b.row
       class={{
         concat "js-config-row" (if (mod b.rowMeta.index 2) " striped")

--- a/app/templates/container-type.hbs
+++ b/app/templates/container-type.hbs
@@ -1,7 +1,7 @@
 {{#if this.toolbarContainer}}
   {{#in-element this.toolbarContainer}}
     <ContainerTypeToolbar
-      @reload={{action send "reload"}}
+      @reload={{action this.send "reload"}}
       @searchValue={{this.searchValue}}
       @sendContainerToConsole={{this.sendContainerToConsole}}
     />

--- a/app/templates/container-types.hbs
+++ b/app/templates/container-types.hbs
@@ -1,6 +1,6 @@
 <ItemTypes
   @header="Types"
-  @sorted={{readonly sorted}}
+  @sorted={{readonly this.sorted}}
   @type="container"
   @width={{180}}
 >

--- a/app/templates/container-types/index.hbs
+++ b/app/templates/container-types/index.hbs
@@ -1,7 +1,7 @@
 {{#if this.toolbarContainer}}
   {{#in-element this.toolbarContainer}}
     <ContainerTypesToolbar
-      @reload={{action send "reload"}}
+      @reload={{action this.send "reload"}}
       @sendContainerToConsole={{this.sendContainerToConsole}}
     />
   {{/in-element}}

--- a/app/templates/deprecations.hbs
+++ b/app/templates/deprecations.hbs
@@ -2,16 +2,16 @@
   {{#in-element this.toolbarContainer}}
     <DeprecationsToolbar
       @changeDeprecationWorkflow={{this.changeDeprecationWorkflow}}
-      @clear={{action send "clear"}}
+      @clear={{action this.send "clear"}}
       @searchValue={{this.searchValue}}
       @toggleDeprecationWorkflow={{this.toggleDeprecationWorkflow}}
     />
   {{/in-element}}
 {{/if}}
 
-{{#if filtered.length}}
+{{#if this.filtered.length}}
   <div class="list__content js-deprecations">
-    {{#vertical-collection filtered estimateHeight=20 as |content|}}
+    {{#vertical-collection this.filtered estimateHeight=20 as |content|}}
       <DeprecationItem
         @model={{content}}
         @openResource={{this.openResource}}

--- a/app/templates/libraries.hbs
+++ b/app/templates/libraries.hbs
@@ -7,7 +7,7 @@
 <EmberTable as |t|>
   <t.head @columns={{schema-for "info-list"}} @enableReorder={{false}} />
 
-  <t.body @rows={{rows}} as |b|>
+  <t.body @rows={{this.rows}} as |b|>
     <b.row
       class={{
         concat "js-library-row" (if (mod b.rowMeta.index 2) " striped")

--- a/app/templates/model-types.hbs
+++ b/app/templates/model-types.hbs
@@ -4,7 +4,7 @@
       @getStore={{this.getStore}}
       @hideEmptyModelTypes={{this.hideEmptyModelTypes}}
       @orderByRecordCount={{this.orderByRecordCount}}
-      @reload={{action send "reload"}}
+      @reload={{action this.send "reload"}}
     />
   {{/in-element}}
 {{/if}}

--- a/app/templates/promise-tree.hbs
+++ b/app/templates/promise-tree.hbs
@@ -4,7 +4,7 @@
       @clear={{this.clear}}
       @filter={{this.filter}}
       @instrumentWithStack={{this.instrumentWithStack}}
-      @refreshPage={{action send "refreshPage"}}
+      @refreshPage={{action this.send "refreshPage"}}
       @searchValue={{this.searchValue}}
       @setFilter={{this.setFilter}}
       @updateInstrumentWithStack={{this.updateInstrumentWithStack}}

--- a/app/templates/render-tree.hbs
+++ b/app/templates/render-tree.hbs
@@ -1,8 +1,8 @@
 {{#if this.toolbarContainer}}
   {{#in-element this.toolbarContainer}}
     <RenderTreeToolbar
-      @clearProfiles={{action send "clearProfiles"}}
-      @refreshPage={{action send "refreshPage"}}
+      @clearProfiles={{action this.send "clearProfiles"}}
+      @refreshPage={{action this.send "refreshPage"}}
       @searchValue={{this.searchValue}}
       @showEmpty={{this.showEmpty}}
       @shouldHighlightRender={{this.shouldHighlightRender}}

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -12,7 +12,6 @@ self.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'implicit-injections' },
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
     { handler: 'silence', matchId: 'route-render-template' },
-    { handler: 'silence', matchId: 'this-property-fallback' },
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'globals-resolver' },
   ],

--- a/tests/integration/components/component-tree-arg-test.js
+++ b/tests/integration/components/component-tree-arg-test.js
@@ -15,14 +15,14 @@ module('Integration | Component | component-tree-arg', function (hooks) {
 
   test('it should correctly render an object argument', async function (assert) {
     this.objectArgs = { testKey: 'test' };
-    await render(hbs`<ComponentTreeArg @value={{objectArgs}} />`);
+    await render(hbs`<ComponentTreeArg @value={{this.objectArgs}} />`);
     assert.dom('[data-test-arg-object]').hasText('...');
   });
 
   test('it should correctly if the argument is not a string or an object', async function (assert) {
     this.falseArgs = false;
 
-    await render(hbs`<ComponentTreeArg @value={{falseArgs}} />`);
+    await render(hbs`<ComponentTreeArg @value={{this.falseArgs}} />`);
     assert.dom('[data-test-arg-string]').hasText('false');
   });
 });


### PR DESCRIPTION
## Description

It is currently possible to reference properties on a component without
a preceding `this`. This style of looking up properties is known as
"property fallback", and has the potential to collide with other types
of values. The alternative way to lookup properties is with a preceding
`this`. This style does not have any ambiguity, since it's clear that
we're looking up the property on this instance of the component, and not
the global helper/component. Property fallback has been deprecated in
favor of this style in general.

As such, let's work through all of our templates in order to eliminate any
instances of this issue. Finally, let's stop silencing violations of this
deprecation in our deprecation-workflow config file. This will ensure that
future violations are not added to the codebase.

## Screenshots
n/a