### PR TITLE
eslintrc: enable 'no-actions-hash' lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,6 @@ module.exports = {
     'ember/avoid-leaking-state-in-ember-objects': 'off',
     'ember/classic-decorator-hooks': 'off',
     'ember/classic-decorator-no-classic-methods': 'off',
-    'ember/no-actions-hash': 'off',
     'ember/no-classic-classes': 'off',
     'ember/no-classic-components': 'off',
     'ember/no-component-lifecycle-hooks': 'off',


### PR DESCRIPTION
## Description
As of Ember Octane, the actions hash and {{action}} modifier and helper
are no longer needed.  We should instead use the @action decorator or
`foo: action(function() {}))` syntax instead.

Right now, we've disabled the 'no-actions-hash' eslint rule. We do not
currently have any issues of this nature, so let's go ahead and
re-enable the rule so that the linter will warn us against creating new
issues of this type going forward.

## Screenshots
n/a