### PR TITLE
allow setting custom object description

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -199,6 +199,10 @@ function inspect(value) {
     // `Ember.inspect` is able to handle this use case,
     // but it is very slow as it loops over all props,
     // so summarize to just first 2 props
+    // if it defines a toString, we use that instead
+    if (value.toString && value.toString !== Object.prototype.toString && value.toString !== Function.prototype.toString) {
+      return `<Object:${value.toString()}>`;
+    }
     let ret = [];
     let v;
     let count = 0;


### PR DESCRIPTION
this can be useful if its a class instance which does not inherit from ember object, then it would show an empty object in the object inspector properties.


## Description
e.g. in Object Inspector -> Own Properties there is a list of properties, if one of those is an object, which is not an ember object and does not have its own members, so only prototype properties. then an empty object is shown as value.
if the object / class has a toString function, it will be uses as display value
