### PR TITLE
bring back tracked dependencies

### DIFF
--- a/app/components/object-inspector/dependent-keys.hbs
+++ b/app/components/object-inspector/dependent-keys.hbs
@@ -3,18 +3,26 @@
   <ul class="m-0 p-0 list-none">
     {{#each @keys as |depKey|}}
       <li class="mixin__property-dependency-item relative text-base12 text-sm">
+      {{#if (match depKey "•")}}
+        <span
+          class="mixin__property-dependency-name subkey"
+          data-label="object-property-name"
+        >
+          {{depKey}}
+        </span>
+      {{else}}
         {{svg-jar
           "dependent-key-bullet"
           width="9px"
           height="9px"
         }}
-
         <span
           class="mixin__property-dependency-name"
           data-label="object-property-name"
         >
           {{depKey}}
         </span>
+      {{/if}}
       </li>
     {{/each}}
   </ul>

--- a/app/styles/object_inspector.scss
+++ b/app/styles/object_inspector.scss
@@ -53,6 +53,11 @@
   }
 }
 
+.mixin__property-dependency-name.subkey {
+  left: -11px;
+  position: relative;
+}
+
 .mixin__property-dependency-item:first-child:before {
   display: none;
 }


### PR DESCRIPTION
## Description
in earlier versions of ember, tags had an _propertyKey which was used to show some tracked dependencies of getters. this brings it back for current versions.
in addition I tried to improve the way its displayed 

## Screenshots
![image](https://user-images.githubusercontent.com/1332320/196641649-486827be-47b2-4943-92c9-cc42b18abd6a.png)
