### PR TITLE
fetch latest version for ember try

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 public-hoist-pattern[]=@babel/*
-resolution-mode=highest

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,12 +2,15 @@
 'use strict';
 
 const getChannelURL = require('ember-source-channel-url');
+const findSatisfyingVersions = require('ember-try-config/lib/find-satisfying-versions');
+const getEmberVersions = require('ember-try-config/lib/get-ember-versions');
 
 module.exports = function () {
   return Promise.all([
     getChannelURL('release'),
     getChannelURL('beta'),
     getChannelURL('canary'),
+    getEmberVersions()
   ]).then((urls) => {
     return {
       usePnpm: true,
@@ -16,7 +19,7 @@ module.exports = function () {
           name: 'ember-lts-3.16',
           npm: {
             devDependencies: {
-              'ember-source': '~3.16.0',
+              'ember-source': findSatisfyingVersions(urls[3], '~3.16.0')[0],
               'ember-qunit': '^5.1.5',
             },
           },
@@ -25,7 +28,7 @@ module.exports = function () {
           name: 'ember-lts-3.20',
           npm: {
             devDependencies: {
-              'ember-source': '~3.20.5',
+              'ember-source': findSatisfyingVersions(urls[3], '~3.20.5')[0],
               'ember-qunit': '^5.1.5',
             },
           },
@@ -34,7 +37,7 @@ module.exports = function () {
           name: 'ember-lts-3.24',
           npm: {
             devDependencies: {
-              'ember-source': '~3.24.0',
+              'ember-source': findSatisfyingVersions(urls[3], '~3.24.0')[0],
               'ember-qunit': '^5.1.5',
             },
           },
@@ -43,7 +46,7 @@ module.exports = function () {
           name: 'ember-lts-3.28',
           npm: {
             devDependencies: {
-              'ember-source': '~3.28.0',
+              'ember-source': findSatisfyingVersions(urls[3], '~3.28.0')[0],
             },
           },
         },


### PR DESCRIPTION
with this we can drop the resolution-highest in the npmrc file and have even faster installs & tests (well, 1-2sec)

## Description


## Screenshots
