### PR TITLE
Fix ember 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,9 @@ jobs:
           - ember-lts-5.4
           - ember-lts-5.8
           - ember-lts-5.12
-          # - ember-release
-          # - ember-beta
-          # - ember-canary
+          - ember-release
+          - ember-beta
+          - ember-canary
           - ember-default-no-prototype-extensions
 
     steps:

--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -35,7 +35,8 @@ class InElementSupportProvider {
     this.debugRenderTree =
       owner.lookup('renderer:-dom')?.debugRenderTree ||
       owner.lookup('service:-glimmer-environment')._debugRenderTree;
-    this.NewElementBuilder = this.runtime.NewElementBuilder;
+    this.NewElementBuilder =
+      this.runtime.NewElementBuilder || this.runtime.NewTreeBuilder;
 
     this.patch();
   }

--- a/ember_debug/utils/ember.js
+++ b/ember_debug/utils/ember.js
@@ -3,7 +3,13 @@ import { emberSafeRequire } from 'ember-debug/utils/ember/loader';
 let Ember;
 
 try {
-  Ember = requireModule('ember').default;
+  Ember = requireModule('ember/barrel').default;
+} catch {
+  // pass through
+}
+
+try {
+  Ember = Ember || requireModule('ember').default;
 } catch {
   Ember = window.Ember;
 }

--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -112,7 +112,10 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
 
       if (!Ember) {
         try {
-          Ember = requireModule('ember')['default'];
+          Ember = requireModule('ember/barrel')['default'];
+        } catch {}
+        try {
+          Ember = Ember || requireModule('ember')['default'];
         } catch {
           Ember = window.Ember;
         }

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -313,10 +313,21 @@ function HtmlElement(
   );
 }
 
+function RouteArgs() {
+  if (hasEmberVersion(6, 4)) {
+    // Related to routable components
+    return Args({ names: ['controller', 'model'] });
+  }
+  if (hasEmberVersion(3, 14)) {
+    return Args({ names: ['model'] });
+  }
+  return Args();
+}
+
 function Route(
   {
     name,
-    args = hasEmberVersion(3, 14) ? Args({ names: ['model'] }) : Args(),
+    args = RouteArgs(),
     instance = Serialized(),
     template = `my-app/templates/${name}.hbs`,
     ...options

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -334,9 +334,10 @@ module('Integration | Injection', function (hooks) {
 
   test('triggering Ember Component Context Menu Item should call inspect nearest', async function (assert) {
     await inject(this.owner, assert);
-    assert.timeout(10);
+    assert.timeout(100);
 
-    const viewInspection = window.EmberInspector.viewDebug.viewInspection;
+    const emberDebug = requireModule('ember-debug/main')['default'];
+    const viewInspection = emberDebug.viewDebug.viewInspection;
 
     const inspectNearestCalled = new Promise((resolve) => {
       viewInspection.inspectNearest = () => {


### PR DESCRIPTION
## Description

This PR enables Ember 6.x support.
- It re-enables `ember-release`, `ember-beta`, and `ember-canary` scenarios on CI.
- It includes a few adjustments to Ember 6 (`runtime.NewTreeBuilder`, barrel file, routable components)

---
This PR was based on #2642, it takes only the commits that re-enable tests for Ember 6.