### PR TITLE
fix class names in object inspector

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -788,7 +788,7 @@ function getClassName(object) {
 
     if (
       constructor.toString &&
-      constructor.toString !== Object.prototype.toString && 
+      constructor.toString !== Object.prototype.toString &&
       constructor.toString !== Function.prototype.toString
     ) {
       name = constructor.toString();

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -788,7 +788,8 @@ function getClassName(object) {
 
     if (
       constructor.toString &&
-      constructor.toString !== Object.prototype.toString
+      constructor.toString !== Object.prototype.toString && 
+      constructor.toString !== Function.prototype.toString
     ) {
       name = constructor.toString();
     } else {

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -815,7 +815,7 @@ function getClassName(object) {
     return name.replace(/<.*:/, `<${className}:`);
   }
 
-  return name || className;
+  return name || className || '(unknown class)';
 }
 
 function ownMixins(object) {


### PR DESCRIPTION
also check for Function prototype.toString
its now different from Object.prototype.toString as its overwritten by core-js...
https://github.com/zloirock/core-js/blob/master/deno/corejs/index.js#L1195

## Description


## Screenshots
