### PR TITLE
[firefox] set access permissions for all websites 

### DIFF
--- a/skeletons/web-extension/manifest.json
+++ b/skeletons/web-extension/manifest.json
@@ -12,7 +12,8 @@
     "128": "{{PANE_ROOT}}/assets/images/icon128.png"
   },
 
-  "permissions": ["<all_urls>", "storage", "contextMenus"],
+  "permissions": ["storage", "contextMenus"],
+  "host_permissions": ["<all_urls>"],
 
   "content_security_policy": {
     "extension_pages": "script-src 'self'; object-src 'self'"


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions

chrome already defaults to it when not specified

fixes #2516 