### PR TITLE
fix no svgs

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "ember-sinon-qunit": "^6.0.0",
     "ember-source": "~4.12.0",
     "ember-source-channel-url": "^3.0.0",
-    "ember-svg-jar": "^2.3.4",
+    "ember-svg-jar": "^2.4.4",
     "ember-table": "^5.0.1",
     "ember-template-lint": "^5.2.0",
     "ember-test-selectors": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,8 +252,8 @@ devDependencies:
     specifier: ^3.0.0
     version: 3.0.0
   ember-svg-jar:
-    specifier: ^2.3.4
-    version: 2.4.3
+    specifier: ^2.4.4
+    version: 2.4.4
   ember-table:
     specifier: ^5.0.1
     version: 5.0.1(@ember/test-helpers@2.8.1)(webpack@5.88.1)
@@ -7678,8 +7678,8 @@ packages:
       - webpack
     dev: true
 
-  /ember-svg-jar@2.4.3:
-    resolution: {integrity: sha512-dY3tA+7iKHa1C8x5MnAM+2kVLbb8j1ECdFAdR4Sys74nje79UFWtJDGERizW2ZSALnsqb3uRgEFINP0V3vCeeg==}
+  /ember-svg-jar@2.4.4:
+    resolution: {integrity: sha512-hzSMuyc6A4FbPBaT9JFYicInq+hVJCgS+1EeoK1zQSMEITiEEzjOGCrAd31GZh8L3g8GOLxpdNBpv982D4loyA==}
     engines: {node: 12.* || 14.* || >= 16}
     dependencies:
       '@embroider/macros': 1.12.3


### PR DESCRIPTION
## Description
current builds do not have svgs because of an issue in older ember-svg-jar version
