### PR TITLE
deprecations: fix instances of routing-transition-methods

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -7,6 +7,7 @@ const { NativeArray } = Ember;
 export default class ApplicationRoute extends Route {
   @service adapter;
   @service port;
+  @service router;
 
   setupController(controller) {
     controller.set('mixinStack', []);
@@ -32,7 +33,7 @@ export default class ApplicationRoute extends Route {
   }
 
   inspectComponent({ id }) {
-    this.transitionTo('component-tree', {
+    this.router.transitionTo('component-tree', {
       queryParams: {
         pinned: id,
       },
@@ -40,7 +41,7 @@ export default class ApplicationRoute extends Route {
   }
 
   previewComponent({ id }) {
-    this.transitionTo('component-tree', {
+    this.router.transitionTo('component-tree', {
       queryParams: {
         previewing: id,
       },

--- a/app/routes/container-type.js
+++ b/app/routes/container-type.js
@@ -5,6 +5,7 @@ import TabRoute from 'ember-inspector/routes/tab';
 
 export default class ContainerTypeRoute extends TabRoute {
   @service port;
+  @service router;
 
   model(params) {
     const type = params.type_id;
@@ -32,7 +33,7 @@ export default class ContainerTypeRoute extends TabRoute {
   @action
   error(err) {
     if (err && err.status === 404) {
-      this.transitionTo('container-types.index');
+      this.router.transitionTo('container-types.index');
       return false;
     }
   }

--- a/app/routes/data/index.js
+++ b/app/routes/data/index.js
@@ -4,6 +4,7 @@ import { Promise } from 'rsvp';
 
 export default class IndexRoute extends Route {
   @service port;
+  @service router;
 
   model() {
     return new Promise((resolve) => {
@@ -16,7 +17,7 @@ export default class IndexRoute extends Route {
 
   afterModel(model) {
     if (model) {
-      this.transitionTo('model-types');
+      this.router.transitionTo('model-types');
     }
   }
 }

--- a/app/routes/info-index.js
+++ b/app/routes/info-index.js
@@ -1,7 +1,10 @@
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class InfoIndexRoute extends Route {
+  @service router;
+
   beforeModel() {
-    this.transitionTo('libraries');
+    this.router.transitionTo('libraries');
   }
 }

--- a/app/routes/launch.js
+++ b/app/routes/launch.js
@@ -12,6 +12,7 @@ const STORE_KEY = 'last-version-opened';
 export default class LaunchRoute extends Route {
   @service config;
   @service storage;
+  @service router;
 
   @readOnly('config.VERSION') version;
 
@@ -28,7 +29,7 @@ export default class LaunchRoute extends Route {
         targetRoute = 'whats-new';
       }
 
-      this.transitionTo(targetRoute);
+      this.router.transitionTo(targetRoute);
     });
   }
 

--- a/app/routes/model-type.js
+++ b/app/routes/model-type.js
@@ -1,8 +1,11 @@
 import { get } from '@ember/object';
+import { inject as service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { Promise } from 'rsvp';
 
 export default class ModelTypeRoute extends Route {
+  @service router;
+
   model(params) {
     return new Promise((resolve) => {
       const type = this.modelFor('model-types').findBy(
@@ -12,7 +15,7 @@ export default class ModelTypeRoute extends Route {
       if (type) {
         resolve(type);
       } else {
-        this.transitionTo('model-types.index');
+        this.router.transitionTo('model-types.index');
       }
     });
   }

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -13,7 +13,6 @@ self.deprecationWorkflow.config = {
     { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
     { handler: 'silence', matchId: 'route-render-template' },
     { handler: 'silence', matchId: 'this-property-fallback' },
-    { handler: 'silence', matchId: 'routing.transition-methods' },
     { handler: 'silence', matchId: 'ember-metal.get-with-default' },
     { handler: 'silence', matchId: 'globals-resolver' },
   ],


### PR DESCRIPTION
## Description

The methods transitionTo and replaceWith of the Route have been
deprecated in order to reduce the API surface related to routing.
Instead, we should inject the Router Service and use its transitionTo()
method.

## Screenshots

n/a