### PR TITLE
make amd safe

### DIFF
--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -1,4 +1,7 @@
-let define = window.define,
+let define = window.define && (...args) => window.define(...args),
+  exports = undefined,
+  module = undefined,
+  require = window.requireModule,
   requireModule = window.requireModule;
 if (typeof define !== 'function' || typeof requireModule !== 'function') {
   (function () {

--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -1,8 +1,10 @@
+/* eslint-disable */
 let define = window.define && ((...args) => window.define(...args)),
   exports = undefined,
   module = undefined,
   require = window.requireModule,
   requireModule = window.requireModule;
+/* eslint-enable */
 if (typeof define !== 'function' || typeof requireModule !== 'function') {
   (function () {
     let registry = {},

--- a/ember_debug/vendor/loader.js
+++ b/ember_debug/vendor/loader.js
@@ -1,4 +1,4 @@
-let define = window.define && (...args) => window.define(...args),
+let define = window.define && ((...args) => window.define(...args)),
   exports = undefined,
   module = undefined,
   require = window.requireModule,


### PR DESCRIPTION
Some could overwrite these with their own implementation.
we can always use requireModule only 