### PR TITLE
Add id for manifest v3 support in Firefox

### DIFF
--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -49,6 +49,12 @@
     "service_worker": "background.js"
   },
 
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "ember-inspector@emberjs.com"
+    }
+  },
+
   "options_ui": {
     "page": "options-dialog.html"
   },


### PR DESCRIPTION
From what I can tell, we need to add a unique id for the extension when using manifest v3 with Firefox. This should accomplish that goal.
