### PR TITLE
fix ember inspector not loading

### DIFF
--- a/app/services/adapters/web-extension.js
+++ b/app/services/adapters/web-extension.js
@@ -151,7 +151,7 @@ function loadEmberDebug() {
       window.addEventListener('Ember', resolve, { once: true });
     });
     waitForEmberLoad.then(() => {
-      'replace-with-ember-debug';
+      return 'replace-with-ember-debug';
     });
   }
   return new Promise((resolve) => {


### PR DESCRIPTION
the placeholder was stripped in production build