### PR TITLE
fix local dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
         env:
           PR: ${{ github.event.pull_request.number }}
       - name: Build
-        run: pnpm ember build --environment production
+        run: pnpm build:production
       - name: Pack
         run: |
           VERSION="$(jq -r '.version' package.json)"

--- a/ember_debug/package.json
+++ b/ember_debug/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "watch": "pnpm build --watch",
-    "build": "rollup --config"
+    "build": "rollup --config",
+    "prepare": "pnpm build"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.25.9",

--- a/ember_debug/package.json
+++ b/ember_debug/package.json
@@ -4,8 +4,7 @@
   "type": "module",
   "scripts": {
     "watch": "pnpm build --watch",
-    "build": "rollup --config",
-    "prepare": "pnpm build"
+    "build": "rollup --config"
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.25.9",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
     "test": "tests"
   },
   "scripts": {
-    "build": "ember build",
-    "build:production": "EMBER_ENV=production node scripts/download-panes.js && ember build --environment production && gulp compress:chrome && gulp compress:firefox && gulp clean-tmp",
+    "build":"pnpm build:ember-debug && ember build",
+    "build:ember-debug": "pnpm --filter ember-debug build",
+    "build:production": "pnpm build:ember-debug && EMBER_ENV=production node scripts/download-panes.js && ember build --environment production && gulp compress:chrome && gulp compress:firefox && gulp clean-tmp",
     "changelog": "github_changelog_generator -u emberjs -p ember-inspector --since-tag v3.8.0",
     "compress:panes": "gulp compress:chrome-pane && gulp compress:firefox-pane && gulp compress:bookmarklet-pane",
     "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\" --prefixColors auto",
@@ -28,8 +29,13 @@
     "serve:bookmarklet": "ember serve --port 9191",
     "start": "ember serve",
     "test": "concurrently \"pnpm:lint\" \"pnpm:test:*\" --names \"lint,test:\" --prefixColors auto",
-    "test:ember": "COVERAGE=true ember test",
-    "watch": "ember build --watch"
+    "test:ember": "pnpm build:ember-debug && COVERAGE=true ember test",
+    "test-watch": "pnpm '/test-watch:/'",
+    "test-watch:ember-debug": "pnpm --filter ember-debug watch",
+    "test-watch:inspector-ui": "ember test --serv",
+    "watch": "pnpm '/watch:/'",
+    "watch:inspector-ui": "ember build --watch",
+    "watch:ember-debug": "pnpm --filter ember-debug watch"
   },
   "dependencies": {
     "got": "^11.8.6",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "start": "ember serve",
     "test": "concurrently \"pnpm:lint\" \"pnpm:test:*\" --names \"lint,test:\" --prefixColors auto",
     "test:ember": "pnpm build:ember-debug && COVERAGE=true ember test",
-    "test-watch": "pnpm '/test-watch:/'",
-    "test-watch:ember-debug": "pnpm --filter ember-debug watch",
-    "test-watch:inspector-ui": "ember test --serv",
+    "watch-test": "pnpm '/test-watch:/'",
+    "watch-test:ember-debug": "pnpm --filter ember-debug watch",
+    "watch-test:inspector-ui": "ember test --serv",
     "watch": "pnpm '/watch:/'",
     "watch:inspector-ui": "ember build --watch",
     "watch:ember-debug": "pnpm --filter ember-debug watch"


### PR DESCRIPTION
## Description
ember-debug was only build once when doing pnpm install. afterwards one had to notice to manually run build or watch for ember-debug.
this joins both into the root package.json for better local dev experience

## Screenshots
