### PR TITLE
Fix theme colors no rendering in tests and bookmarklet

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -31,7 +31,7 @@
 
     {{content-for "head-footer"}}
   </head>
-  <body class="theme--light">
+  <body class="theme-light">
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>

--- a/tests/index.html
+++ b/tests/index.html
@@ -31,7 +31,7 @@
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
   </head>
-  <body class="theme--light">
+  <body class="theme-light">
 
     {{content-for "body"}}
     {{content-for "test-body"}}


### PR DESCRIPTION
## Description

`theme--light` and `theme--dark` do not exist and this only worked in the extension by accident because `_setThemeColors()` method added the `light-theme` class to the body.

## Screenshots

<img width="1246" height="798" alt="image" src="https://github.com/user-attachments/assets/fcada306-3835-4ba3-a1af-8223f2ebbb78" />

Dark mode

<img width="1280" height="545" alt="image" src="https://github.com/user-attachments/assets/9ca80e42-e91e-4b9f-a2c6-9b096f37f940" />

