### PR TITLE
remove overkill use of env to simplify new build process

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -170,7 +170,7 @@ module.exports = function (defaults) {
     function (dist) {
       emberDebugs[dist] = map(emberDebug, '**/*.js', function (content) {
         return wrapWithLoader(
-          `(function(adapter, env) {\n${content}\n}('${dist}', '${env}'))`,
+          `(function(adapter) {\n${content}\n}('${dist}'))`,
         );
       });
     },

--- a/ember_debug/adapters/basic.js
+++ b/ember_debug/adapters/basic.js
@@ -12,21 +12,6 @@ export default class BasicAdapter extends BaseObject {
     this._messageCallbacks = [];
   }
 
-  /**
-   * Uses the current build's config module to determine
-   * the environment.
-   *
-   * @property environment
-   * @type {String}
-   */
-  get environment() {
-    if (!this.__environment) {
-      this.__environment =
-        requireModule('ember-debug/config')['default'].environment;
-    }
-    return this.__environment;
-  }
-
   debug() {
     return console.debug(...arguments);
   }
@@ -94,19 +79,14 @@ export default class BasicAdapter extends BaseObject {
    * @param {Error} error
    */
   handleError(error) {
-    if (this.environment === 'production') {
-      if (error && error instanceof Error) {
-        error = `Error message: ${error.message}\nStack trace: ${error.stack}`;
-      }
-      this.warn(
-        `Ember Inspector has errored.\n` +
-          `This is likely a bug in the inspector itself.\n` +
-          `You can report bugs at https://github.com/emberjs/ember-inspector.\n${error}`,
-      );
-    } else {
-      this.warn('EmberDebug has errored:');
-      throw error;
+    if (error && error instanceof Error) {
+      error = `Error message: ${error.message}\nStack trace: ${error.stack}`;
     }
+    this.warn(
+      `Ember Inspector has errored.\n` +
+        `This is likely a bug in the inspector itself.\n` +
+        `You can report bugs at https://github.com/emberjs/ember-inspector.\n${error}`,
+    );
   }
 
   /**

--- a/ember_debug/vendor/startup-wrapper.js
+++ b/ember_debug/vendor/startup-wrapper.js
@@ -45,14 +45,6 @@ var EMBER_VERSIONS_SUPPORTED = {{EMBER_VERSIONS_SUPPORTED}};
 
     // prevent from injecting twice
     if (!window.EmberInspector) {
-      // Make sure we only work for the supported version
-      define('ember-debug/config', function() {
-        return {
-          default: {
-            environment: currentEnv
-          }
-        };
-      });
 
       let emberDebugMainModule = requireModule('ember-debug/main');
       if (!emberDebugMainModule) {


### PR DESCRIPTION
## Description

This is to simplify the removal of the `wrapWithLoader` function in ember-cli-build since the build env is only being used to determine a different structure of error that is being passed to the console.

This is totally overkill for the cost of the complexity it adds to the build 🙈 