### PR TITLE
fix evented off 

### DIFF
--- a/app/services/port.js
+++ b/app/services/port.js
@@ -72,4 +72,12 @@ export default class PortService extends Service.extend(Evented) {
     message.applicationName = this.applicationName;
     this.adapter.sendMessage(message);
   }
+
+  off(...args) {
+    try {
+      super.off(...args);
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }


### PR DESCRIPTION
there isban issue in tests where off is called before it was setup, causing inspector to become unresponsive.


another way would be to setup a deactivate listener after setting up the port listener.
e.g.  
```
this.port.one('general:reset', this, this.reset);
this.one(this, 'deactivate', () => this.port.off('general:reset', this, this.reset))
```