### PR TITLE
define packageManager and use-node-version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 public-hoist-pattern[]=@babel/*
 resolution-mode=highest
+use-node-version=18.20.4

--- a/package.json
+++ b/package.json
@@ -194,5 +194,6 @@
   "volta": {
     "node": "18.20.4",
     "pnpm": "9.12.1"
-  }
+  },
+  "packageManager": "pnpm@9.12.1"
 }


### PR DESCRIPTION
## Description

This makes it easier for people not using volta to contribute. Personally since pnpm can manage node version and pnpm version itself now I think we should remove the volta configuration, if you agree then let me know and I'll update this PR 👍 

## Screenshots
