### PR TITLE
limit max width of tooltips

### DIFF
--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -160,6 +160,8 @@ function makeStylesheet(id) {
       text-align: right;
       color: #000;
       background: transparent;
+      max-width: 400px;
+      word-break: break-word;
     }
 
     #${prefix}-tooltip-${id} .${prefix}-tooltip-arrow {
@@ -519,6 +521,7 @@ export default class ViewInspection {
       this._renderTokens(td, value);
     } else {
       td.innerText = value;
+      td.title = value;
     }
 
     tr.appendChild(th);


### PR DESCRIPTION
## Description
limit width of tooltips and clips too long content.
On hover it will show the full string as tooltip, via title attribute 

## Screenshots
