### PR TITLE
catch errors while getting args in capture tree

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -71,6 +71,7 @@ class InElementSupportProvider {
       const [id, state] = args;
       const node = this.nodeFor(state);
       let capture;
+      // workaround for https://github.com/glimmerjs/glimmer-vm/pull/1447
       try {
         capture = captureNode.call(this, ...args);
         self.setupNodeRemotes(node, id, capture);


### PR DESCRIPTION
workaround for
https://github.com/glimmerjs/glimmer-vm/pull/1447

