### PR TITLE
Fix value.hasOwnProperty is not a function error

### DIFF
--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -101,7 +101,7 @@ export function inspect(value) {
     let broken = false;
 
     for (let key in value) {
-      if (!('hasOwnProperty' in value) || value.hasOwnProperty(key)) {
+      if (!('hasOwnProperty' in value) || (value.hasOwnProperty && value.hasOwnProperty(key))) {
         if (count++ > 1) {
           broken = true;
           break;

--- a/ember_debug/utils/type-check.js
+++ b/ember_debug/utils/type-check.js
@@ -101,7 +101,7 @@ export function inspect(value) {
     let broken = false;
 
     for (let key in value) {
-      if (!('hasOwnProperty' in value) || (value.hasOwnProperty && value.hasOwnProperty(key))) {
+      if (Object.prototype.hasOwnProperty.call(value, key)) {
         if (count++ > 1) {
           broken = true;
           break;


### PR DESCRIPTION
## Description

I keep running into this error when `value` is a proxy. With this change, it works even w/ proxies.

TBH I didn't really look at what the point of this code is so IDK if this fix is correct. I just want it to stop borking my debug sessions. 😂 


## Screenshots

<img width="1021" height="231" alt="image" src="https://github.com/user-attachments/assets/62088e9e-005a-4a71-9bc3-f74b2677a0b6" />
