### PR TITLE
improve tree perf

### DIFF
--- a/app/components/component-tree-arg.js
+++ b/app/components/component-tree-arg.js
@@ -12,6 +12,15 @@ export default class ComponentTreeArg extends Component {
 
   get displayValue() {
     if (this.isObject) {
+      if (this.args.value.inspect) {
+        if (this.args.value.type === 'function') {
+          return this.args.value.inspect
+            .replace(/"/g, '\\"')
+            .replace('bound ', '')
+            .replace('{ ... }', '');
+        }
+        return this.args.value.inspect.replace(/"/g, '\\"');
+      }
       return '...';
     } else if (typeof this.args.value === 'string') {
       // Escape any interior quotes – we will add the surrounding quotes in the template

--- a/app/components/component-tree-item.hbs
+++ b/app/components/component-tree-item.hbs
@@ -87,6 +87,16 @@
         <span class="component-name">
           {{@item.name}}
         </span>
+        {{#each-in @item.args.named as |name value|}}
+          <div class="arg-token flex ml-2">
+              <span class="key-token">
+                {{name}}
+              </span>
+            ={{if (is-string value) "\""}}
+            <ComponentTreeArg @value={{value}} />
+            {{if (is-string value) "\""}}
+          </div>
+        {{/each-in}}
       {{/if}}
     </code>
   </div>

--- a/app/components/component-tree-item.hbs
+++ b/app/components/component-tree-item.hbs
@@ -24,7 +24,7 @@
     <code
       class="component-tree-item__tag flex whitespace-no-wrap
         {{if
-          @item.isComponent
+        (or @item.isComponent @item.isModifier @item.isHtmlTag)
           (if
             @item.isCurlyInvocation
             "component-tree-item-classic__bracket"
@@ -37,7 +37,7 @@
         }}"
     >
       {{!-- template-lint-disable no-unbalanced-curlies --}}
-      {{#if @item.isComponent}}
+      {{#if (or @item.isComponent @item.isModifier)}}
         {{#if @item.isCurlyInvocation}}
           <span class="component-name">
             {{@item.name}}
@@ -83,6 +83,10 @@
         \{{mount "{{@item.name}}"}}
       {{else if @item.isRouteTemplate}}
         {{@item.name}} route
+      {{else if @item.isHtmlTag}}
+        <span class="component-name">
+          {{@item.name}}
+        </span>
       {{/if}}
     </code>
   </div>

--- a/app/components/component-tree-item.hbs
+++ b/app/components/component-tree-item.hbs
@@ -11,6 +11,7 @@
   {{on "mouseenter" @item.showPreview}}
   {{on "mouseleave" @item.hidePreview}}
 >
+  {{resource @item.id create=@item.load update=@item.update teardown=@item.unload}}
   <div class="component-tree-item-background flex items-center pr-2 rounded">
     {{#if @item.hasChildren}}
       <Ui::DisclosureTriangle

--- a/app/components/object-inspector/property.ts
+++ b/app/components/object-inspector/property.ts
@@ -119,8 +119,8 @@ export default class ObjectInspectorProperty extends Component<ObjectInspectorPr
   }
 
   get cannotEdit() {
-    if (this.args.model.name === '...' || !this.isCalculated) return true;
-    return this.isFunction || this.isOverridden || this.readOnly;
+    if (this.args.model.name === '...' || !this.isCalculated || this.readOnly) return true;
+    return this.args.model?.value?.type !== 'type-string' && this.args.model?.value?.type !== 'type-number';
   }
 
   @action

--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -301,7 +301,7 @@ class RenderItem {
   }
 
   get isComponent() {
-    return this.renderNode.type === 'component' || this.renderNode.type === 'remote-element';
+    return this.renderNode.type === 'component';
   }
 
   get isModifier() {
@@ -309,7 +309,7 @@ class RenderItem {
   }
 
   get isHtmlTag() {
-    return this.renderNode.type === 'htmlTag';
+    return this.renderNode.type === 'html-element';
   }
 
   get name() {

--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -301,7 +301,15 @@ class RenderItem {
   }
 
   get isComponent() {
-    return this.renderNode.type === 'component';
+    return this.renderNode.type === 'component' || this.renderNode.type === 'remote-element';
+  }
+
+  get isModifier() {
+    return this.renderNode.type === 'modifier';
+  }
+
+  get isHtmlTag() {
+    return this.renderNode.type === 'htmlTag';
   }
 
   get name() {
@@ -313,6 +321,9 @@ class RenderItem {
   }
 
   get isCurlyInvocation() {
+    if (this.isModifier) {
+      return true;
+    }
     return this.renderNode.args && this.renderNode.args.positional;
   }
 

--- a/app/controllers/component-tree.js
+++ b/app/controllers/component-tree.js
@@ -1,6 +1,6 @@
 import Controller, { inject as controller } from '@ember/controller';
 import { action } from '@ember/object';
-import { debounce } from '@ember/runloop';
+import { debounce, next } from '@ember/runloop';
 import { inject as service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
@@ -42,6 +42,9 @@ export default class ComponentTreeController extends Controller {
           item = new RenderItem(this, parent, renderNode);
         } else {
           item.renderNode = renderNode;
+          if (item.isRendered) {
+            item.load();
+          }
         }
 
         store[renderNode.id] = item;
@@ -57,6 +60,15 @@ export default class ComponentTreeController extends Controller {
     this._store = store;
 
     this.renderItems = renderItems;
+  }
+
+  setRenderTreeItem(item) {
+    if (item && this._store[item.id]) {
+      this._store[item.id].renderNode = Object.assign(
+        this._store[item.id].renderNode,
+        item
+      );
+    }
   }
 
   findItem(id) {
@@ -275,6 +287,7 @@ function arrowKeyPressed(keyCode) {
 class RenderItem {
   @tracked isExpanded;
   @tracked renderNode;
+  @tracked renderCounter = 0;
 
   constructor(controller, parentItem, renderNode) {
     this.controller = controller;
@@ -282,6 +295,42 @@ class RenderItem {
     this.renderNode = renderNode;
 
     this.isExpanded = this.isExpandable;
+  }
+
+  get isRendered() {
+    return this.renderCounter > 0;
+  }
+
+  @action
+  load() {
+    next(() => {
+      this.renderCounter += 1;
+      if (this.renderNode.args) {
+        return;
+      }
+      console.log('load', this.id);
+      this.send('view:getTreeItem', { id: this.id });
+    });
+  }
+
+  @action
+  async update(prevId) {
+    next(() => {
+      this.controller._store[prevId].renderCounter -= 1;
+      this.renderCounter += 1;
+      if (this.renderNode.args) {
+        return;
+      }
+      console.log('load', this.id);
+      this.send('view:getTreeItem', { id: this.id });
+    });
+  }
+
+  @action
+  async unload() {
+    next(() => {
+      this.renderCounter -= 1;
+    });
   }
 
   get id() {

--- a/app/helpers/resource.js
+++ b/app/helpers/resource.js
@@ -1,0 +1,25 @@
+import Helper from '@ember/component/helper';
+import { registerDestructor, unregisterDestructor } from '@ember/destroyable';
+
+export default class ResourceHelper extends Helper {
+  compute(positional, named) {
+    const firstTime = !this.updateCallback;
+    this.updateCallback = named.update;
+    if (named.teardown) {
+      if (this.teardownCallback) {
+        unregisterDestructor(this, this.teardownCallback);
+      }
+      this.teardownCallback = named.teardown;
+      registerDestructor(this, this.teardownCallback);
+    }
+    if (this.updateCallback && !firstTime) {
+      this.updateCallback(this.prevState, positional);
+    }
+    if (firstTime && named.create) {
+      named.create();
+    }
+    //access all positional params
+    positional.forEach(() => null);
+    this.prevState = [...positional];
+  }
+}

--- a/app/routes/component-tree.js
+++ b/app/routes/component-tree.js
@@ -28,6 +28,7 @@ export default class ComponentTreeRoute extends TabRoute {
     super.activate(...arguments);
 
     this.port.on('view:renderTree', this, this.setRenderTree);
+    this.port.on('view:renderTreeItem', this, this.setRenderTreeItem);
     this.port.on('view:cancelSelection', this, this.cancelSelection);
     this.port.on('view:startInspecting', this, this.startInspecting);
     this.port.on('view:stopInspecting', this, this.stopInspecting);
@@ -38,6 +39,7 @@ export default class ComponentTreeRoute extends TabRoute {
     super.deactivate(...arguments);
 
     this.port.off('view:renderTree', this, this.setRenderTree);
+    this.port.off('view:renderTreeItem', this, this.setRenderTreeItem);
     this.port.off('view:cancelSelection', this, this.cancelSelection);
     this.port.off('view:startInspecting', this, this.startInspecting);
     this.port.off('view:stopInspecting', this, this.stopInspecting);
@@ -46,6 +48,10 @@ export default class ComponentTreeRoute extends TabRoute {
 
   setRenderTree({ tree }) {
     this.controller.renderTree = tree;
+  }
+
+  setRenderTreeItem({ treeItem }) {
+    this.controller.setRenderTreeItem(treeItem);
   }
 
   cancelSelection({ id, pin }) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -381,19 +381,18 @@ module.exports = function (defaults) {
   if (env === 'test') {
     // `ember test` expects the index.html file to be in the
     // output directory.
-    output = mergeTrees([dists.basic, dists.chrome]);
-  } else {
     // Change base tag for running tests in development env.
     dists.basic = replace(dists.basic, {
       files: ['tests/index.html'],
       patterns: [
         {
           match: /<base.*\/>/,
-          replacement: '<base href="../" />',
+          replacement: '',
         },
       ],
     });
-
+    output = mergeTrees([dists.basic, dists.chrome]);
+  } else {
     dists.testing = mergeTrees([dists.basic, dists.chrome]);
 
     output = mergeTrees([

--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -1,5 +1,9 @@
-import Debug from 'ember-debug/utils/ember/debug';
-import { ComputedProperty, meta as emberMeta } from 'ember-debug/utils/ember';
+import Debug, { inspect as emberInspect } from 'ember-debug/utils/ember/debug';
+import {
+  ComputedProperty,
+  EmberObject,
+  meta as emberMeta,
+} from 'ember-debug/utils/ember';
 import { emberSafeRequire } from 'ember-debug/utils/ember/loader';
 
 /**
@@ -60,4 +64,78 @@ export function typeOf(obj) {
     .call(obj)
     .match(/\s([a-zA-Z]+)/)[1]
     .toLowerCase();
+}
+
+export function inspect(value) {
+  if (typeof value === 'function') {
+    return `${value.name || 'function'}() { ... }`;
+  } else if (value instanceof EmberObject) {
+    return value.toString();
+  } else if (value instanceof HTMLElement) {
+    return `<${value.tagName.toLowerCase()}>`;
+  } else if (typeOf(value) === 'array') {
+    if (value.length === 0) {
+      return '[]';
+    } else if (value.length === 1) {
+      return `[ ${inspect(value[0])} ]`;
+    } else {
+      return `[ ${inspect(value[0])}, ... ]`;
+    }
+  } else if (value instanceof Error) {
+    return `Error: ${value.message}`;
+  } else if (value === null) {
+    return 'null';
+  } else if (typeOf(value) === 'date') {
+    return value.toString();
+  } else if (typeof value === 'object') {
+    // `Ember.inspect` is able to handle this use case,
+    // but it is very slow as it loops over all props,
+    // so summarize to just first 2 props
+    // if it defines a toString, we use that instead
+    if (
+      typeof value.toString === 'function' &&
+      value.toString !== Object.prototype.toString &&
+      value.toString !== Function.prototype.toString
+    ) {
+      try {
+        return `<Object:${value.toString()}>`;
+      } catch (e) {
+        //
+      }
+    }
+    let ret = [];
+    let v;
+    let count = 0;
+    let broken = false;
+
+    for (let key in value) {
+      if (!('hasOwnProperty' in value) || value.hasOwnProperty(key)) {
+        if (count++ > 1) {
+          broken = true;
+          break;
+        }
+        v = value[key];
+        if (v === 'toString') {
+          continue;
+        } // ignore useless items
+        if (typeOf(v).includes('function')) {
+          v = `function ${v.name}() { ... }`;
+        }
+        if (typeOf(v) === 'array') {
+          v = `[Array : ${v.length}]`;
+        }
+        if (typeOf(v) === 'object') {
+          v = '[Object]';
+        }
+        ret.push(`${key}: ${v}`);
+      }
+    }
+    let suffix = ' }';
+    if (broken) {
+      suffix = ' ...}';
+    }
+    return `{ ${ret.join(', ')}${suffix}`;
+  } else {
+    return emberInspect(value);
+  }
 }

--- a/ember_debug/utils/version.js
+++ b/ember_debug/utils/version.js
@@ -24,6 +24,35 @@ export function compareVersion(version1, version2) {
 }
 
 /**
+ *
+ * @param specifier e.g. ^5.12.0
+ * @param version 5.13
+ * @return {boolean}
+ */
+export function isInVersionSpecifier(specifier, version) {
+  let compared, i, version2;
+  let operator = specifier[0];
+  if (Number.isNaN(operator)) {
+    specifier = specifier.slice(1);
+  }
+  specifier = cleanupVersion(specifier).split('.');
+  version2 = cleanupVersion(version).split('.');
+  if (operator === '~' && specifier[1] !== version2[1]) {
+    return false;
+  }
+  if (operator === '^' && specifier[0] !== version2[0]) {
+    return false;
+  }
+  for (i = 0; i < 3; i++) {
+    compared = compare(+specifier[i], +version2[i]);
+    if (compared > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
  * Remove -alpha, -beta, etc from versions
  *
  * @param {String} version

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -20,6 +20,10 @@ export default class extends DebugPort {
         this.sendTree(immediate);
       },
 
+      getTreeItem({ id }) {
+        this.sendTreeItem(id);
+      },
+
       showInspection({ id, pin }) {
         this.viewInspection.show(id, pin);
       },
@@ -149,6 +153,12 @@ export default class extends DebugPort {
       this.send();
       this.scheduledSendTree = null;
     }, 250);
+  }
+
+  sendTreeItem(id) {
+    this.sendMessage('renderTreeItem', {
+      treeItem: this.renderTree._serializeRenderNode(id),
+    });
   }
 
   send() {

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -87,6 +87,23 @@ async function getRenderTree() {
     EmberDebug.port.trigger('view:getTree', {});
   });
 
+  const all = [];
+  const stack = [...message.tree];
+  while (stack.length) {
+    const item = stack.pop();
+    all.push(item);
+    stack.push(...item.children);
+  }
+
+  const fetchAll = all.map(async (item) => {
+    const message = await captureMessage('view:renderTreeItem', async () => {
+      EmberDebug.port.trigger('view:getTreeItem', { id: item.id });
+    });
+    Object.assign(item, message.treeItem);
+  });
+
+  await Promise.all(fetchAll);
+
   if (message) {
     return message.tree;
   }

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -12,6 +12,7 @@ import EmberComponent from '@ember/component';
 import EmberRoute from '@ember/routing/route';
 import EmberObject from '@ember/object';
 import Controller from '@ember/controller';
+import didInsert from '@ember/render-modifiers/modifiers/did-insert';
 import QUnit, { module, test } from 'qunit';
 import { hbs } from 'ember-cli-htmlbars';
 import EmberDebug from 'ember-debug/main';
@@ -265,6 +266,47 @@ function Component(
   );
 }
 
+function Modifier(
+  {
+    name,
+    instance = Serialized(),
+    template = null,
+    bounds = 'single',
+    ...options
+  },
+  ...children
+) {
+  return RenderNode(
+    { name, instance, template, bounds, ...options, type: 'modifier' },
+    ...children
+  );
+}
+
+function HtmlElement(
+  {
+    name,
+    instance = Serialized(),
+    args = Args(),
+    template = null,
+    bounds = 'single',
+    ...options
+  },
+  ...children
+) {
+  return RenderNode(
+    {
+      name,
+      instance,
+      args,
+      template,
+      bounds,
+      ...options,
+      type: 'html-element',
+    },
+    ...children
+  );
+}
+
 function Route(
   {
     name,
@@ -430,6 +472,7 @@ module('Ember Debug - View', function (hooks) {
     this.owner.register(
       'controller:simple',
       Controller.extend({
+        foo() {},
         get elementTarget() {
           return document.querySelector('#target');
         },
@@ -501,7 +544,11 @@ module('Ember Debug - View', function (hooks) {
     this.owner.register(
       'template:simple',
       hbs(
-        'Simple {{test-foo}} {{test-bar value=(hash x=123 [x.y]=456)}} {{#in-element this.elementTarget}}<TestComponentInInElement />{{/in-element}}',
+        `
+        <div {{did-insert this.foo}}>
+          Simple {{test-foo}} {{test-bar value=(hash x=123 [x.y]=456)}} {{#in-element this.elementTarget}}<TestComponentInInElement />{{/in-element}}
+        </div>
+        `,
         {
           moduleName: 'my-app/templates/simple.hbs',
         }
@@ -587,6 +634,8 @@ module('Ember Debug - View', function (hooks) {
                 {{/in-element}}
               `)
     );
+
+    this.owner.register('modifier:did-insert', didInsert);
   });
 
   test('Simple Inputs Tree', async function () {
@@ -596,6 +645,43 @@ module('Ember Debug - View', function (hooks) {
 
     const inputChildren = [];
     // https://github.com/emberjs/ember.js/commit/e6cf1766f8e02ddb24bf67833c148e7d7c93182f
+    const modifiers = [
+      Modifier({
+        name: 'on',
+        args: Args({ positionals: 2 }),
+      }),
+      Modifier({
+        name: 'on',
+        args: Args({ positionals: 2 }),
+      }),
+      Modifier({
+        name: 'on',
+        args: Args({ positionals: 2 }),
+      }),
+      Modifier({
+        name: 'on',
+        args: Args({ positionals: 2 }),
+      }),
+      Modifier({
+        name: 'on',
+        args: Args({ positionals: 2 }),
+      }),
+    ];
+    if (hasEmberVersion(3, 28) && !hasEmberVersion(4, 0)) {
+      modifiers.push(
+        Modifier({
+          name: 'unknown-modifier',
+          args: Args({ positionals: 1 }),
+        })
+      );
+    }
+    const htmlElement = HtmlElement(
+      {
+        name: 'input',
+        args: Args({ names: ['id', 'class', 'type'] }),
+      },
+      ...modifiers
+    );
     if (!hasEmberVersion(3, 26)) {
       inputChildren.push(
         Component({
@@ -604,6 +690,8 @@ module('Ember Debug - View', function (hooks) {
           args: Args({ names: ['target', 'value'], positionals: 0 }),
         })
       );
+    } else {
+      inputChildren.push(htmlElement);
     }
 
     matchTree(tree, [
@@ -640,44 +728,53 @@ module('Ember Debug - View', function (hooks) {
           { name: 'application' },
           Route(
             { name: 'simple' },
-            Component({ name: 'test-foo', bounds: 'single' }),
-            Component({
-              name: 'test-bar',
-              bounds: 'range',
-              args: Args({ names: ['value'], positionals: 0 }),
-              instance: (actual) => {
-                async function testArgsValue() {
-                  const value = await digDeeper(actual.id, 'args');
-                  QUnit.assert.equal(
-                    value.details[0].properties[0].value.inspect,
-                    '{ x: 123, x.y: 456 }',
-                    'value inspect should be correct'
-                  );
-                }
-                argsTestPromise = testArgsValue();
-              },
-            }),
-            Component(
+            HtmlElement(
               {
-                name: 'in-element',
-                args: (actual) => {
-                  QUnit.assert.ok(actual.positional[0]);
+                name: 'div',
+              },
+              Modifier({
+                name: 'did-insert',
+                args: Args({ positionals: 1 }),
+              }),
+              Component({ name: 'test-foo', bounds: 'single' }),
+              Component({
+                name: 'test-bar',
+                bounds: 'range',
+                args: Args({ names: ['value'], positionals: 0 }),
+                instance: (actual) => {
                   async function testArgsValue() {
-                    const value = await inspectById(actual.positional[0].id);
+                    const value = await digDeeper(actual.id, 'args');
                     QUnit.assert.equal(
-                      value.details[1].name,
-                      'HTMLDivElement',
-                      'in-element args value inspect should be correct'
+                      value.details[0].properties[0].value.inspect,
+                      '{ x: 123, x.y: 456 }',
+                      'test-bar args value inspect should be correct'
                     );
                   }
                   argsTestPromise = testArgsValue();
                 },
-                template: null,
-              },
-              Component({
-                name: 'test-component-in-in-element',
-                template: () => null,
-              })
+              }),
+              Component(
+                {
+                  name: 'in-element',
+                  args: (actual) => {
+                    QUnit.assert.ok(actual.positional[0]);
+                    async function testArgsValue() {
+                      const value = await inspectById(actual.positional[0].id);
+                      QUnit.assert.equal(
+                        value.details[1].name,
+                        'HTMLDivElement',
+                        'in-element args value inspect should be correct'
+                      );
+                    }
+                    argsTestPromise = testArgsValue();
+                  },
+                  template: null,
+                },
+                Component({
+                  name: 'test-component-in-in-element',
+                  template: () => null,
+                })
+              )
             )
           )
         )
@@ -722,22 +819,31 @@ module('Ember Debug - View', function (hooks) {
           { name: 'application' },
           Route(
             { name: 'simple' },
-            Component({ name: 'test-foo', bounds: 'single' }),
-            Component({
-              name: 'test-bar',
-              bounds: 'range',
-              args: Args({ names: ['value'], positionals: 0 }),
-            }),
-            Component(
+            HtmlElement(
               {
-                name: 'in-element',
-                args: Args({ names: [], positionals: 1 }),
-                template: null,
+                name: 'div',
               },
+              Modifier({
+                name: 'did-insert',
+                args: Args({ positionals: 1 }),
+              }),
+              Component({ name: 'test-foo', bounds: 'single' }),
               Component({
-                name: 'test-component-in-in-element',
-                template: () => null,
-              })
+                name: 'test-bar',
+                bounds: 'range',
+                args: Args({ names: ['value'], positionals: 0 }),
+              }),
+              Component(
+                {
+                  name: 'in-element',
+                  args: Args({ names: [], positionals: 1 }),
+                  template: null,
+                },
+                Component({
+                  name: 'test-component-in-in-element',
+                  template: () => null,
+                })
+              )
             )
           )
         )

--- a/tests/index.html
+++ b/tests/index.html
@@ -5,6 +5,7 @@
     <title>EmberInspector Tests</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <base href="../" />
     <style>
       /* Smoke and mirrors requires the container
       to be visible all the time since rendering


### PR DESCRIPTION
This improves the tree serialization performance by only serializing the nodes that are displayed.
This is done by only sending the id, name, type of the nodes.
 The inspector then requests the serialized node that are in the view and also happens whenever an update is sent
