### PR TITLE
bring back the inspect component context menu functionality

### DIFF
--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -97,7 +97,7 @@
         onclick: function() {
           chrome.tabs.sendMessage(activeTabId, {
             from: 'devtools',
-            type: 'view:inspectComponent'
+            type: 'view:contextMenu'
           });
         }
       });


### PR DESCRIPTION
It wasn't working. This triggers contextMenu in the ember_debug app and selects the nearest component. There is no way to programmatically open devtools. There is experimental api for it. But then it cannot be put into the market

## Description


## Screenshots
