### PR TITLE
use vendored requireModule if it becomes available

### DIFF
--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -19,6 +19,14 @@ if (typeof define !== 'function' || typeof requireModule !== 'function') {
       }
 
       let mod = registry[name];
+      
+      if (!mod) {
+        mod = window.requireModule(name);
+        if (mod) {
+          return mod;
+        }
+      }
+      
       if (!mod) {
         throw new Error(`Module: '${name}' not found.`);
       }

--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -19,14 +19,14 @@ if (typeof define !== 'function' || typeof requireModule !== 'function') {
       }
 
       let mod = registry[name];
-      
+
       if (!mod) {
         mod = window.requireModule(name);
         if (mod) {
           return mod;
         }
       }
-      
+
       if (!mod) {
         throw new Error(`Module: '${name}' not found.`);
       }

--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -20,7 +20,7 @@ if (typeof define !== 'function' || typeof requireModule !== 'function') {
 
       let mod = registry[name];
 
-      if (!mod) {
+      if (!mod && window.requireModule) {
         mod = window.requireModule(name);
         if (mod) {
           return mod;


### PR DESCRIPTION
all requireModule which try to load ember related modules would fail in some cases of some race conditions.
window.requireModule is guaranteed to have the vendored one.
old relevant issue: https://github.com/emberjs/ember-inspector/issues/1595.

this happens when ember inspector was already opened and the app is reloaded. (e.g. during development). in that case it can happen that ember_debug is loaded before ember
