### PR TITLE
remove terser

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ember-cli-inject-live-reload": "^2.1.0",
     "ember-cli-sass": "^11.0.1",
     "ember-cli-stylelint": "^4.0.0",
-    "ember-cli-terser": "^4.0.2",
     "ember-cli-version-checker": "^5.1.2",
     "ember-concurrency": "^2.0.3",
     "ember-decorators": "^6.1.1",


### PR DESCRIPTION
because firefox needs non-minified code

minifyJS is already set to false, but its not applied for terser
https://github.com/emberjs/ember-inspector/blob/main/ember-cli-build.js#L33
