### PR TITLE
update publish remove token for checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,8 +145,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_PAT }}
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
the token was there to support a flow with no/mininimal changes to release-plan. release plan would do its npm release. create tag & git release. the git tag would then trigger the workflow to do the chrome/firefox release. to support this flow a PAT token was required. as otherwise a git tag would not trigger a new workflow

## Description


## Screenshots
