### PR TITLE
fix args of template only components

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -255,9 +255,7 @@ export default class RenderTree {
         instance: this._serializeItem(
           node.instance ||
             (node.type === 'component'
-              ? this._createTemplateOnlyComponent(
-                  this._serializeArgs(node.args).named
-                )
+              ? this._createTemplateOnlyComponent(node.args.named)
               : undefined)
         ),
         bounds: this._serializeBounds(node.bounds),


### PR DESCRIPTION
just noticed that the objects in the args had only an id as it was serialized. no need to serialize args at this point

## Description


## Screenshots
