### PR TITLE
exclude remotes for serialization

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -165,9 +165,11 @@ class InElementSupportProvider {
   registerRemote(block, node) {
     const obj = this.buildInElementNode(node);
     if (this.currentNode) {
-      if (!this.currentNode.remotes) Object.defineProperty(this.currentNode, 'remotes', {
-        value: []
-      });
+      if (!this.currentNode.remotes) {
+        Object.defineProperty(this.currentNode, 'remotes', {
+          value: [],
+        });
+      }
       this.currentNode.remotes.push(obj);
     }
     this.remoteRoots.push(obj);


### PR DESCRIPTION
the remotes are only there to find the nodes inside in-element nodes. they do not need to be serialized and sent to the inspector.

closes #2512 