### PR TITLE
fix iframes without src, e.g. twiddle

### DIFF
--- a/app/services/adapters/web-extension.js
+++ b/app/services/adapters/web-extension.js
@@ -151,6 +151,24 @@ function loadEmberDebug() {
       window.addEventListener('Ember', resolve, { once: true });
     });
     waitForEmberLoad.then(() => 'replace-with-ember-debug');
+    const emberInspectorDebug =
+      '(' + loadEmberDebugInWebpage.toString() + ')()';
+    const injectIntoIframe = () => {
+      for (let i = 0; i < window.frames.length; i++) {
+        window.frames[i].postMessage(
+          {
+            type: 'inject-ember-debug',
+            value: emberInspectorDebug,
+          },
+          '*'
+        );
+      }
+    };
+    window.addEventListener('message', (event) => {
+      if (event.data?.type === 'ember-inspector-iframe-ready') {
+        injectIntoIframe();
+      }
+    });
   }
   return new Promise((resolve) => {
     if (!emberDebug) {

--- a/ember_debug/utils/ember/debug.js
+++ b/ember_debug/utils/ember/debug.js
@@ -6,9 +6,13 @@ export let inspect;
 
 try {
   module = requireModule('@ember/debug');
-  inspect = module.inspect;
+  inspect = module.inspect || requireModule('@ember/-internals/utils').inspect;
 } catch {
   module = Ember.Debug;
+  inspect = Ember.inspect;
+}
+
+if (!inspect) {
   inspect = Ember.inspect;
 }
 

--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -42,7 +42,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
       sendVersionMiss();
       return;
     }
-    
+
     // prevent from injecting twice
     if (!window.EmberInspector) {
       // Make sure we only work for the supported version
@@ -53,7 +53,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
           }
         };
       });
-      
+
       let emberDebugMainModule = requireModule('ember-debug/main');
       if (!emberDebugMainModule['default']) {
         return;
@@ -131,7 +131,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
     };
 
     // Newest Ember versions >= 1.10
-   
+
     const later = () => setTimeout(triggerOnce, 0);
     window.addEventListener('Ember', later, { once: true });
     // Oldest Ember versions or if this was injected after Ember has loaded.
@@ -157,7 +157,7 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
         let current = window.EmberInspector._application;
         let selected = getApplications().find(app => Ember.guidFor(app) === message.applicationId);
 
-        if (current !== selected && selected.__deprecatedInstance__) {
+        if (selected && current !== selected && selected.__deprecatedInstance__) {
           bootEmberInspector(selected.__deprecatedInstance__);
         }
       }

--- a/skeletons/web-extension/content-script.js
+++ b/skeletons/web-extension/content-script.js
@@ -83,21 +83,18 @@
     };
   }
 
-  /**
-   * Gather the iframes running in the ClientApp
-   */
-  var iframes = document.getElementsByTagName('iframe');
-  var urls = [];
-  for (var i = 0, l = iframes.length; i < l; i++) {
-    urls.push(iframes[i].src);
-  }
+  let injected = false;
 
-  /**
-   * Send the iframes to EmberInspector so that it can run
-   * EmberDebug in the context of the iframe.
-   */
-  //FIX ME
-  setTimeout(function() {
-    chrome.runtime.sendMessage({type: 'iframes', urls: urls});
-  }, 500);
+  window.addEventListener('message', (event) => {
+    if (event.data?.type === 'inject-ember-debug' && !injected) {
+      // cannot use eval here, as the context is limited to the content script-
+      const elem = document.createElement('script') ;
+      elem.textContent = event.data.value;
+      document.head.appendChild(elem) ;
+      injected = true;
+    }
+  });
+  window.parent.postMessage({
+    type: 'ember-inspector-iframe-ready'
+  }, '*');
 })();

--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -25,14 +25,16 @@
     "matches": ["<all_urls>"],
     "js": ["boot.js"],
     "run_at": "document_start",
+    "match_about_blank": true,
     "all_frames": true
   },
-  {
-    "matches": ["<all_urls>"],
-    "js": ["content-script.js"],
-    "run_at": "document_end",
-    "all_frames": true
-  }],
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_end",
+      "match_about_blank": true,
+      "all_frames": true
+    }],
 
   "background": {
     "scripts": ["background-script.js"]


### PR DESCRIPTION
chrome.devtools.inspectedWindow.eval(emberDebug, { frameURL: url }) does not work for iframes without a src

fixes #868