### PR TITLE
fix ember 3.x-lts

### DIFF
--- a/app/services/adapters/web-extension.ts
+++ b/app/services/adapters/web-extension.ts
@@ -13,8 +13,9 @@ export default class WebExtension extends BasicAdapter {
   /**
    * Called when the adapter is created.
    */
-  constructor() {
-    super();
+  constructor(...args: unknown[]) {
+    // @ts-expect-error ignore
+    super(...args);
 
     this._connect();
     this._handleReload();

--- a/tests/helpers/setup-ember-debug-test.js
+++ b/tests/helpers/setup-ember-debug-test.js
@@ -10,6 +10,8 @@ import {
   teardownContext,
 } from '@ember/test-helpers';
 import { run } from '@ember/runloop';
+import Route from '@ember/routing/route';
+import Controller from '@ember/controller';
 import BasicAdapter from 'ember-inspector/services/adapters/basic';
 import config from 'ember-inspector/config/environment';
 import EmberDebug from 'ember-debug/main';
@@ -51,6 +53,16 @@ export default function setupEmberDebugTest(hooks, options = {}) {
 
     this.owner.register('router:main', Router);
     this.owner.register('service:adapter', BasicAdapter);
+    /**
+     * preferably, ember debug tests should use their own test app
+     * but currently its mangled with the inspector ui app, which is not compatible with all ember versions being tested.
+     * we do filter the tests to only run the ember_debug tests, but that does not prevent the app merging.
+     * The application route/controller/template of inspector ui was being indirectly used in ember_debug tests,
+     * which is not required and broke older lts tests
+     */
+    this.owner.register('route:application', class extends Route {});
+    this.owner.register('controller:application', class extends Controller {});
+    this.owner.register('template:application', hbs('{{outlet}}'));
 
     run(() => {
       EmberDebug.isTesting = true;

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import Service from '@ember/service';
 
 class ChromePort {
   constructor(self, other) {
@@ -289,6 +290,7 @@ module('Integration | Injection', function (hooks) {
         }
       });
     });
+    owner.register('service:port', class extends Service {});
     owner.lookup('service:adapters/web-extension');
     await p;
     await emberDebugStarted;

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -13,8 +13,13 @@ import 'ember-debug/main';
 
 registerWaiter();
 
+/**
+ * we need to override the adapter that is set up in initializers/setup.js
+ * for that we suffix the name of setup initializer with `-2` so that
+ * this initializer comes right after it
+ */
 Application.initializer({
-  name: `00-override-adapter`,
+  name: `setup-2-override-adapter`,
   initialize(app) {
     app.register('service:adapter', TestAdapter);
   },


### PR DESCRIPTION
## Description
* the application route/controller/template of inspector ui was beeing indirectly used in ember_debug tests, which is not required and broke older lts tests
* the override of the adapter was happening to early and then it was again overridden in inspector ui init/setup
* port is not necessary for injection test and is breaking older lts tests, override with empty service