### PR TITLE
delay loading so that ember can finish loading

### DIFF
--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -86,7 +86,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
           });
 
           if (!window.EmberInspector._application) {
-            bootEmberInspector(instance);
+            setTimeout(() => bootEmberInspector(instance), 0);
           }
         }
       });
@@ -131,7 +131,9 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
     };
 
     // Newest Ember versions >= 1.10
-    window.addEventListener('Ember', triggerOnce, { once: true });
+   
+    const later = () => setTimeout(triggerOnce, 0);
+    window.addEventListener('Ember', later, { once: true });
     // Oldest Ember versions or if this was injected after Ember has loaded.
     onReady(triggerOnce);
   }


### PR DESCRIPTION
Without this onEmberReady will do a requireModule('ember') while ember is still loading inside the define. So it's state is not finalized and then ember and onEmberReady will run multiple times. https://github.com/ember-cli/loader.js/blob/master/lib/loader/loader.js#L294

this will also cause e.g requireModule('@ember/array') https://github.com/emberjs/ember-inspector/blob/master/ember_debug/utils/ember/array.js#L6 to return an empty object
