### PR TITLE
Centralize interactions with ember-source: wormhole

### DIFF
--- a/ember_debug/libs/render-tree.js
+++ b/ember_debug/libs/render-tree.js
@@ -17,11 +17,6 @@ class InElementSupportProvider {
     this.remoteRoots = [];
     this.runtime = GlimmerRuntime;
     this.reference = GlimmerReference;
-    try {
-      this.Wormhole = requireModule('ember-wormhole/components/ember-wormhole');
-    } catch {
-      // nope
-    }
 
     if (GlimmerManager) {
       GlimmerManager.CustomModifierManager.prototype.getDebugInstance = (
@@ -607,9 +602,11 @@ export default class RenderTree {
         this.inElementSupport?.remoteRoots.push(node);
       }
 
+      // EmberWormhole component from ember-wormhole was used to provide
+      // rendering into a given DOM element prior to built-in in-element.
       if (
-        this.inElementSupport?.Wormhole &&
-        node.instance instanceof this.inElementSupport.Wormhole.default
+        node.template ===
+        'ember-wormhole/templates/components/ember-wormhole.hbs'
       ) {
         this.inElementSupport?.remoteRoots.push(node);
         const bounds = node.bounds;


### PR DESCRIPTION
## Context

This PR is part of implementing Vite apps support for the inspector. Inspecting an Ember app built with Vite will change how the `ember_debug.js` script interacts with ember-source (specifically, how Ember modules are imported).

To implement with more confidence how `ember_debug` should adapt its behavior depending on the build system, we started to centralize all the interactions with ember-source in one single script (`ember_debug/utils/ember.js`). In other words, any instruction to require a module (`requireModule`, `emberSafeRequire`) should take place in `ember_debug/utils/ember.js`, and nowhere else in the `ember_debug` folder.

There's one case left, though, where `requireModule` was used to require ember-wormhole component in another file.

## Description

This PR removes the import of ember-wormhole component in `render-tree.js`, in favor of another approach. The tree is built out of a node tree provided by Ember. Nodes with the type `component` have a `name` and `template` that get printed in the inspector's popups. When ember-wormhole is used, the node corresponding to the `<EmberWormhole>` component has the template `ember-wormhole/templates/components/ember-wormhole.hbs`. This template location never changed from ember-wormhole 0.5.0 (which introduced the compatibility with Ember 3.16) to latest.

