### PR TITLE
provide name for hbs template only components

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -663,7 +663,7 @@ export default class RenderTree {
       if (node.type === 'component' && !node.instance) {
         if (
           node.name === '(unknown template-only component)' &&
-          node.template.endsWith('.hbs')
+          node.template?.endsWith('.hbs')
         ) {
           node.name = node.template
             .split(/\\|\//)

--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -661,6 +661,9 @@ export default class RenderTree {
       }
 
       if (node.type === 'component' && !node.instance) {
+        if (node.name === '(unknown template-only component)' && node.template.endsWith('.hbs')) {
+          node.name = node.template.split(/\\|\//).slice(-1)[0].slice(0, -'.hbs'.length);
+        }
         node.instance = this._createSimpleInstance(
           'TemplateOnlyComponent',
           node.args.named

--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -661,8 +661,14 @@ export default class RenderTree {
       }
 
       if (node.type === 'component' && !node.instance) {
-        if (node.name === '(unknown template-only component)' && node.template.endsWith('.hbs')) {
-          node.name = node.template.split(/\\|\//).slice(-1)[0].slice(0, -'.hbs'.length);
+        if (
+          node.name === '(unknown template-only component)' &&
+          node.template.endsWith('.hbs')
+        ) {
+          node.name = node.template
+            .split(/\\|\//)
+            .slice(-1)[0]
+            .slice(0, -'.hbs'.length);
         }
         node.instance = this._createSimpleInstance(
           'TemplateOnlyComponent',


### PR DESCRIPTION
for template only components coming from .hbs files we can know the name by using the moduleName.

this is when gjs/gts files import hbs template only components. Or also when references via js. e.g `<this.MyTemplateOnlyComponent />`