### PR TITLE
perf: do not re-render positionals

### DIFF
--- a/app/components/component-tree-item.hbs
+++ b/app/components/component-tree-item.hbs
@@ -45,7 +45,7 @@
             {{@item.name}}
           </span>
 
-          {{#each @item.args.positional as |value|}}
+          {{#each @item.args.positional key="@index" as |value|}}
             <div class="arg-token flex ml-2">
               {{if (is-string value) "\""}}
               <ComponentTreeArg @value={{value}} />


### PR DESCRIPTION
## Description
positionals where being re-rendered every time, causing some flickering.
This is happening because the objects are always recreated when something is sent over from ember_debug


## Screenshots
