### PR TITLE
fix service detection

### DIFF
--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -899,18 +899,7 @@ function addProperties(properties, hash) {
     let options = { isMandatorySetter: isMandatorySetter(desc) };
 
     if (typeof hash[prop] === 'object' && hash[prop] !== null) {
-      options.isService =
-        !('type' in hash[prop]) && hash[prop].type === 'service';
-
-      if (!options.isService) {
-        if (hash[prop].constructor) {
-          options.isService = hash[prop].constructor.isServiceFactory;
-        }
-      }
-
-      if (!options.isService) {
-        options.isService = desc.value instanceof Service;
-      }
+      options.isService = desc.value instanceof Service;
     }
     if (options.isService) {
       replaceProperty(properties, prop, inspectValue(hash, prop), options);

--- a/ember_debug/object-inspector.js
+++ b/ember_debug/object-inspector.js
@@ -1101,6 +1101,9 @@ function calculateCPs(
               item.code = '';
             }
           }
+          if (value instanceof Service) {
+            item.isService = true;
+          }
         }
       }
     });

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -11,7 +11,7 @@ import EmberObject, { computed } from '@ember/object';
 import MutableArray from '@ember/array/mutable';
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
-import Service, { service } from '@ember/service';
+import Service, { inject as service } from '@ember/service';
 import { VERSION } from '@ember/version';
 import { tracked } from '@glimmer/tracking';
 import { module, skip, test } from 'qunit';

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -912,7 +912,6 @@ module('Ember Debug - Object Inspector', function (hooks) {
     }).create(this);
 
     let message = await inspectObject(inspected);
-    console.log('mesg', message);
 
     let serializedServiceProperty = message.details[1].properties[0];
     let serializedService2Property = message.details[1].properties[1];

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -11,7 +11,7 @@ import EmberObject, { computed } from '@ember/object';
 import MutableArray from '@ember/array/mutable';
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
-import Service from '@ember/service';
+import Service, { service } from '@ember/service';
 import { VERSION } from '@ember/version';
 import { tracked } from '@glimmer/tracking';
 import { module, skip, test } from 'qunit';
@@ -902,17 +902,23 @@ module('Ember Debug - Object Inspector', function (hooks) {
       fooBoo() {
         return true;
       },
-    }).create();
+    });
+
+    this.owner.register('service:test-inspect-service', inspectedService);
 
     let inspected = EmberObject.extend({
-      service: inspectedService,
-    }).create();
+      service: inspectedService.create(),
+      service2: service('test-inspect-service'),
+    }).create(this);
 
     let message = await inspectObject(inspected);
+    console.log('mesg', message);
 
     let serializedServiceProperty = message.details[1].properties[0];
+    let serializedService2Property = message.details[1].properties[1];
 
     assert.true(serializedServiceProperty.isService);
+    assert.true(serializedService2Property.isService);
   });
 
   test('Proxy Service should be successfully tagged as service on serialization', async function (assert) {


### PR DESCRIPTION
## Description

The current code in object-inspector.js doesn't fit well how Services can be detected in the versions we support. Part of the code is now unused, and services appear in the inspector as Computed Properties.

this does the service detection by checking the value after obtaining the value

based on #2661 

## Screenshots
before:
![image](https://github.com/user-attachments/assets/b34ebe3b-be22-4bd2-9115-b32bdb534663)

after
![image](https://github.com/user-attachments/assets/ea9d500e-8224-44b0-90eb-ad78be8b3eb9)
