### PR TITLE
Remove unused file `trigger-port.js`

### DIFF
--- a/tests/helpers/trigger-port.js
+++ b/tests/helpers/trigger-port.js
@@ -1,8 +1,0 @@
-import { run } from '@ember/runloop';
-import { settled } from '@ember/test-helpers';
-
-export async function triggerPort(app, ...args) {
-  // eslint-disable-next-line ember/no-runloop
-  run(() => app.owner.lookup('service:port').trigger(...args));
-  await settled();
-}


### PR DESCRIPTION
## Description

There's no reference to the file `tests/helpers/trigger-port.js` in the current test suite. It seems that in the past, it was imported and used in files that no longer exist.