### PR TITLE
list: fixup dot access for run.bind deprecation

### DIFF
--- a/app/components/list.js
+++ b/app/components/list.js
@@ -1,6 +1,6 @@
 /* eslint-disable ember/require-tagless-components */
 import Component from '@ember/component';
-import { run, scheduleOnce } from '@ember/runloop';
+import { bind, scheduleOnce } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
 import ResizableColumns from 'ember-inspector/libs/resizable-columns';
 import { inject as service } from '@ember/service';
@@ -165,7 +165,7 @@ export default Component.extend({
         arr.push({
           name,
           title: name,
-          fn: run.bind(this, this.toggleColumnVisibility, id),
+          fn: bind(this, this.toggleColumnVisibility, id),
         });
         return arr;
       }, []);


### PR DESCRIPTION
## Description
Since Ember 3.27, using . to access run loop functions has been
deprecated, such as run.bind. Instead, we must import the value directly
from the module like so:

import { bind } from '@ember/runloop';

See the deprecated-run-loop-and-computed-dot-access rule in ember's
deprecation-app for more details.

## Screenshots
n/a 