### PR TITLE
eslintrc: enable no-test-import-export rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,6 @@ module.exports = {
     'ember/no-component-lifecycle-hooks': 'off',
     'ember/no-computed-properties-in-native-classes': 'off',
     'ember/no-get': 'off',
-    'ember/no-test-import-export': 'off',
 
     // Best practice
     'no-duplicate-imports': 'error',


### PR DESCRIPTION
## Description
Due to how qunit unloads a test module, importing a test file will cause
any modules and tests within the file to be executed every time it gets
loaded.

The no-test-import-export eslint rule will help us avoid this by
checking for any imports or exports from *-test.js files.

As we don't have any outstanding issues of this nature, let's go ahead
and re-enable the rule so that the linter will help us avoid adding any
going forward.

## Screenshots
n/a