### PR TITLE
docs: add precisions about running for development with bookmarklet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,18 @@ Internet explorer will open an iframe instead of a popup due to the lack of supp
 
 For development:
 
-- run `pnpm serve:bookmarklet`
-- create a bookmark (make sure you unblock the popup when you run the bookmarklet):
+- In a terminal:
+  - run `pnpm serve:bookmarklet`
+- In your browser:
+  - If Ember Inspector is installed as an active extension, deactivate it
+  - Visit the Ember app you want to inspect
+  - Open the developer tool console and execute the following to create a bookmark (make sure you unblock the popup when you run the bookmarklet):
 
 ```javascript
 javascript: (function() { var s = document.createElement('script'); s.src = 'http://localhost:9191/bookmarklet/load_inspector.js'; document.body.appendChild(s); }());
 ```
+
+The expected behavior is a new window opening with the URL `http://localhost:9191/bookmarklet/<pane-root>/index.html?inspectedWindowURL=<inspected-app-url>`, running your local ember-inspector. The content should be the same as the one you see when using the published extension, but not properly styled.
 
 ## Building and Testing:
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ For development:
 - In your browser:
   - If Ember Inspector is installed as an active extension, deactivate it
   - Visit the Ember app you want to inspect
-  - Open the developer tool console and execute the following to create a bookmark (make sure you unblock the popup when you run the bookmarklet):
+  - Open the developer tool console and execute the following (make sure you unblock the popup when you run the bookmarklet):
 
 ```javascript
 javascript: (function() { var s = document.createElement('script'); s.src = 'http://localhost:9191/bookmarklet/load_inspector.js'; document.body.appendChild(s); }());
 ```
+
+- Or to do this more easily in the future, create a new bookmark in your browser, and copy the above script as the URL.
 
 The expected behavior is a new window opening with the URL `http://localhost:9191/bookmarklet/<pane-root>/index.html?inspectedWindowURL=<inspected-app-url>`, running your local ember-inspector. The content should be the same as the one you see when using the published extension, but not properly styled.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For development:
 javascript: (function() { var s = document.createElement('script'); s.src = 'http://localhost:9191/bookmarklet/load_inspector.js'; document.body.appendChild(s); }());
 ```
 
-- Or to do this more easily in the future, create a new bookmark in your browser, and copy the above script as the URL.
+Or to do this more easily in the future, create a new bookmark in your browser, and copy the above script as the URL.
 
 The expected behavior is a new window opening with the URL `http://localhost:9191/bookmarklet/<pane-root>/index.html?inspectedWindowURL=<inspected-app-url>`, running your local ember-inspector. The content should be the same as the one you see when using the published extension, but not properly styled.
 


### PR DESCRIPTION
## Description

This PR is a proposal to make the documentation for development more verbose. The changes are the following:
- Indicate that if you use Ember Inspector already, you should first deactivate it. I didn't do it the first time I followed this doc, and it resulted in my local Ember Inspector not detecting the Ember app (I didn't investigate the mechanics behind that problem, but I assume that 2 inspectors trying to do things at the same time could trigger issues) 
- Be more specific about what runs where. What to do can be deduced easily enough by an experienced developer who already has a rough idea of how the inspector works, but I believe more precision could be helpful and precisely give some clues about how the inspector is supposed to load.
- Add the expected result, so a new contributor understands if what they experiment is correct.
