### PR TITLE
deprecations: fixup instances of no-inline-styles

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     // TODO: enable these rules
     'no-action': false,
     'no-implicit-this': false,
-    'no-inline-styles': false,
     'no-positive-tabindex': false,
     'table-groups': false,
   },

--- a/app/styles/deprecations.scss
+++ b/app/styles/deprecations.scss
@@ -1,3 +1,7 @@
+.js-deprecations {
+  height: 100%;
+}
+
 .deprecation-item {
   border-bottom: 1px solid var(--base01);
 

--- a/app/templates/deprecations.hbs
+++ b/app/templates/deprecations.hbs
@@ -10,7 +10,7 @@
 {{/if}}
 
 {{#if filtered.length}}
-  <div class="list__content js-deprecations" style="height: 100%;">
+  <div class="list__content js-deprecations">
     {{#vertical-collection filtered estimateHeight=20 as |content|}}
       <DeprecationItem
         @model={{content}}


### PR DESCRIPTION
## Description
ember-template-lint's no-inline-styles rule forbids using inline styles
as they are often harder to maintain and can make the overall size of
the project bigger. It recommends using css classes instead.

Let's fixup any instances of this issue in the codebase and then
re-enable the rule in our template-lintrc so that the linter will help
us avoid adding more instances of this in the future.

## Screenshots
n/a