### PR TITLE
fix `whats new` not showing latest changes

### DIFF
--- a/app/routes/whats-new.js
+++ b/app/routes/whats-new.js
@@ -45,7 +45,7 @@ export default class WhatsNewRoute extends TabRoute {
     let ref = version.indexOf('alpha') === -1 ? `v${version}` : 'main';
     let url = `https://raw.githubusercontent.com/emberjs/ember-inspector/${encodeURIComponent(
       ref,
-    )}/CHANGELOG.md`;
+    )}-ember-inspector/CHANGELOG.md`;
 
     return fetch(url)
       .then(checkStatus)

--- a/tests/acceptance/whats-new-test.js
+++ b/tests/acceptance/whats-new-test.js
@@ -7,7 +7,7 @@ import { setupTestAdapter } from '../test-adapter';
 function urlFor(ref) {
   return `https://raw.githubusercontent.com/emberjs/ember-inspector/${encodeURIComponent(
     ref,
-  )}/CHANGELOG.md`;
+  )}-ember-inspector/CHANGELOG.md`;
 }
 
 function generateContent(main = false) {


### PR DESCRIPTION
whats new needs to fetch version with `-ember-inspector` suffix

## Description


## Screenshots
