### PR TITLE
use word-wrap and add line break controls

### DIFF
--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -161,7 +161,7 @@ function makeStylesheet(id) {
       color: #000;
       background: transparent;
       max-width: 400px;
-      word-break: break-word;
+      word-wrap: break-word;
     }
 
     #${prefix}-tooltip-${id} .${prefix}-tooltip-arrow {
@@ -521,7 +521,7 @@ export default class ViewInspection {
     if (Array.isArray(value)) {
       this._renderTokens(td, value);
     } else {
-      td.innerText = value;
+      td.innerText = value.replace(/\//g, '\u200B/\u200B');
     }
 
     tr.appendChild(th);

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -803,7 +803,12 @@ module('Ember Debug - View', function (hooks) {
         .hasText('<TestFoo>');
       assert
         .dom('.ember-inspector-tooltip-detail-template', tooltip)
-        .hasText('my-app/templates/components/test-foo.hbs');
+        .hasText(
+          'my-app/templates/components/test-foo.hbs'.replace(
+            /\//g,
+            '\u200B/\u200B'
+          )
+        );
       assert
         .dom('.ember-inspector-tooltip-detail-instance', tooltip)
         .hasText('App.TestFooComponent');
@@ -833,7 +838,12 @@ module('Ember Debug - View', function (hooks) {
         .hasText('<TestBar>');
       assert
         .dom('.ember-inspector-tooltip-detail-template', tooltip)
-        .hasText('my-app/templates/components/test-bar.hbs');
+        .hasText(
+          'my-app/templates/components/test-bar.hbs'.replace(
+            /\//g,
+            '\u200B/\u200B'
+          )
+        );
       assert
         .dom('.ember-inspector-tooltip-detail-instance', tooltip)
         .hasText(
@@ -874,7 +884,12 @@ module('Ember Debug - View', function (hooks) {
         .hasText('<TestFoo>');
       assert
         .dom('.ember-inspector-tooltip-detail-template', tooltip)
-        .hasText('my-app/templates/components/test-foo.hbs');
+        .hasText(
+          'my-app/templates/components/test-foo.hbs'.replace(
+            /\//g,
+            '\u200B/\u200B'
+          )
+        );
       assert
         .dom('.ember-inspector-tooltip-detail-instance', tooltip)
         .hasText('App.TestFooComponent');
@@ -898,7 +913,12 @@ module('Ember Debug - View', function (hooks) {
         .hasText('<TestFoo>');
       assert
         .dom('.ember-inspector-tooltip-detail-template', tooltip)
-        .hasText('my-app/templates/components/test-foo.hbs');
+        .hasText(
+          'my-app/templates/components/test-foo.hbs'.replace(
+            /\//g,
+            '\u200B/\u200B'
+          )
+        );
       assert
         .dom('.ember-inspector-tooltip-detail-instance', tooltip)
         .hasText('App.TestFooComponent');


### PR DESCRIPTION
sorry for pr again...
found this issue when a small component is at the right side
![image](https://github.com/emberjs/ember-inspector/assets/1332320/46417cb9-7029-4d94-828b-32497384b450)