### PR TITLE
Cleanup import ember

### DIFF
--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -1,7 +1,7 @@
 import BasicAdapter from './basic';
 import { typeOf } from 'ember-debug/utils/type-check';
 
-import Ember from 'ember-debug/utils/ember';
+import { getEnv } from 'ember-debug/utils/ember';
 import { run } from 'ember-debug/utils/ember/runloop';
 
 const { isArray } = Array;
@@ -106,7 +106,7 @@ export default class extends BasicAdapter {
 // adapter later. See GH #1114.
 const HAS_ARRAY_PROTOTYPE_EXTENSIONS = (() => {
   try {
-    return Ember.ENV.EXTEND_PROTOTYPES.Array === true;
+    return getEnv().EXTEND_PROTOTYPES.Array === true;
   } catch {
     return false;
   }

--- a/ember_debug/deprecation-debug.js
+++ b/ember_debug/deprecation-debug.js
@@ -1,7 +1,7 @@
 import DebugPort from './debug-port';
 import SourceMap from 'ember-debug/libs/source-map';
 
-import { registerDeprecationHandler } from 'ember-debug/utils/ember/debug';
+import { Debug } from 'ember-debug/utils/ember';
 import { guidFor } from 'ember-debug/utils/ember/object/internals';
 import { cancel, debounce } from 'ember-debug/utils/ember/runloop';
 
@@ -194,7 +194,7 @@ export default class extends DebugPort {
   }
 
   handleDeprecations() {
-    registerDeprecationHandler((message, options, next) => {
+    Debug.registerDeprecationHandler((message, options, next) => {
       if (!this.adapter) {
         next(message, options);
         return;

--- a/ember_debug/general-debug.js
+++ b/ember_debug/general-debug.js
@@ -1,7 +1,7 @@
 /* eslint no-empty:0 */
 import DebugPort from './debug-port';
 
-import Ember from 'ember-debug/utils/ember';
+import { libraries } from 'ember-debug/utils/ember';
 
 /**
  * Class that handles gathering general information of the inspected app.
@@ -88,7 +88,7 @@ export default class extends DebugPort {
        */
       getLibraries() {
         this.sendMessage('libraries', {
-          libraries: Ember.libraries?._registry,
+          libraries: libraries?._registry,
         });
       },
 

--- a/ember_debug/libs/promise-assembler.js
+++ b/ember_debug/libs/promise-assembler.js
@@ -6,7 +6,7 @@
  */
 
 import Promise from 'ember-debug/models/promise';
-import RSVP from 'ember-debug/utils/rsvp';
+import { RSVP } from 'ember-debug/utils/ember';
 import BaseObject from 'ember-debug/utils/base-object';
 import Evented from 'ember-debug/utils/evented';
 

--- a/ember_debug/models/profile-manager.js
+++ b/ember_debug/models/profile-manager.js
@@ -1,5 +1,5 @@
 import ProfileNode from './profile-node';
-import Ember from 'ember-debug/utils/ember';
+import { VERSION } from 'ember-debug/utils/ember';
 import { compareVersion } from 'ember-debug/utils/version';
 
 import { later, scheduleOnce, cancel } from 'ember-debug/utils/ember/runloop';
@@ -75,8 +75,7 @@ export default class ProfileManager {
     this.stylesheet = insertStylesheet();
     // keep track of all the active highlights
     this.highlights = [];
-    // eslint-disable-next-line ember/new-module-imports
-    this.isHighlightEnabled = compareVersion(Ember?.VERSION, '3.20.0') !== -1;
+    this.isHighlightEnabled = compareVersion(VERSION, '3.20.0') !== -1;
   }
 
   began(timestamp, payload, now) {

--- a/ember_debug/promise-debug.js
+++ b/ember_debug/promise-debug.js
@@ -1,7 +1,7 @@
 import DebugPort from './debug-port';
 import PromiseAssembler from 'ember-debug/libs/promise-assembler';
 import { debounce } from 'ember-debug/utils/ember/runloop';
-import RSVP from 'ember-debug/utils/rsvp';
+import { RSVP } from 'ember-debug/utils/ember';
 
 export default class extends DebugPort {
   get objectInspector() {

--- a/ember_debug/render-debug.js
+++ b/ember_debug/render-debug.js
@@ -1,7 +1,7 @@
 import DebugPort from './debug-port';
 import ProfileManager from './models/profile-manager';
 
-import { subscribe } from 'ember-debug/utils/ember/instrumentation';
+import { subscribe } from 'ember-debug/utils/ember';
 import { _backburner } from 'ember-debug/utils/ember/runloop';
 import bound from 'ember-debug/utils/bound-method';
 

--- a/ember_debug/utils/ember.js
+++ b/ember_debug/utils/ember.js
@@ -29,31 +29,30 @@ export function emberSafeRequire(id) {
   }
 }
 
-let ArrayProxy = Ember.ArrayProxy;
-let Namespace = Ember.Namespace;
-let ActionHandler = Ember.ActionHandler;
-let ControllerMixin = Ember.ControllerMixin;
-let CoreObject = Ember.CoreObject;
-let Application = Ember.Application;
-let MutableArray = Ember.MutableArray;
-let MutableEnumerable = Ember.MutableEnumerable;
-let NativeArray = Ember.NativeArray;
-let Component = Ember.Component;
-let Observable = Ember.Observable;
-let Evented = Ember.Evented;
-let PromiseProxyMixin = Ember.PromiseProxyMixin;
-let Service = Ember.Service;
-let ObjectProxy = Ember.ObjectProxy;
-let VERSION = Ember.VERSION;
-let ComputedProperty = Ember.ComputedProperty;
-let meta = Ember.meta;
-let get = Ember.get;
-let set = Ember.set;
-let computed = Ember.computed;
-let EmberObject = Ember.Object;
-let captureRenderTree = Ember._captureRenderTree;
-
-let getEnv = () => Ember.ENV;
+let ArrayProxy,
+  Namespace,
+  ActionHandler,
+  ControllerMixin,
+  CoreObject,
+  Application,
+  MutableArray,
+  MutableEnumerable,
+  NativeArray,
+  Component,
+  Observable,
+  Evented,
+  PromiseProxyMixin,
+  Service,
+  ObjectProxy,
+  VERSION,
+  ComputedProperty,
+  meta,
+  get,
+  set,
+  computed,
+  EmberObject,
+  captureRenderTree,
+  getEnv;
 
 let Debug = emberSafeRequire('@ember/debug');
 let InternalsMetal = emberSafeRequire('@ember/-internals/metal');
@@ -72,7 +71,32 @@ let GlimmerRuntime = emberSafeRequire('@glimmer/runtime');
 let GlimmerUtil = emberSafeRequire('@glimmer/util');
 let GlimmerValidator = emberSafeRequire('@glimmer/validator');
 
-if (!Ember) {
+if (Ember) {
+  captureRenderTree = Ember._captureRenderTree;
+  getEnv = () => Ember.ENV;
+  ArrayProxy = Ember.ArrayProxy;
+  ObjectProxy = Ember.ObjectProxy;
+  MutableArray = Ember.MutableArray;
+  Namespace = Ember.Namespace;
+  MutableEnumerable = Ember.MutableEnumerable;
+  NativeArray = Ember.NativeArray;
+  ControllerMixin = Ember.ControllerMixin;
+  CoreObject = Ember.CoreObject;
+  Application = Ember.Application;
+  Component = Ember.Component;
+  Observable = Ember.Observable;
+  Evented = Ember.Evented;
+  PromiseProxyMixin = Ember.PromiseProxyMixin;
+  Service = Ember.Service;
+  EmberObject = Ember.Object;
+  VERSION = Ember.VERSION;
+  ComputedProperty = Ember.ComputedProperty;
+  meta = Ember.meta;
+  get = Ember.get;
+  set = Ember.set;
+  computed = Ember.computed;
+  ActionHandler = Ember.ActionHandler;
+} else {
   captureRenderTree = emberSafeRequire('@ember/debug')?.captureRenderTree;
   getEnv = emberSafeRequire('@ember/-internals/environment')?.getENV;
   ArrayProxy = emberSafeRequire('@ember/array/proxy')?.default;

--- a/ember_debug/utils/ember.js
+++ b/ember_debug/utils/ember.js
@@ -63,13 +63,21 @@ let EmberDestroyable = emberSafeRequire('@ember/destroyable');
 let ObjectInternals = emberSafeRequire('@ember/object/internals');
 let Instrumentation = emberSafeRequire('@ember/instrumentation');
 let Runloop = emberSafeRequire('@ember/runloop');
+
 let RSVP = emberSafeRequire('rsvp');
+
 let GlimmerComponent = emberSafeRequire('@glimmer/component');
 let GlimmerManager = emberSafeRequire('@glimmer/manager');
 let GlimmerReference = emberSafeRequire('@glimmer/reference');
 let GlimmerRuntime = emberSafeRequire('@glimmer/runtime');
 let GlimmerUtil = emberSafeRequire('@glimmer/util');
 let GlimmerValidator = emberSafeRequire('@glimmer/validator');
+
+let inspect = Debug?.inspect || InternalsUtils?.inspect;
+let subscribe = Instrumentation?.subscribe;
+let cacheFor = ObjectInternals?.cacheFor;
+let guidFor = ObjectInternals?.guidFor;
+let libraries = InternalsMetal?.libraries;
 
 if (Ember) {
   captureRenderTree = Ember._captureRenderTree;
@@ -96,6 +104,15 @@ if (Ember) {
   set = Ember.set;
   computed = Ember.computed;
   ActionHandler = Ember.ActionHandler;
+  Debug = Debug ?? Ember.Debug;
+  inspect = inspect ?? Ember.inspect;
+  Instrumentation = Instrumentation ?? Ember.Instrumentation;
+  subscribe = subscribe ?? Ember.subscribe;
+  RSVP = RSVP ?? Ember.RSVP;
+  Runloop = Runloop ?? Ember.run;
+  cacheFor = cacheFor ?? Ember.cacheFor;
+  guidFor = guidFor ?? Ember.guidFor;
+  libraries = libraries ?? Ember.libraries;
 } else {
   captureRenderTree = emberSafeRequire('@ember/debug')?.captureRenderTree;
   getEnv = emberSafeRequire('@ember/-internals/environment')?.getENV;
@@ -160,6 +177,11 @@ export {
   set,
   captureRenderTree,
   getEnv,
+  inspect,
+  subscribe,
+  cacheFor,
+  guidFor,
+  libraries,
   GlimmerComponent,
   GlimmerManager,
   GlimmerReference,

--- a/ember_debug/utils/ember/debug.js
+++ b/ember_debug/utils/ember/debug.js
@@ -1,21 +1,5 @@
-import Ember, { Debug, InternalsUtils } from '../ember';
+import { Debug, inspect as emberInspect } from '../ember';
 
-let module;
-export let inspect;
-
-if (Debug) {
-  module = Debug;
-  inspect = Debug.inspect || InternalsUtils.inspect;
-} else {
-  module = Ember.Debug;
-  // eslint-disable-next-line ember/new-module-imports
-  inspect = Ember.inspect;
-}
-
-if (!inspect) {
-  // eslint-disable-next-line ember/new-module-imports
-  inspect = Ember.inspect;
-}
-
-export let { registerDeprecationHandler } = module;
-export default module;
+export let inspect = emberInspect;
+export let { registerDeprecationHandler } = Debug;
+export default Debug;

--- a/ember_debug/utils/ember/debug.js
+++ b/ember_debug/utils/ember/debug.js
@@ -1,5 +1,0 @@
-import { Debug, inspect as emberInspect } from '../ember';
-
-export let inspect = emberInspect;
-export let { registerDeprecationHandler } = Debug;
-export default Debug;

--- a/ember_debug/utils/ember/instrumentation.js
+++ b/ember_debug/utils/ember/instrumentation.js
@@ -1,3 +1,0 @@
-import { subscribe as emberSubscribe } from '../ember';
-
-export let subscribe = emberSubscribe;

--- a/ember_debug/utils/ember/instrumentation.js
+++ b/ember_debug/utils/ember/instrumentation.js
@@ -1,11 +1,3 @@
-import Ember, { Instrumentation } from '../ember';
+import { subscribe as emberSubscribe } from '../ember';
 
-let module;
-
-if (Instrumentation) {
-  module = Instrumentation;
-} else {
-  module = Ember;
-}
-
-export let { subscribe } = module;
+export let subscribe = emberSubscribe;

--- a/ember_debug/utils/ember/object/internals.js
+++ b/ember_debug/utils/ember/object/internals.js
@@ -1,9 +1,4 @@
-import Ember, { ObjectInternals } from '../../ember';
-
-// eslint-disable-next-line ember/new-module-imports
-let cacheFor = ObjectInternals?.cacheFor ?? Ember.cacheFor;
-// eslint-disable-next-line ember/new-module-imports
-let emberGuidFor = ObjectInternals?.guidFor ?? Ember.guidFor;
+import { cacheFor, guidFor as emberGuidFor } from '../../ember';
 
 // it can happen that different ember apps/iframes have the same id for different objects
 // since the implementation is just a counter, so we add a prefix per iframe & app

--- a/ember_debug/utils/ember/runloop.js
+++ b/ember_debug/utils/ember/runloop.js
@@ -1,4 +1,4 @@
-import Ember, { Runloop as EmberRunloop } from '../ember';
+import { Runloop as EmberRunloop } from '../ember';
 import * as runloop from './own-runloop';
 
 // it could happen that runloop is available but _backburner is not exported (dead code)
@@ -8,15 +8,9 @@ let _backburner = runloop._backburner;
 
 const keys = ['cancel', 'debounce', 'join', 'later', 'scheduleOnce'];
 
-if (EmberRunloop) {
-  module = EmberRunloop;
-  _backburner = EmberRunloop._backburner || EmberRunloop.backburner;
-} else {
-  // eslint-disable-next-line ember/new-module-imports
-  module = Ember?.run || module;
-  // eslint-disable-next-line ember/new-module-imports
-  _backburner = Ember?.run?.backburner || _backburner;
-}
+module = EmberRunloop;
+_backburner =
+  EmberRunloop._backburner || EmberRunloop.backburner || _backburner;
 
 if (!keys.every((k) => k in module)) {
   module = runloop;

--- a/ember_debug/utils/rsvp.js
+++ b/ember_debug/utils/rsvp.js
@@ -1,14 +1,5 @@
-import Ember, { RSVP as emberRSVP } from './ember';
+import { RSVP as emberRSVP } from './ember';
 
-let module;
+export let { Promise, all, resolve } = emberRSVP;
 
-if (emberRSVP) {
-  module = emberRSVP;
-} else {
-  // eslint-disable-next-line ember/new-module-imports
-  module = Ember.RSVP;
-}
-
-export let { Promise, all, resolve } = module;
-
-export default module;
+export default emberRSVP;

--- a/ember_debug/utils/rsvp.js
+++ b/ember_debug/utils/rsvp.js
@@ -1,5 +1,0 @@
-import { RSVP as emberRSVP } from './ember';
-
-export let { Promise, all, resolve } = emberRSVP;
-
-export default emberRSVP;

--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -1,4 +1,4 @@
-import Debug, { inspect as emberInspect } from 'ember-debug/utils/ember/debug';
+import { Debug, inspect as emberInspect } from 'ember-debug/utils/ember';
 import {
   ComputedProperty,
   EmberObject,


### PR DESCRIPTION
## Description

This PR is part of preparing the ground for Vite support. When running the Inspector against a Vite app, the `Ember` global from `ember_debug/utils/ember` is undefined. The problem is twofold: first, the utils file itself is not prepared for this case; second, Ember is exported as default from the utils to be used in different places of the code. 

This PR:
- Complete the "centralization" work by removing all the `import Ember from 'ember_debug/utils/ember'` in favor of the named exports.
- Re-order things in the utils so we never try to access `Ember` properties if `Ember` is not defined.