### PR TITLE
Proposal: serialize remote nodes on in-element nodes to avoid dom exceptions 

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -165,7 +165,9 @@ class InElementSupportProvider {
   registerRemote(block, node) {
     const obj = this.buildInElementNode(node);
     if (this.currentNode) {
-      this.currentNode.remotes = this.currentNode.remotes || [];
+      if (!this.currentNode.remotes) Object.defineProperty(this.currentNode, 'remotes', {
+        value: []
+      });
       this.currentNode.remotes.push(obj);
     }
     this.remoteRoots.push(obj);


### PR DESCRIPTION
## Description
At my work we have a complex component that does direct dom manipluation and uses an in-element helper to boot.  This caused the ember-inspector to crash with a dom exception error when trying to deepClone the render tree (dom nodes can not be deep cloned).  Some debugging showed that the dom nodes were showing up in the `remotes` array of the in-element node, specifically in the `bounds` of the remote node items.  Running those nodes through the same `_serializeRenderNodes` method kept ember-inspector from crashing.

