### PR TITLE
test ember 5.8 and 5.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,9 +90,11 @@ jobs:
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
-          - ember-release
-          - ember-beta
-          - ember-canary
+          - ember-lts-5.8
+          - ember-lts-5.12
+          # - ember-release
+          # - ember-beta
+          # - ember-canary
           - ember-default-no-prototype-extensions
 
     steps:

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -84,6 +84,22 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-5.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.8.0',
+          },
+        },
+      },
+      {
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "ember-source-channel-url": "^3.0.0",
     "ember-svg-jar": "^2.6.0",
     "ember-table": "^5.0.6",
-    "ember-template-imports": "^4.2.0",
     "ember-template-lint": "^6.0.0",
     "ember-test-selectors": "^6.0.0",
     "ember-truth-helpers": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,9 +240,6 @@ importers:
       ember-table:
         specifier: ^5.0.6
         version: 5.0.6(@ember/test-helpers@4.0.4(@babel/core@7.26.0)(@glint/template@1.5.1)(ember-source@5.12.0(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.5.1)(rsvp@4.8.5)(webpack@5.97.1)))(@glint/template@1.5.1)(webpack@5.97.1)
-      ember-template-imports:
-        specifier: ^4.2.0
-        version: 4.2.0
       ember-template-lint:
         specifier: ^6.0.0
         version: 6.0.0
@@ -3239,9 +3236,6 @@ packages:
   content-tag@2.0.2:
     resolution: {integrity: sha512-qHRyTp02dgzRK2tsCFxZ1H289bZOuSLNpupr6prvnSFq4SFPmNlBKbbE5PCMb+8+Z1a1z+yCVtXvQIGUCCa3lQ==}
 
-  content-tag@3.1.0:
-    resolution: {integrity: sha512-gSESx+fia81/vKjorui0V6wY7IBpuitd84LcQnaPVF9Xe9ctLAf4saHwbUi3SAhYfi9kxs5ODfAVnm5MmjojCQ==}
-
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
@@ -3933,10 +3927,6 @@ packages:
   ember-template-imports@3.4.2:
     resolution: {integrity: sha512-OS8TUVG2kQYYwP3netunLVfeijPoOKIs1SvPQRTNOQX4Pu8xGGBEZmrv0U1YTnQn12Eg+p6w/0UdGbUnITjyzw==}
     engines: {node: 12.* || >= 14}
-
-  ember-template-imports@4.2.0:
-    resolution: {integrity: sha512-qwf/38E1ut8M2/1tsFJl6kL99799MvxQrx0lN3LAc0HJRQhM/lYHqnHhzS30rkH76g+76TfxcMB5JJZQabWk2A==}
-    engines: {node: 16.* || >= 18}
 
   ember-template-lint@6.0.0:
     resolution: {integrity: sha512-TWWt/qCd4KoQ50T3We5nCoKcsrAT8Ip79Kmm9eyWjjyL+LAbRFu0z+GxcmW7MR+QCNW/1LQs3kwEdtIcaHEGiA==}
@@ -12487,8 +12477,6 @@ snapshots:
 
   content-tag@2.0.2: {}
 
-  content-tag@3.1.0: {}
-
   content-type@1.0.5: {}
 
   continuable-cache@0.3.1: {}
@@ -13748,14 +13736,6 @@ snapshots:
       parse-static-imports: 1.1.0
       string.prototype.matchall: 4.0.11
       validate-peer-dependencies: 1.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ember-template-imports@4.2.0:
-    dependencies:
-      broccoli-stew: 3.0.0
-      content-tag: 3.1.0
-      ember-cli-version-checker: 5.1.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Description

This PR adds explicit tests for Ember 5.8 and 5.12 and also temporarily turns off tests for canary, beta, and release as they are currently broken. I intend to open a PR to track support for 6.4 in a bit 👍 

