### PR TITLE
fix: Cannot convert a Symbol value to a string

### DIFF
--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -119,6 +119,10 @@ export function inspect(value) {
         if (typeOf(v) === 'object') {
           v = '[Object]';
         }
+        // to avoid TypeError: Cannot convert a Symbol value to a string
+        if (typeOf(v) === 'symbol') {
+          v = v.toString();
+        }
         ret.push(`${key}: ${v}`);
       }
     }

--- a/tests/unit/utils/type-check-test.js
+++ b/tests/unit/utils/type-check-test.js
@@ -1,0 +1,22 @@
+import { inspect } from 'ember-debug/utils/type-check';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | type-check', function () {
+  test('inspect | An POJO with Symbols is correctly transformed into preview', async function (assert) {
+    let symbol = Symbol('test');
+    let symbolValue = Symbol('value');
+
+    let inspected = {
+      [symbol]: 'Symbol Value',
+      symbolVal: symbolValue,
+    };
+
+    let obj = inspect(inspected);
+
+    assert.deepEqual(
+      obj,
+      '{ symbolVal: Symbol(value) }',
+      'object is in expected shape',
+    );
+  });
+});


### PR DESCRIPTION
## Description

If object have symbol value, inspector fails trying to render preview for it.
Adding check for for symbol and related test.

```
TypeError: Cannot convert a Symbol value to a string
```

## Screenshots

<img width="689" alt="image" src="https://github.com/user-attachments/assets/9fff534f-3ffa-43c0-a13d-c35bbac9e5b5" />
