### PR TITLE
handle glimmer validator patch failure

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -67,7 +67,7 @@ if (GlimmerValidator) {
       }
       return r;
     };
-  } catch (_e) {
+  } catch {
     // cannot patch
   }
 } else if (GlimmerReference) {


### PR DESCRIPTION
## Description

if ember is build with vite, all exports are readonly. cannot patch. this part is to support tracked deps, but currently doesn't work with ember 6 or vite.