### PR TITLE
show args for template only components

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -225,6 +225,16 @@ export default class RenderTree {
     this.retainedObjects = new Map();
   }
 
+  _createTemplateOnlyComponent(args) {
+    const obj = Object.create(null);
+    obj.args = args;
+    obj.constructor = {
+      name: 'TemplateOnlyComponent',
+      comment: 'fake constructor',
+    };
+    return obj;
+  }
+
   _serializeRenderNodes(nodes, parentNode = null) {
     return nodes.map((node) => this._serializeRenderNode(node, parentNode));
   }
@@ -242,7 +252,14 @@ export default class RenderTree {
       this.serialized[node.id] = serialized = {
         ...node,
         args: this._serializeArgs(node.args),
-        instance: this._serializeItem(node.instance),
+        instance: this._serializeItem(
+          node.instance ||
+            (node.type === 'component'
+              ? this._createTemplateOnlyComponent(
+                  this._serializeArgs(node.args).named
+                )
+              : undefined)
+        ),
         bounds: this._serializeBounds(node.bounds),
         children: this._serializeRenderNodes(node.children, node),
       };

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -797,7 +797,8 @@ function getClassName(object) {
     }
   } else if (
     'toString' in object &&
-    object.toString !== Object.prototype.toString
+    object.toString !== Object.prototype.toString &&
+    object.toString !== Function.prototype.toString
   ) {
     name = object.toString();
   }

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -11,7 +11,16 @@ import { hbs } from 'ember-cli-htmlbars';
 import EmberDebug from 'ember-debug/main';
 import setupEmberDebugTest from '../helpers/setup-ember-debug-test';
 
-const templateOnlyComponent = require('ember').default._templateOnlyComponent;
+let templateOnlyComponent = null;
+try {
+  // eslint-disable-next-line no-undef,ember/new-module-imports
+  templateOnlyComponent = Ember._templateOnlyComponent;
+  // eslint-disable-next-line no-empty
+} catch (e) {}
+try {
+  templateOnlyComponent = require('ember').default._templateOnlyComponent;
+  // eslint-disable-next-line no-empty
+} catch (e) {}
 
 // TODO make the debounce configurable for tests
 async function timeout(ms) {

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -11,6 +11,8 @@ import { hbs } from 'ember-cli-htmlbars';
 import EmberDebug from 'ember-debug/main';
 import setupEmberDebugTest from '../helpers/setup-ember-debug-test';
 
+const templateOnlyComponent = require('ember').default._templateOnlyComponent;
+
 // TODO make the debounce configurable for tests
 async function timeout(ms) {
   return new Promise((resolve) => {
@@ -348,12 +350,13 @@ module('Ember Debug - View', function (hooks) {
 
     this.owner.register(
       'component:test-bar',
-      EmberComponent.extend({
-        tagName: '',
-        toString() {
-          return 'App.TestBarComponent';
-        },
-      })
+      templateOnlyComponent?.() ||
+        EmberComponent.extend({
+          tagName: '',
+          toString() {
+            return 'App.TestBarComponent';
+          },
+        })
     );
 
     /*
@@ -545,7 +548,7 @@ module('Ember Debug - View', function (hooks) {
       .hasText('my-app/templates/components/test-bar.hbs');
     assert
       .dom('.ember-inspector-tooltip-detail-instance', tooltip)
-      .hasText('App.TestBarComponent');
+      .hasText(templateOnlyComponent ? '(unknown)' : 'App.TestBarComponent');
 
     actual = highlight.getBoundingClientRect();
     expected = bar.getBoundingClientRect();


### PR DESCRIPTION
fixes #1536, fixes #1387

## Description
shows args for template only components in the object inspector

## Screenshots
![Screenshot 2022-09-19 111252](https://user-images.githubusercontent.com/1332320/190985929-47c93d4a-460a-46c5-ae30-274b4c645155.png)

