### PR TITLE
rename inspect to select

### DIFF
--- a/skeletons/web-extension/background-script.js
+++ b/skeletons/web-extension/background-script.js
@@ -92,7 +92,7 @@
     if (isEmberApp && !contextMenuAdded) {
       chrome.contextMenus.create({
         id: 'inspect-ember-component',
-        title: 'Inspect Ember Component',
+        title: 'Select Ember Component',
         contexts: ['all'],
         onclick: function() {
           chrome.tabs.sendMessage(activeTabId, {


### PR DESCRIPTION
I suggest to rename this so to prevent confusion. the native inspect opens the inspect tools itself, but thats not possible to do with an extension.