### PR TITLE
fix: Use correct value path in object inspector (#2237)

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -1404,7 +1404,9 @@ function calculateCP(object, item, errorsForObject) {
     if (object instanceof Ember.ArrayProxy && property == parseInt(property)) {
       return object.objectAt(property);
     }
-    return item.isGetter ? object[property] : get(object, property);
+    return item.isGetter || property.includes('.')
+      ? object[property]
+      : get(object, property);
   } catch (error) {
     errorsForObject[property] = { property, error };
     return new CalculateCPError();

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -1076,6 +1076,26 @@ module('Ember Debug - Object Inspector', function (hooks) {
     assert.strictEqual(plainProperty.value.inspect, '123');
   });
 
+  test('Plain properties with period in name do not use nested value', async function (assert) {
+    let inspected = EmberObject.create({
+      'hi.there': 123,
+      hi: { there: 456 },
+    });
+    let message = await inspectObject(inspected);
+
+    let plainProperty = message.details[0].properties[0];
+    assert.strictEqual(plainProperty.name, 'hi.there');
+    assert.ok(plainProperty.isProperty);
+    assert.strictEqual(plainProperty.value.type, 'type-number');
+    assert.strictEqual(plainProperty.value.inspect, '123');
+
+    plainProperty = message.details[0].properties[1];
+    assert.strictEqual(plainProperty.name, 'hi');
+    assert.ok(plainProperty.isProperty);
+    assert.strictEqual(plainProperty.value.type, 'type-object');
+    assert.strictEqual(plainProperty.value.inspect, '{ there: 456 }');
+  });
+
   test('Getters work', async function (assert) {
     class Foo {
       get hi() {

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -411,7 +411,7 @@ module('Ember Debug - View', function (hooks) {
     );
     this.owner.register(
       'template:simple',
-      hbs('Simple {{test-foo}} {{test-bar value=(hash x=123)}}', {
+      hbs('Simple {{test-foo}} {{test-bar value=(hash x=123 [x.y]=456)}}', {
         moduleName: 'my-app/templates/simple.hbs',
       })
     );
@@ -508,7 +508,7 @@ module('Ember Debug - View', function (hooks) {
                   const value = await digDeeper(actual.id, 'args');
                   QUnit.assert.equal(
                     value.details[0].properties[0].value.inspect,
-                    '{ x: 123 }',
+                    '{ x: 123, x.y: 456 }',
                     'value inspect should be correct'
                   );
                 }


### PR DESCRIPTION
## Description
Fixes known issue #2237.

If a property name includes a `.` such as in `{ 'property.name': 123 }`, the value is now accessed using bracket notation instead of `get()` in order to treat the name as a string literal and avoid attempting to access a nested value.

If a property name does not include a `.`, there is no change in functionality.

A test was added to ensure the correct value is accessed given this scenario.