### PR TITLE
do not close the object inspector

### DIFF
--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -311,7 +311,7 @@ export default class ViewInspection {
       } else if (this.isInspecting) {
         event.preventDefault();
         event.stopPropagation();
-        this.stop();
+        this.stop(false);
       }
     }
   }
@@ -345,7 +345,7 @@ export default class ViewInspection {
     if (match) {
       this.show(match.id, pin);
     } else {
-      this.hide();
+      this.hide(false);
     }
 
     if (isInspecting) {

--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -325,7 +325,7 @@ export default class ViewInspection {
       event.preventDefault();
       event.stopPropagation();
       this.inspectNearest(event.target, true);
-      this.stop();
+      this.stop(false);
     }
   }
 

--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -307,11 +307,11 @@ export default class ViewInspection {
       if (this.isPinned) {
         event.preventDefault();
         event.stopPropagation();
-        this.hide(false);
+        this.hide();
       } else if (this.isInspecting) {
         event.preventDefault();
         event.stopPropagation();
-        this.stop(false);
+        this.stop();
       }
     }
   }
@@ -320,12 +320,12 @@ export default class ViewInspection {
     if (this.isPinned && !this.tooltip.contains(event.target)) {
       event.preventDefault();
       event.stopPropagation();
-      this.hide(false);
+      this.hide();
     } else if (this.isInspecting && event.button === 0) {
       event.preventDefault();
       event.stopPropagation();
       this.inspectNearest(event.target, true);
-      this.stop(false);
+      this.stop();
     }
   }
 
@@ -345,7 +345,7 @@ export default class ViewInspection {
     if (match) {
       this.show(match.id, pin);
     } else {
-      this.hide(false);
+      this.hide();
     }
 
     if (isInspecting) {
@@ -379,11 +379,11 @@ export default class ViewInspection {
 
       this.didShow(id, pin);
     } else {
-      this.hide(false);
+      this.hide();
     }
   }
 
-  hide(notify = true) {
+  hide(notify = false) {
     let { isShowing, isPinned, currentId } = this;
 
     if (isShowing) {

--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -307,7 +307,7 @@ export default class ViewInspection {
       if (this.isPinned) {
         event.preventDefault();
         event.stopPropagation();
-        this.hide();
+        this.hide(false);
       } else if (this.isInspecting) {
         event.preventDefault();
         event.stopPropagation();
@@ -320,7 +320,7 @@ export default class ViewInspection {
     if (this.isPinned && !this.tooltip.contains(event.target)) {
       event.preventDefault();
       event.stopPropagation();
-      this.hide();
+      this.hide(false);
     } else if (this.isInspecting && event.button === 0) {
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
when selecting a component on the webpage, e.g via context menu. a tooltip will show in the website highlighting the selected component.
after clicking outside the tooltip or clicking escape it will hide the tooltip on the webpage and also the object inspector in the ember inspector.
Hiding tooltip is enough. Keep inspector open so i can debug my app, interact with my app and see changes directly in ember-inspector/ object inspector

fixes #2013 
