### PR TITLE
getRange might return null

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -130,7 +130,7 @@ export default class RenderTree {
     if (isSingleNode(bounds) && firstNode.getBoundingClientRect) {
       rect = firstNode.getBoundingClientRect();
     } else {
-      rect = this.getRange(id).getBoundingClientRect();
+      rect = this.getRange(id)?.getBoundingClientRect();
     }
 
     if (rect && !isEmptyRect(rect)) {


### PR DESCRIPTION
for components that did not render anything. e.g. everything inside an `if`