### PR TITLE
object-inspector-test: fix legacy-attribute-arguments issue

### DIFF
--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -96,7 +96,7 @@ module('Ember Debug - Object Inspector', function (hooks) {
     this.owner.register('component:x-simple', Component);
     this.owner.register(
       'template:simple',
-      hbs`Simple {{input class="simple-input"}} {{x-simple class="simple-view"}}`
+      hbs`Simple <Input class="simple-input"/> {{x-simple class="simple-view"}}`
     );
 
     objectInspector = EmberDebug.get('objectInspector');


### PR DESCRIPTION
## Description
Right now, when we run the 'Views are correctly handled when destroyed
during transitions' test from the 'Ember Debug - Object Inspector'
suite, there is a deprecation logged along the lines of:

    Passing the `@class` argument to <Input> is deprecated. Instead,
    please pass the attribute directly, i.e. `<Input class={{...}} />`
    instead of `<Input @class={{...}} />` or `{{input class=...}}`.

Let's fix this deprecation by preferring angle bracket syntax for the
input component. This will help avoid having an unnecessary deprecation
show up in the test output.

## Screenshots
n/a