### PR TITLE
always include tab id

### DIFF
--- a/app/services/adapters/web-extension.ts
+++ b/app/services/adapters/web-extension.ts
@@ -24,6 +24,9 @@ export default class WebExtension extends BasicAdapter {
   }
 
   sendMessage(message?: Partial<Message>) {
+    if (message) {
+      message.tabId = chrome.devtools.inspectedWindow.tabId;
+    }
     this._chromePort.postMessage(message ?? {});
   }
 


### PR DESCRIPTION
chrome can stop the page at any time and put it into the cache. then the tabid will get lost

https://developer.chrome.com/blog/bfcache-extension-messaging-changes