### PR TITLE
resizable-column: convert to glimmer

### DIFF
--- a/lib/ui/addon/components/resizable-column.js
+++ b/lib/ui/addon/components/resizable-column.js
@@ -1,14 +1,10 @@
-import { tagName } from '@ember-decorators/component';
-import { computed } from '@ember/object';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 
-@tagName('')
 export default class ResizableColumn extends Component {
-  width = null;
-
-  @computed('width')
   get style() {
-    return htmlSafe(`-webkit-flex: none; flex: none; width: ${this.width}px;`);
+    return htmlSafe(
+      `-webkit-flex: none; flex: none; width: ${this.args.width}px;`
+    );
   }
 }


### PR DESCRIPTION
## Description
Right now, the resizable-column component is a classic component. For
this particular component, migrating to Glimmer will allow us to take
advantage of the simpler API, no wrapper element, and namespaced
arguments.

As such, let's go ahead and migrate over resizable-column so that it
extends glimmer/component instead of ember/component.

## Screenshots
n/a