### PR TITLE
Use GH_PAT token to hopefully fix releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build and Publish
 on:
+  workflow_dispatch:
   pull_request: {}
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,5 @@
 name: Build and Publish
 on:
-  workflow_dispatch:
   pull_request: {}
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with: 
+          token: ${{ secrets.GH_PAT }}
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,5 +55,5 @@ jobs:
       - name: npm publish
         run: pnpm release-plan publish --singlePackage=ember-inspector
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GH_PAT }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,5 +54,5 @@ jobs:
       - name: npm publish
         run: pnpm release-plan publish --singlePackage=ember-inspector
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_DEPLOY_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
           ref: 'main'
       # This will only cause the `check-plan` job to have a result of `success`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.GH_PAT }}
           fetch-depth: 0
           ref: 'main'
       # This will only cause the `check-plan` job to have a result of `success`
@@ -54,5 +55,5 @@ jobs:
       - name: npm publish
         run: pnpm release-plan publish --singlePackage=ember-inspector
         env:
-          GITHUB_AUTH: ${{ secrets.GITHUB_DEPLOY_TOKEN }}
+          GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
this is needed so that the tag push triggers a workflow run, which will not happen if using gihub bot token