### PR TITLE
scroll into view while previewing or selecting from page

### DIFF
--- a/app/components/scroll-container.hbs
+++ b/app/components/scroll-container.hbs
@@ -3,5 +3,7 @@
   style={{this.scrollTargetStyle}}
   role="presentation"
   {{did-insert this.elementInserted}}
+  {{did-update this.scrollPreviewIntoViewIfNeeded this.previewing}}
+  {{did-update this.scrollIntoViewIfNeeded this.currentItem}}
 ></div>
 {{yield}}

--- a/app/components/scroll-container.js
+++ b/app/components/scroll-container.js
@@ -78,7 +78,7 @@ export default class ScrollContainerComponent extends Component {
     if (this.lastCurrentItem?.id === this.currentItem?.id && !this.previewing) {
       return;
     }
-    
+
     if (!this.previewing) {
       this.lastCurrentItem = this.currentItem;
     }

--- a/app/components/scroll-container.js
+++ b/app/components/scroll-container.js
@@ -66,17 +66,18 @@ export default class ScrollContainerComponent extends Component {
 
   @action
   scrollPreviewIntoViewIfNeeded() {
-    let { previewing } = this;
-    if (!previewing) return;
-    this.scrollIntoViewIfNeeded();
+    if (this.previewing) {
+      this.scrollIntoViewIfNeeded();
+    }
   }
 
   @action
   scrollIntoViewIfNeeded() {
     let { element, scrollTarget } = this;
 
-    if (this.lastCurrentItem?.id === this.currentItem?.id && !this.previewing)
+    if (this.lastCurrentItem?.id === this.currentItem?.id && !this.previewing) {
       return;
+    }  
     if (!this.previewing) {
       this.lastCurrentItem = this.currentItem;
     }

--- a/app/components/scroll-container.js
+++ b/app/components/scroll-container.js
@@ -10,7 +10,9 @@ export default class ScrollContainerComponent extends Component {
 
   @tracked collection;
   @tracked currentItem;
+  @tracked previewing;
   @tracked itemHeight;
+  lastCurrentItem;
 
   lastIndex = -1;
   lastItem = undefined;
@@ -43,7 +45,7 @@ export default class ScrollContainerComponent extends Component {
   }
 
   get index() {
-    return this.collection.indexOf(this.currentItem);
+    return this.collection.indexOf(this.previewing || this.currentItem);
   }
 
   get scrollTarget() {
@@ -63,8 +65,21 @@ export default class ScrollContainerComponent extends Component {
   }
 
   @action
+  scrollPreviewIntoViewIfNeeded() {
+    let { previewing } = this;
+    if (!previewing) return;
+    this.scrollIntoViewIfNeeded();
+  }
+
+  @action
   scrollIntoViewIfNeeded() {
     let { element, scrollTarget } = this;
+
+    if (this.lastCurrentItem?.id === this.currentItem?.id && !this.previewing)
+      return;
+    if (!this.previewing) {
+      this.lastCurrentItem = this.currentItem;
+    }
 
     if (needsScroll(element, scrollTarget)) {
       scrollTarget.scrollIntoView({

--- a/app/components/scroll-container.js
+++ b/app/components/scroll-container.js
@@ -77,7 +77,8 @@ export default class ScrollContainerComponent extends Component {
 
     if (this.lastCurrentItem?.id === this.currentItem?.id && !this.previewing) {
       return;
-    }  
+    }
+    
     if (!this.previewing) {
       this.lastCurrentItem = this.currentItem;
     }

--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -63,10 +63,16 @@ export default class ComponentTreeController extends Controller {
     return this._store[id];
   }
 
-  get currentItem() {
+  get currentPreviewItem() {
     if (this.previewing) {
       return this.findItem(this.previewing);
-    } else if (this.pinned) {
+    } else {
+      return undefined;
+    }
+  }
+
+  get currentItem() {
+    if (this.pinned) {
       return this.findItem(this.pinned);
     } else {
       return undefined;

--- a/app/templates/component-tree.hbs
+++ b/app/templates/component-tree.hbs
@@ -13,6 +13,7 @@
 <ScrollContainer
   @collection={{this.visibleItems}}
   @currentItem={{this.currentItem}}
+  @previewing={{this.currentPreviewItem}}
   @itemHeight={{this.itemHeight}}
   class="list__content"
   tabindex="-1"


### PR DESCRIPTION
## Description
this makes the component tree view scroll the previewing or selected component into view.
This is when previewing components on the page or selecting them via the context menu on the page
I also made sure that it only scrolls one time to the current item