### PR TITLE
support in-element & wormhole

### DIFF
--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -1,5 +1,6 @@
 import classify from 'ember-debug/utils/classify';
 import bound from 'ember-debug/utils/bound-method';
+import getObjectName from '../utils/get-object-name';
 
 function makeHighlight(id) {
   return `<div id="ember-inspector-highlight-${id}" role="presentation"></div>`;
@@ -592,7 +593,7 @@ export default class ViewInspection {
     let stringified;
 
     try {
-      stringified = String(object);
+      stringified = getObjectName(object);
     } catch {
       // nope!
     }

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -9,9 +9,7 @@ import {
 } from 'ember-debug/utils/type-check';
 import { compareVersion } from 'ember-debug/utils/version';
 import Ember from 'ember-debug/utils/ember';
-import MutableArray from 'ember-debug/utils/ember/array/mutable';
 import ArrayProxy from 'ember-debug/utils/ember/array/proxy';
-import Component from 'ember-debug/utils/ember/component';
 import { inspect as emberInspect } from 'ember-debug/utils/ember/debug';
 import EmberObject, {
   computed,
@@ -19,23 +17,13 @@ import EmberObject, {
   set,
 } from 'ember-debug/utils/ember/object';
 import { oneWay } from 'ember-debug/utils/ember/object/computed';
-import Observable from 'ember-debug/utils/ember/object/observable';
-import Evented from 'ember-debug/utils/ember/object/evented';
 import { cacheFor, guidFor } from 'ember-debug/utils/ember/object/internals';
-import PromiseProxyMixin from 'ember-debug/utils/ember/object/promise-proxy-mixin';
 import { _backburner, join } from 'ember-debug/utils/ember/runloop';
 import { isNone } from 'ember-debug/utils/ember/utils';
+import emberNames from './utils/ember-object-names';
+import getObjectName from './utils/get-object-name';
 
-const {
-  meta: emberMeta,
-  VERSION,
-  ActionHandler,
-  ControllerMixin,
-  CoreObject,
-  MutableEnumerable,
-  NativeArray,
-  ObjectProxy,
-} = Ember;
+const { meta: emberMeta, VERSION, CoreObject, ObjectProxy } = Ember;
 
 const GlimmerComponent = (() => {
   try {
@@ -110,41 +98,6 @@ const HAS_GLIMMER_TRACKING = tagValue && tagValidate && track && tagForProperty;
 const keys = Object.keys || Ember.keys;
 
 /**
- * Add Known Ember Mixins and Classes so we can label them correctly in the inspector
- */
-const emberNames = new Map([
-  [Evented, 'Evented Mixin'],
-  [PromiseProxyMixin, 'PromiseProxy Mixin'],
-  [MutableArray, 'MutableArray Mixin'],
-  [MutableEnumerable, 'MutableEnumerable Mixin'],
-  [NativeArray, 'NativeArray Mixin'],
-  [Observable, 'Observable Mixin'],
-  [ControllerMixin, 'Controller Mixin'],
-  [ActionHandler, 'ActionHandler Mixin'],
-  [CoreObject, 'CoreObject'],
-  [EmberObject, 'EmberObject'],
-  [Component, 'Component'],
-]);
-
-if (compareVersion(VERSION, '3.27.0') === -1) {
-  emberNames.set(Ember.TargetActionSupport, 'TargetActionSupport Mixin');
-}
-
-try {
-  const Views = Ember.__loader.require('@ember/-internals/views');
-  emberNames.set(Views.ViewStateSupport, 'ViewStateSupport Mixin');
-  emberNames.set(Views.ViewMixin, 'View Mixin');
-  emberNames.set(Views.ActionSupport, 'ActionSupport Mixin');
-  emberNames.set(Views.ClassNamesSupport, 'ClassNamesSupport Mixin');
-  emberNames.set(Views.ChildViewsSupport, 'ChildViewsSupport Mixin');
-  emberNames.set(Views.ViewStateSupport, 'ViewStateSupport  Mixin');
-  // this one is not a Mixin, but an .extend({}), which results in a class
-  emberNames.set(Views.CoreView, 'CoreView');
-} catch (e) {
-  // do nothing
-}
-
-/**
  * Determine the type and get the value of the passed property
  * @param {*} object The parent object we will look for `key` on
  * @param {string} key The key for the property which points to a computed, EmberObject, etc
@@ -205,7 +158,11 @@ function inspect(value) {
       value.toString !== Object.prototype.toString &&
       value.toString !== Function.prototype.toString
     ) {
-      return `<Object:${value.toString()}>`;
+      try {
+        return `<Object:${value.toString()}>`;
+      } catch (e) {
+        //
+      }
     }
     let ret = [];
     let v;
@@ -269,7 +226,7 @@ function getTagTrackedProps(tag, ownTag, level = 0) {
   if (tag.subtag && !Array.isArray(tag.subtag)) {
     if (tag.subtag._propertyKey)
       props.push(
-        (tag.subtag._object ? getClassName(tag.subtag._object) + '.' : '') +
+        (tag.subtag._object ? getObjectName(tag.subtag._object) + '.' : '') +
           tag.subtag._propertyKey
       );
     props.push(...getTagTrackedProps(tag.subtag, ownTag, level + 1));
@@ -279,7 +236,7 @@ function getTagTrackedProps(tag, ownTag, level = 0) {
       if (t === ownTag) return;
       if (t._propertyKey)
         props.push(
-          (t._object ? getClassName(t._object) + '.' : '') + t._propertyKey
+          (t._object ? getObjectName(t._object) + '.' : '') + t._propertyKey
         );
       props.push(...getTagTrackedProps(t, ownTag, level + 1));
     });
@@ -587,7 +544,7 @@ export default DebugPort.extend({
         parentObject: objectId,
         property,
         objectId: details.objectId,
-        name: getClassName(object),
+        name: getObjectName(object),
         details: details.mixins,
         errors: details.errors,
       });
@@ -603,7 +560,7 @@ export default DebugPort.extend({
     let details = this.mixinsForObject(object);
     this.sendMessage('updateObject', {
       objectId: details.objectId,
-      name: getClassName(object),
+      name: getObjectName(object),
       details: details.mixins,
       errors: details.errors,
     });
@@ -700,7 +657,7 @@ export default DebugPort.extend({
 
     const objectMixin = {
       id: guidFor(object),
-      name: getClassName(object),
+      name: getObjectName(object),
       properties: ownProperties(object, own),
     };
 
@@ -831,66 +788,6 @@ export default DebugPort.extend({
   inspect,
   inspectValue,
 });
-
-function getClassName(object) {
-  let name = '';
-  let className =
-    (object.constructor &&
-      (emberNames.get(object.constructor) || object.constructor.name)) ||
-    '';
-
-  // check if object is a primitive value
-  if (object !== Object(object)) {
-    return typeof object;
-  }
-
-  if (Array.isArray(object)) {
-    return 'array';
-  }
-
-  if (object.constructor && object.constructor.prototype === object) {
-    let { constructor } = object;
-
-    if (
-      constructor.toString &&
-      constructor.toString !== Object.prototype.toString &&
-      constructor.toString !== Function.prototype.toString
-    ) {
-      try {
-        name = constructor.toString();
-      } catch (e) {
-        name = constructor.name;
-      }
-    } else {
-      name = constructor.name;
-    }
-  } else if (
-    'toString' in object &&
-    object.toString !== Object.prototype.toString &&
-    object.toString !== Function.prototype.toString
-  ) {
-    try {
-      name = object.toString();
-    } catch (e) {
-      //
-    }
-  }
-
-  // If the class has a decent looking name, and the `toString` is one of the
-  // default Ember toStrings, replace the constructor portion of the toString
-  // with the class name. We check the length of the class name to prevent doing
-  // this when the value is minified.
-  if (
-    name.match(/<.*:.*>/) &&
-    !className.startsWith('_') &&
-    className.length > 2 &&
-    className !== 'Class'
-  ) {
-    return name.replace(/<.*:/, `<${className}:`);
-  }
-
-  return name || className || '(unknown class)';
-}
 
 function ownMixins(object) {
   // TODO: We need to expose an API for getting _just_ the own mixins directly

--- a/ember_debug/utils/ember-object-names.js
+++ b/ember_debug/utils/ember-object-names.js
@@ -1,0 +1,54 @@
+import Ember from 'ember-debug/utils/ember';
+import MutableArray from 'ember-debug/utils/ember/array/mutable';
+import Component from 'ember-debug/utils/ember/component';
+import Observable from 'ember-debug/utils/ember/object/observable';
+import Evented from 'ember-debug/utils/ember/object/evented';
+import PromiseProxyMixin from 'ember-debug/utils/ember/object/promise-proxy-mixin';
+import EmberObject from 'ember-debug/utils/ember/object';
+import { compareVersion } from 'ember-debug/utils/version';
+
+const {
+  VERSION,
+  ActionHandler,
+  ControllerMixin,
+  CoreObject,
+  MutableEnumerable,
+  NativeArray,
+} = Ember;
+
+/**
+ * Add Known Ember Mixins and Classes so we can label them correctly in the inspector
+ */
+const emberNames = new Map([
+  [Evented, 'Evented Mixin'],
+  [PromiseProxyMixin, 'PromiseProxy Mixin'],
+  [MutableArray, 'MutableArray Mixin'],
+  [MutableEnumerable, 'MutableEnumerable Mixin'],
+  [NativeArray, 'NativeArray Mixin'],
+  [Observable, 'Observable Mixin'],
+  [ControllerMixin, 'Controller Mixin'],
+  [ActionHandler, 'ActionHandler Mixin'],
+  [CoreObject, 'CoreObject'],
+  [EmberObject, 'EmberObject'],
+  [Component, 'Component'],
+]);
+
+if (compareVersion(VERSION, '3.27.0') === -1) {
+  emberNames.set(Ember.TargetActionSupport, 'TargetActionSupport Mixin');
+}
+
+try {
+  const Views = Ember.__loader.require('@ember/-internals/views');
+  emberNames.set(Views.ViewStateSupport, 'ViewStateSupport Mixin');
+  emberNames.set(Views.ViewMixin, 'View Mixin');
+  emberNames.set(Views.ActionSupport, 'ActionSupport Mixin');
+  emberNames.set(Views.ClassNamesSupport, 'ClassNamesSupport Mixin');
+  emberNames.set(Views.ChildViewsSupport, 'ChildViewsSupport Mixin');
+  emberNames.set(Views.ViewStateSupport, 'ViewStateSupport  Mixin');
+  // this one is not a Mixin, but an .extend({}), which results in a class
+  emberNames.set(Views.CoreView, 'CoreView');
+} catch (e) {
+  // do nothing
+}
+
+export default emberNames;

--- a/ember_debug/utils/get-object-name.js
+++ b/ember_debug/utils/get-object-name.js
@@ -1,0 +1,61 @@
+import emberNames from './ember-object-names';
+
+export default function getObjectName(object) {
+  let name = '';
+  let className =
+    (object.constructor &&
+      (emberNames.get(object.constructor) || object.constructor.name)) ||
+    '';
+
+  // check if object is a primitive value
+  if (object !== Object(object)) {
+    return typeof object;
+  }
+
+  if (Array.isArray(object)) {
+    return 'array';
+  }
+
+  if (object.constructor && object.constructor.prototype === object) {
+    let { constructor } = object;
+
+    if (
+      constructor.toString &&
+      constructor.toString !== Object.prototype.toString &&
+      constructor.toString !== Function.prototype.toString
+    ) {
+      try {
+        name = constructor.toString();
+      } catch (e) {
+        name = constructor.name;
+      }
+    } else {
+      name = constructor.name;
+    }
+  } else if (
+    'toString' in object &&
+    object.toString !== Object.prototype.toString &&
+    object.toString !== Function.prototype.toString
+  ) {
+    try {
+      name = object.toString();
+    } catch (e) {
+      //
+    }
+  }
+
+  // If the class has a decent looking name, and the `toString` is one of the
+  // default Ember toStrings, replace the constructor portion of the toString
+  // with the class name. We check the length of the class name to prevent doing
+  // this when the value is minified.
+  if (
+    name.match(/<.*:.*>/) &&
+    !className.startsWith('_') &&
+    className.length > 2 &&
+    className !== 'Class'
+  ) {
+    return name.replace(/<.*:/, `<${className}:`);
+  }
+
+  return name || className || '(unknown class)';
+}

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "ember-template-lint": "^5.2.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.0.0",
+    "ember-wormhole": "^0.6.0",
     "ember-try": "^2.0.0",
     "ensure-posix-path": "^1.1.1",
     "eslint": "^8.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ devDependencies:
   ember-try:
     specifier: ^2.0.0
     version: 2.0.0
+  ember-wormhole:
+    specifier: ^0.6.0
+    version: 0.6.0
   ensure-posix-path:
     specifier: ^1.1.1
     version: 1.1.1
@@ -7809,6 +7812,16 @@ packages:
       walk-sync: 2.2.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+    dev: true
+
+  /ember-wormhole@0.6.0:
+    resolution: {integrity: sha512-b7RrRxkwCBEJxM2zR34dEzIET81BOZWTcYNJtkidLycLQvdbxPys5QJEjJ/IfDikT/z5HuQBdZRKBhXI0vZNXQ==}
+    engines: {node: 10.* || >= 12}
+    dependencies:
+      ember-cli-babel: 7.26.11
+      ember-cli-htmlbars: 5.7.2
+    transitivePeerDependencies:
       - supports-color
     dev: true
 

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -1,4 +1,10 @@
-import { click, find, triggerEvent, visit } from '@ember/test-helpers';
+import {
+  click,
+  find,
+  rerender,
+  triggerEvent,
+  visit,
+} from '@ember/test-helpers';
 import hasEmberVersion from '@ember/test-helpers/has-ember-version';
 import { A } from '@ember/array';
 import { run } from '@ember/runloop';
@@ -22,13 +28,6 @@ try {
   // eslint-disable-next-line no-empty
 } catch (e) {}
 
-// TODO make the debounce configurable for tests
-async function timeout(ms) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}
-
 // TODO switch to an adapter architecture, similar to the acceptance tests
 async function captureMessage(type, callback) {
   if (!EmberDebug.port) {
@@ -40,15 +39,20 @@ async function captureMessage(type, callback) {
   try {
     let captured;
 
-    EmberDebug.port.send = (name, message) => {
-      if (!captured && name === type) {
-        captured = message;
-      } else {
-        send.call(EmberDebug.port, name, message);
-      }
-    };
+    const receivedPromise = new Promise((resolve) => {
+      setTimeout(resolve, 500);
+      EmberDebug.port.send = (name, message) => {
+        if (!captured && name === type) {
+          resolve();
+          captured = JSON.parse(JSON.stringify(message));
+        } else {
+          send.call(EmberDebug.port, name, message);
+        }
+      };
+    });
 
     await callback();
+    await receivedPromise;
 
     if (captured) {
       return captured;
@@ -66,14 +70,12 @@ async function digDeeper(objectId, property) {
       objectId,
       property,
     });
-    await timeout(300);
   });
 }
 
 async function getRenderTree() {
   let message = await captureMessage('view:renderTree', async () => {
     EmberDebug.port.trigger('view:getTree', {});
-    await timeout(300);
   });
 
   if (message) {
@@ -86,11 +88,11 @@ function isVisible(element) {
   return width > 0 && height > 0;
 }
 
-function matchTree(tree, matchers) {
+function matchTree(tree, matchers, name) {
   QUnit.assert.strictEqual(
     tree.length,
     matchers.length,
-    'tree and matcher should have the same length'
+    `${name} tree and matcher should have the same length`
   );
 
   for (let i = 0; i < matchers.length; i++) {
@@ -106,7 +108,7 @@ function match(actual, matcher, message) {
       matcher.indexOf(actual) > -1,
       `${actual} should be one of ${matcher.join('/')}`
     );
-  } else if (matcher instanceof RegExp) {
+  } else if (matcher instanceof RegExp && actual !== null) {
     QUnit.assert.ok(actual.match(matcher), `${actual} should match ${matcher}`);
   } else if (matcher !== null && typeof matcher === 'object') {
     QUnit.assert.deepEqual(actual, matcher, message);
@@ -221,13 +223,21 @@ function RenderNode(
 ) {
   return (actual) => {
     match(actual.id, id);
-    match(actual.type, type, 'should have correct type');
-    match(actual.name, name, 'should have correct name');
+    match(actual.type, type, `${name} should have correct type`);
+    match(actual.name, name, `${name} should have correct name`);
     match(actual.args, args);
-    match(actual.instance, instance);
-    match(actual.template, template);
-    match(actual.bounds, bounds);
-    matchTree(actual.children, children);
+    match(
+      actual.instance,
+      instance,
+      `${name} ${type} should have correct instance`
+    );
+    match(
+      actual.template,
+      template,
+      `${name} ${type} should have correct template`
+    );
+    match(actual.bounds, bounds, `${name} ${type} should have correct bounds`);
+    matchTree(actual.children, children, `${name} ${type}`);
   };
 }
 
@@ -292,6 +302,9 @@ module('Ember Debug - View', function (hooks) {
   setupEmberDebugTest(hooks, {
     routes() {
       this.route('simple');
+      this.route('test-in-element-in-component');
+      this.route('test-component-in-in-element');
+      this.route('wormhole');
       this.route('inputs');
       this.route('comments', { resetNamespace: true }, function () {});
       this.route('posts', { resetNamespace: true });
@@ -321,6 +334,45 @@ module('Ember Debug - View', function (hooks) {
           return EmberObject.create({
             toString() {
               return 'Simple Model';
+            },
+          });
+        },
+      })
+    );
+
+    this.owner.register(
+      'route:test-in-element-in-component',
+      EmberRoute.extend({
+        model() {
+          return EmberObject.create({
+            toString() {
+              return 'test-in-element-in-component Model';
+            },
+          });
+        },
+      })
+    );
+
+    this.owner.register(
+      'route:test-component-in-in-element',
+      EmberRoute.extend({
+        model() {
+          return EmberObject.create({
+            toString() {
+              return 'Simple Model';
+            },
+          });
+        },
+      })
+    );
+
+    this.owner.register(
+      'route:wormhole',
+      EmberRoute.extend({
+        model() {
+          return EmberObject.create({
+            toString() {
+              return 'Wormhole Model';
             },
           });
         },
@@ -370,6 +422,9 @@ module('Ember Debug - View', function (hooks) {
     this.owner.register(
       'controller:simple',
       Controller.extend({
+        get elementTarget() {
+          return document.querySelector('#target');
+        },
         toString() {
           return 'App.SimpleController';
         },
@@ -397,6 +452,28 @@ module('Ember Debug - View', function (hooks) {
         })
     );
 
+    this.owner.register(
+      'component:test-in-element-in-component',
+      EmberComponent.extend({
+        init(...args) {
+          this._super(...args);
+          this.elementTarget = document.querySelector('#target');
+        },
+        toString() {
+          return 'App.TestInElementInComponent';
+        },
+      })
+    );
+
+    this.owner.register(
+      'component:test-component-in-in-element',
+      EmberComponent.extend({
+        toString() {
+          return 'App.TestComponentInElement';
+        },
+      })
+    );
+
     /*
     Setting line-height to normal because normalize.css sets the
     html line-height to 1.15. This seems to cause a measurement
@@ -405,15 +482,46 @@ module('Ember Debug - View', function (hooks) {
     this.owner.register(
       'template:application',
       hbs(
-        '<div class="application" style="line-height: normal;">{{outlet}}</div>',
+        `<div class="application" style="line-height: normal;">
+          <div id="target"></div>
+          {{outlet}}
+        </div>`,
         { moduleName: 'my-app/templates/application.hbs' }
       )
     );
+
     this.owner.register(
       'template:simple',
-      hbs('Simple {{test-foo}} {{test-bar value=(hash x=123 [x.y]=456)}}', {
-        moduleName: 'my-app/templates/simple.hbs',
+      hbs(
+        'Simple {{test-foo}} {{test-bar value=(hash x=123 [x.y]=456)}} {{#in-element this.elementTarget}}<TestComponentInInElement />{{/in-element}}',
+        {
+          moduleName: 'my-app/templates/simple.hbs',
+        }
+      )
+    );
+
+    this.owner.register(
+      'template:test-in-element-in-component',
+      hbs('<TestInElementInComponent />', {
+        moduleName: 'my-app/templates/test-in-element-in-component.hbs',
       })
+    );
+
+    this.owner.register(
+      'template:test-component-in-in-element',
+      hbs('<TestComponentInInElement />', {
+        moduleName: 'my-app/templates/test-component-in-in-element.hbs',
+      })
+    );
+
+    this.owner.register(
+      'template:wormhole',
+      hbs(
+        '<EmberWormhole @to="target"><div class="in-wormhole">Wormhole</div></EmberWormhole>',
+        {
+          moduleName: 'my-app/templates/wormhole.hbs',
+        }
+      )
     );
     this.owner.register(
       'template:inputs',
@@ -441,9 +549,35 @@ module('Ember Debug - View', function (hooks) {
     this.owner.register(
       'template:components/test-bar',
       hbs(
-        '<!-- before --><div class="another-component">{{@value}}<span>test</span> <span class="bar-inner">bar</span></div><!-- after -->',
+        `<!-- before -->
+        <div class="another-component">
+        {{@value}}
+          <span>test</span>
+          <span class="bar-inner">bar</span>
+        </div>
+        <!-- after -->`,
         { moduleName: 'my-app/templates/components/test-bar.hbs' }
       )
+    );
+
+    this.owner.register(
+      'template:components/test-component-in-in-element',
+      hbs(`
+            <p class='test-component-in-in-element'>
+              App.TestComponentInElement
+            </p>
+        `)
+    );
+
+    this.owner.register(
+      'template:components/test-in-element-in-component',
+      hbs(`
+                {{#in-element this.elementTarget}}
+                  <p class='test-in-element-in-component'>
+                    App.TestInElementInComponent
+                  </p>
+                {{/in-element}}
+              `)
     );
   });
 
@@ -514,7 +648,18 @@ module('Ember Debug - View', function (hooks) {
                 }
                 argsTestPromise = testArgsValue();
               },
-            })
+            }),
+            Component(
+              {
+                name: 'in-element',
+                args: Args({ names: ['destination'], positionals: 0 }),
+                template: null,
+              },
+              Component({
+                name: 'test-component-in-in-element',
+                template: () => null,
+              })
+            )
           )
         )
       ),
@@ -563,7 +708,18 @@ module('Ember Debug - View', function (hooks) {
               name: 'test-bar',
               bounds: 'range',
               args: Args({ names: ['value'], positionals: 0 }),
-            })
+            }),
+            Component(
+              {
+                name: 'in-element',
+                args: Args({ names: ['destination'], positionals: 0 }),
+                template: null,
+              },
+              Component({
+                name: 'test-component-in-in-element',
+                template: () => null,
+              })
+            )
           )
         )
       ),
@@ -610,124 +766,260 @@ module('Ember Debug - View', function (hooks) {
     ]);
   });
 
-  test('Highlighting Views on hover', async function (assert) {
-    await visit('/simple');
-    await getRenderTree();
+  module('Highlighting Views on hover', function (hooks) {
+    let foo;
+    let bar;
+    let inElement;
+    let tooltip;
+    let highlight;
 
-    let foo = find('.simple-component');
-    let bar = find('.another-component');
-    let tooltip = findInspectorElement('tooltip');
-    let highlight = findInspectorElement('highlight');
+    hooks.beforeEach(async function (assert) {
+      await visit('/simple');
+      await getRenderTree();
 
-    assert.notOk(isVisible(tooltip), 'tooltip is not visible');
-    assert.notOk(isVisible(highlight), 'highlight is not visible');
+      foo = find('.simple-component');
+      bar = find('.another-component');
+      tooltip = findInspectorElement('tooltip');
+      highlight = findInspectorElement('highlight');
 
-    run(() => EmberDebug.port.trigger('view:inspectViews', { inspect: true }));
+      assert.ok(!isVisible(tooltip), 'tooltip is not visible');
+      assert.ok(!isVisible(highlight), 'highlight is not visible');
 
-    await triggerEvent('.simple-component', 'mousemove');
+      run(() =>
+        EmberDebug.port.trigger('view:inspectViews', { inspect: true })
+      );
+    });
 
-    assert.ok(isVisible(tooltip), 'tooltip is visible');
-    assert.dom('.ember-inspector-tooltip-header', tooltip).hasText('<TestFoo>');
-    assert
-      .dom('.ember-inspector-tooltip-detail-template', tooltip)
-      .hasText('my-app/templates/components/test-foo.hbs');
-    assert
-      .dom('.ember-inspector-tooltip-detail-instance', tooltip)
-      .hasText('App.TestFooComponent');
+    hooks.afterEach(function () {
+      foo = bar = inElement = tooltip = highlight = undefined;
+    });
 
-    let actual = highlight.getBoundingClientRect();
-    let expected = foo.getBoundingClientRect();
+    test('Highlighting Views on hover', async function (assert) {
+      await triggerEvent('.simple-component', 'mousemove');
 
-    assert.ok(isVisible(highlight), 'highlight is visible');
-    assert.strictEqual(actual.x, expected.x, 'same x as component');
-    assert.strictEqual(actual.y, expected.y, 'same y as component');
-    assert.strictEqual(actual.width, expected.width, 'same width as component');
-    assert.strictEqual(
-      actual.height,
-      expected.height,
-      'same height as component'
-    );
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<TestFoo>');
+      assert
+        .dom('.ember-inspector-tooltip-detail-template', tooltip)
+        .hasText('my-app/templates/components/test-foo.hbs');
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText('App.TestFooComponent');
 
-    await triggerEvent('.bar-inner', 'mousemove');
+      let actual = highlight.getBoundingClientRect();
+      let expected = foo.getBoundingClientRect();
 
-    assert.ok(isVisible(tooltip), 'tooltip is visible');
-    assert.dom('.ember-inspector-tooltip-header', tooltip).hasText('<TestBar>');
-    assert
-      .dom('.ember-inspector-tooltip-detail-template', tooltip)
-      .hasText('my-app/templates/components/test-bar.hbs');
-    assert
-      .dom('.ember-inspector-tooltip-detail-instance', tooltip)
-      .hasText(templateOnlyComponent ? '(unknown)' : 'App.TestBarComponent');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+      assert.strictEqual(actual.x, expected.x, 'same x as component');
+      assert.strictEqual(actual.y, expected.y, 'same y as component');
+      assert.strictEqual(
+        actual.width,
+        expected.width,
+        'same width as component'
+      );
+      assert.strictEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
 
-    actual = highlight.getBoundingClientRect();
-    expected = bar.getBoundingClientRect();
+      await triggerEvent('.bar-inner', 'mousemove');
 
-    assert.ok(isVisible(highlight), 'highlight is visible');
-    assert.strictEqual(actual.x, expected.x, 'same x as component');
-    assert.strictEqual(actual.y, expected.y, 'same y as component');
-    assert.strictEqual(actual.width, expected.width, 'same width as component');
-    assert.strictEqual(
-      actual.height,
-      expected.height,
-      'same height as component'
-    );
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<TestBar>');
+      assert
+        .dom('.ember-inspector-tooltip-detail-template', tooltip)
+        .hasText('my-app/templates/components/test-bar.hbs');
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText(
+          templateOnlyComponent
+            ? 'TemplateOnlyComponent'
+            : 'App.TestBarComponent'
+        );
 
-    await triggerEvent(document.body, 'mousemove');
+      actual = highlight.getBoundingClientRect();
+      expected = bar.getBoundingClientRect();
 
-    assert.notOk(isVisible(tooltip), 'tooltip is not visible');
-    assert.notOk(isVisible(highlight), 'highlight is not visible');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+      assert.strictEqual(actual.x, expected.x, 'same x as component');
+      assert.strictEqual(actual.y, expected.y, 'same y as component');
+      assert.strictEqual(
+        actual.width,
+        expected.width,
+        'same width as component'
+      );
+      assert.strictEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
 
-    // Pin tooltip and stop inspecting
-    await click('.simple-component');
-    await triggerEvent('.bar-inner', 'mousemove');
+      await triggerEvent(document.body, 'mousemove');
 
-    assert.ok(isVisible(tooltip), 'tooltip is visible');
-    assert.dom('.ember-inspector-tooltip-header', tooltip).hasText('<TestFoo>');
-    assert
-      .dom('.ember-inspector-tooltip-detail-template', tooltip)
-      .hasText('my-app/templates/components/test-foo.hbs');
-    assert
-      .dom('.ember-inspector-tooltip-detail-instance', tooltip)
-      .hasText('App.TestFooComponent');
+      assert.notOk(isVisible(tooltip), 'tooltip is not visible');
+      assert.notOk(isVisible(highlight), 'highlight is not visible');
 
-    actual = highlight.getBoundingClientRect();
-    expected = foo.getBoundingClientRect();
+      // Pin tooltip and stop inspecting
+      await click('.simple-component');
+      await triggerEvent('.bar-inner', 'mousemove');
 
-    assert.ok(isVisible(highlight), 'highlight is visible');
-    assert.strictEqual(actual.x, expected.x, 'same x as component');
-    assert.strictEqual(actual.y, expected.y, 'same y as component');
-    assert.strictEqual(actual.width, expected.width, 'same width as component');
-    assert.strictEqual(
-      actual.height,
-      expected.height,
-      'same height as component'
-    );
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<TestFoo>');
+      assert
+        .dom('.ember-inspector-tooltip-detail-template', tooltip)
+        .hasText('my-app/templates/components/test-foo.hbs');
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText('App.TestFooComponent');
 
-    assert.ok(isVisible(tooltip), 'tooltip is visible');
-    assert.dom('.ember-inspector-tooltip-header', tooltip).hasText('<TestFoo>');
-    assert
-      .dom('.ember-inspector-tooltip-detail-template', tooltip)
-      .hasText('my-app/templates/components/test-foo.hbs');
-    assert
-      .dom('.ember-inspector-tooltip-detail-instance', tooltip)
-      .hasText('App.TestFooComponent');
+      actual = highlight.getBoundingClientRect();
+      expected = foo.getBoundingClientRect();
 
-    await triggerEvent(this.element, 'mousemove');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+      assert.deepEqual(actual.x, expected.x, 'same x as component');
+      assert.deepEqual(actual.y, expected.y, 'same y as component');
+      assert.deepEqual(actual.width, expected.width, 'same width as component');
+      assert.deepEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
 
-    assert.ok(isVisible(tooltip), 'tooltip is pinned');
-    assert.ok(isVisible(highlight), 'highlight is pinned');
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<TestFoo>');
+      assert
+        .dom('.ember-inspector-tooltip-detail-template', tooltip)
+        .hasText('my-app/templates/components/test-foo.hbs');
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText('App.TestFooComponent');
 
-    // TODO support clicking on the instance to open object inspector
+      await triggerEvent(this.element, 'mousemove');
 
-    // Dismiss tooltip
-    await click(this.element);
+      assert.ok(isVisible(tooltip), 'tooltip is pinned');
+      assert.ok(isVisible(highlight), 'highlight is pinned');
 
-    assert.notOk(isVisible(tooltip), 'tooltip is not visible');
-    assert.notOk(isVisible(highlight), 'highlight is not visible');
+      // Dismiss tooltip
+      await click(this.element);
 
-    await triggerEvent('.bar-inner', 'mousemove');
+      assert.notOk(isVisible(tooltip), 'tooltip is not visible');
+      assert.notOk(isVisible(highlight), 'highlight is not visible');
 
-    assert.notOk(isVisible(tooltip), 'tooltip is not visible');
-    assert.notOk(isVisible(highlight), 'highlight is not visible');
+      await triggerEvent('.bar-inner', 'mousemove');
+
+      assert.notOk(isVisible(tooltip), 'tooltip is not visible');
+      assert.notOk(isVisible(highlight), 'highlight is not visible');
+    });
+
+    test('in-element inside component', async function (assert) {
+      await visit('test-in-element-in-component');
+      await rerender();
+      await getRenderTree();
+
+      inElement = find('.test-in-element-in-component');
+
+      await click('.test-in-element-in-component');
+
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<InElement>');
+
+      let actual = highlight.getBoundingClientRect();
+      let expected = inElement.getBoundingClientRect();
+
+      // await this.pauseTest();
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+
+      assert.deepEqual(actual.x, expected.x, 'same x as component');
+      assert.deepEqual(actual.y, expected.y, 'same y as component');
+      assert.deepEqual(actual.width, expected.width, 'same width as component');
+      assert.deepEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
+
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText('InElement');
+    });
+
+    test('component inside in-element', async function (assert) {
+      await visit('test-component-in-in-element');
+      await rerender();
+      await getRenderTree();
+
+      inElement = find('.test-component-in-in-element');
+
+      await click('.test-component-in-in-element');
+
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<TestComponentInInElement>');
+
+      let actual = highlight.getBoundingClientRect();
+      let expected = inElement.getBoundingClientRect();
+
+      // await this.pauseTest();
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+
+      assert.deepEqual(actual.x, expected.x, 'same x as component');
+      assert.deepEqual(actual.y, expected.y, 'same y as component');
+      assert.deepEqual(actual.width, expected.width, 'same width as component');
+      assert.deepEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
+
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText('App.TestComponentInElement');
+    });
+
+    test('wormhole', async function (assert) {
+      await visit('wormhole');
+      await rerender();
+      await getRenderTree();
+
+      inElement = find('.in-wormhole');
+
+      await click('.in-wormhole');
+
+      assert
+        .dom('.ember-inspector-tooltip-header', tooltip)
+        .hasText('<EmberWormhole>');
+
+      let actual = highlight.getBoundingClientRect();
+      let expected = inElement.getBoundingClientRect();
+
+      // await this.pauseTest();
+      assert.ok(isVisible(tooltip), 'tooltip is visible');
+      assert.ok(isVisible(highlight), 'highlight is visible');
+
+      assert.deepEqual(actual.x, expected.x, 'same x as component');
+      assert.deepEqual(actual.y, expected.y, 'same y as component');
+      assert.deepEqual(actual.width, expected.width, 'same width as component');
+      assert.deepEqual(
+        actual.height,
+        expected.height,
+        'same height as component'
+      );
+
+      assert
+        .dom('.ember-inspector-tooltip-detail-instance', tooltip)
+        .hasText(/ember-wormhole/);
+    });
   });
 });


### PR DESCRIPTION
this injects a InElement component into the component tree, which has its bounds set to the target. it also adds it as a root tree element, so the click & hover work correctly.
This is also done for EmberWormhole, the code checks for the EmberWormhole instance and changes the bounds to its target element

resolves #1255 
closes #1375 
