### PR TITLE
route-debug-test: avoid 'view:renderTree' race condition

### DIFF
--- a/tests/ember_debug/route-debug-test.js
+++ b/tests/ember_debug/route-debug-test.js
@@ -1,4 +1,4 @@
-import { settled, visit } from '@ember/test-helpers';
+import { settled, visit, waitUntil } from '@ember/test-helpers';
 import { get } from '@ember/object';
 import { run } from '@ember/runloop';
 import Route from '@ember/routing/route';
@@ -43,6 +43,12 @@ module('Ember Debug - Route Tree', function (hooks) {
     });
 
     await visit('/');
+    await waitUntil(
+      () => {
+        return name === 'view:renderTree';
+      },
+      { timeout: 3000 }
+    );
 
     run(EmberDebug.port, 'trigger', 'route:getTree');
     await settled();


### PR DESCRIPTION
## Description
Right now, the 'Route tree' test from the 'Ember Debug - Route Tree' has
a race condition between receiving the 'view:renderTree' message and
triggering 'route:getTree'.

The 'view:renderTree' message is sent after a 250ms debounce once a tree
is finished being profiled by the ProfileManager, so settled() isn't
going to be able to cover that operation.

To work around this, let's waitUntil we receive the 'view:renderTree'
message before proceeding with our test. This is fairly similar to how
this message is waited for in the view-debug-test suite.

## Screenshots
n/a