### PR TITLE
correctly load scripts in chrome & firefox

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -273,9 +273,21 @@ module.exports = function (defaults) {
 
   replacementPattern = replacementPattern.concat(emberInspectorVersionPattern);
 
+  const firefoxBackgroundServiceReplacement = [
+    {
+      match: /"service_worker": "background.js"/g,
+      replacement: '"scripts": ["background.js"]',
+    },
+  ];
+
   const skeletonWebExtension = replace('skeletons/web-extension', {
     files: ['*'],
     patterns: replacementPattern,
+  });
+
+  const skeletonFirefoxWebExtension = replace('skeletons/web-extension', {
+    files: ['*'],
+    patterns: replacementPattern.concat(firefoxBackgroundServiceReplacement),
   });
 
   const skeletonBookmarklet = replace('skeletons/bookmarklet', {
@@ -285,7 +297,7 @@ module.exports = function (defaults) {
 
   let firefox = mergeTrees([
     mv(mergeTrees([tree, emberDebugs.firefox]), webExtensionRoot),
-    skeletonWebExtension,
+    skeletonFirefoxWebExtension,
   ]);
 
   let chrome = mergeTrees([

--- a/skeletons/web-extension/boot.js
+++ b/skeletons/web-extension/boot.js
@@ -3,9 +3,13 @@
 // TODO: make this conditional, only do it when requested.
 // only inject boot script when on an HTML page
 if (document.contentType === 'text/html') {
-  let script = document.createElement('script');
+  window.EmberENV = { _DEBUG_RENDER_TREE: true };
 
-  script.src = chrome.runtime.getURL('scripts/boot.js');
-
-  document.documentElement.appendChild(script);
+  // for firefox
+  //https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Sharing_objects_with_page_scripts
+  if (window.wrappedJSObject) {
+    const EmberENV = new window.Object();
+    EmberENV._DEBUG_RENDER_TREE = true
+    window.wrappedJSObject.EmberENV = EmberENV;
+  }
 }

--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -22,6 +22,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["boot.js"],
+      "world": "MAIN",
       "run_at": "document_start",
       "match_about_blank": true,
       "all_frames": true
@@ -63,7 +64,6 @@
     {
       "resources": [
         "scripts/in-page-script.js",
-        "scripts/boot.js",
         "panes-*/ember_debug.js"
       ],
       "matches": [

--- a/skeletons/web-extension/scripts/boot.js
+++ b/skeletons/web-extension/scripts/boot.js
@@ -1,2 +1,0 @@
-window.EmberENV = { _DEBUG_RENDER_TREE: true };
-document.currentScript.remove();


### PR DESCRIPTION
this does not work for firefox
```
Reading manifest: Warning processing content_scripts.0.world: An unexpected property was found in the WebExtension manifest.
```
Also has warnings about permissions

but firefox keeps the order right for script loading

it needs to run before everything else so that ember gets the debug config. If the property is set later, component tree will not work.
this issue only happens on page refresh, then browser uses cached data and immediately runs the scripts, without waiting for the new script that have been added by extensions. this does not happen in firefox, only chrome.
https://bugs.chromium.org/p/chromium/issues/detail?id=634381

fixes #2500 