### PR TITLE
ensure port is connected

### DIFF
--- a/app/services/adapters/web-extension.js
+++ b/app/services/adapters/web-extension.js
@@ -60,12 +60,23 @@ export default class WebExtension extends BasicAdapter {
   }
 
   _connect() {
+    if (this._isConnected) {
+      return;
+    }
     let chromePort = this._chromePort;
     chromePort.postMessage({ appId: chrome.devtools.inspectedWindow.tabId });
 
     chromePort.onMessage.addListener((...args) => {
       this._messageReceived(...args);
     });
+
+    chromePort.onDisconnect.addListener(() => {
+      this._isConnected = false;
+      this.notifyPropertyChange('_chromePort');
+      this._connect();
+    });
+
+    this._isConnected = true;
   }
 
   _handleReload() {

--- a/app/services/adapters/web-extension.js
+++ b/app/services/adapters/web-extension.js
@@ -60,9 +60,6 @@ export default class WebExtension extends BasicAdapter {
   }
 
   _connect() {
-    if (this._isConnected) {
-      return;
-    }
     let chromePort = this._chromePort;
     chromePort.postMessage({ appId: chrome.devtools.inspectedWindow.tabId });
 
@@ -71,12 +68,9 @@ export default class WebExtension extends BasicAdapter {
     });
 
     chromePort.onDisconnect.addListener(() => {
-      this._isConnected = false;
       this.notifyPropertyChange('_chromePort');
       this._connect();
     });
-
-    this._isConnected = true;
   }
 
   _handleReload() {


### PR DESCRIPTION
fixes #2532 

looks like service workers can be shutown after idle time... with manifest V3.
but it can be stopped any time, as it is not guaranteed.
also we reconnect immediately so that we can receive updates  when some start coming in from ember_debug site
https://developer.chrome.com/docs/extensions/develop/concepts/service-workers/lifecycle#idle-shutdown

tested manually by stopping the service worker in chrome://serviceworker-internals/?devtools