### PR TITLE
template-lintrc: enable 'table-groups' rule

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -9,6 +9,5 @@ module.exports = {
     // TODO: enable these rules
     'no-action': false,
     'no-positive-tabindex': false,
-    'table-groups': false,
   },
 };


### PR DESCRIPTION
## Description

Right now, we disable the 'table-groups' linting rule. This rule helps
to ensure that table rows are grouped into one of: thead, tbody, tfoot,
helps avoid relying upon a (possibly to be deprecated) feature of
glimmer that auto-inserts these tags, and enforces that children of
<table> are ordered correctly. As such, it would be ideal to have this
enabled.

We don't have any outstanding issues that would cause errors to be
thrown by the linter by enabling this, so let's go ahead and do so.


## Screenshots
n/a