### PR TITLE
Enable Opening of Components in Preferred Text Editor

### DIFF
--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -85,6 +85,13 @@ export default class extends BasicAdapter {
       // think we most likely can. In the limited cases (if any) where the
       // runloop is needed, the callback code should just do the wrapping
       // themselves.
+      // Handle messages from both content-script and devtools
+      if (message.from === 'content-script' || message.from === 'devtools') {
+        if (message.type && message.type.startsWith('view:')) {
+          this._messageReceived(message);
+          return;
+        }
+      }
       if (message.type.startsWith('view:')) {
         this._messageReceived(message);
       } else {

--- a/ember_debug/adapters/web-extension.js
+++ b/ember_debug/adapters/web-extension.js
@@ -85,13 +85,6 @@ export default class extends BasicAdapter {
       // think we most likely can. In the limited cases (if any) where the
       // runloop is needed, the callback code should just do the wrapping
       // themselves.
-      // Handle messages from both content-script and devtools
-      if (message.from === 'content-script' || message.from === 'devtools') {
-        if (message.type && message.type.startsWith('view:')) {
-          this._messageReceived(message);
-          return;
-        }
-      }
       if (message.type.startsWith('view:')) {
         this._messageReceived(message);
       } else {

--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -229,6 +229,7 @@ export default class ViewInspection {
   constructor({
     renderTree,
     objectInspector,
+    editorUrlPattern,
     didShow,
     didHide,
     didStartInspecting,
@@ -236,6 +237,7 @@ export default class ViewInspection {
   }) {
     this.renderTree = renderTree;
     this.objectInspector = objectInspector;
+    this.editorUrlPattern = editorUrlPattern || null;
 
     this.didShow = didShow;
     this.didHide = didHide;
@@ -557,7 +559,21 @@ export default class ViewInspection {
     if (Array.isArray(value)) {
       this._renderTokens(td, value);
     } else {
-      td.innerText = value.replace(/\//g, '\u200B/\u200B');
+      if (key === 'Template') {
+        if (this.editorUrlPattern && value.startsWith('/')) {
+          const editorUrl = this.editorUrlPattern.replace('{{file}}', value);
+          const anchor = document.createElement('a');
+          anchor.setAttribute('href', editorUrl);
+          anchor.setAttribute('target', '_blank');
+          anchor.setAttribute('rel', 'noopener noreferrer');
+          anchor.innerText = value.replace(/\//g, '\u200B/\u200B');
+          td.appendChild(anchor);
+        } else {
+          td.innerText = value.replace(/\//g, '\u200B/\u200B');
+        }
+      } else {
+        td.innerText = value.replace(/\//g, '\u200B/\u200B');
+      }
     }
 
     tr.appendChild(th);

--- a/ember_debug/libs/view-inspection.js
+++ b/ember_debug/libs/view-inspection.js
@@ -229,7 +229,6 @@ export default class ViewInspection {
   constructor({
     renderTree,
     objectInspector,
-    editorUrlPattern,
     didShow,
     didHide,
     didStartInspecting,
@@ -237,7 +236,6 @@ export default class ViewInspection {
   }) {
     this.renderTree = renderTree;
     this.objectInspector = objectInspector;
-    this.editorUrlPattern = editorUrlPattern || null;
 
     this.didShow = didShow;
     this.didHide = didHide;

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -49,12 +49,18 @@ export default class extends DebugPort {
         this.lastRightClicked = null;
         this.inspectNearest(lastRightClicked);
       },
+
+      editorUrlPatternReceived(message) {
+        this.setEditorPattern(message.value);
+      },
     };
   }
 
   // eslint-disable-next-line ember/classic-decorator-hooks
   init() {
     super.init();
+
+    this.editorPattern = null;
 
     let renderTree = (this.renderTree = new RenderTree({
       owner: this.getOwner(),
@@ -72,6 +78,7 @@ export default class extends DebugPort {
     this.viewInspection = new ViewInspection({
       renderTree,
       objectInspector: this.objectInspector,
+      editorUrlPattern: this.editorPattern,
       didShow: bound(this, this.didShowInspection),
       didHide: bound(this, this.didHideInspection),
       didStartInspecting: bound(this, this.didStartInspecting),
@@ -197,5 +204,12 @@ export default class extends DebugPort {
 
   getOwner() {
     return this.namespace?.owner;
+  }
+
+  setEditorPattern(pattern) {
+    this.editorPattern = pattern && typeof pattern === 'string' ? pattern : null;
+    if (this.viewInspection) {
+      this.viewInspection.editorUrlPattern = this.editorPattern;
+    }
   }
 }

--- a/ember_debug/view-debug.js
+++ b/ember_debug/view-debug.js
@@ -60,8 +60,6 @@ export default class extends DebugPort {
   init() {
     super.init();
 
-    this.editorPattern = null;
-
     let renderTree = (this.renderTree = new RenderTree({
       owner: this.getOwner(),
       retainObject: bound(
@@ -78,7 +76,6 @@ export default class extends DebugPort {
     this.viewInspection = new ViewInspection({
       renderTree,
       objectInspector: this.objectInspector,
-      editorUrlPattern: this.editorPattern,
       didShow: bound(this, this.didShowInspection),
       didHide: bound(this, this.didHideInspection),
       didStartInspecting: bound(this, this.didStartInspecting),
@@ -207,9 +204,6 @@ export default class extends DebugPort {
   }
 
   setEditorPattern(pattern) {
-    this.editorPattern = pattern && typeof pattern === 'string' ? pattern : null;
-    if (this.viewInspection) {
-      this.viewInspection.editorUrlPattern = this.editorPattern;
-    }
+    this.viewInspection.editorUrlPattern = pattern;
   }
 }

--- a/skeletons/web-extension/content-script.js
+++ b/skeletons/web-extension/content-script.js
@@ -52,6 +52,17 @@
     });
 
     emberDebugPort.start();
+
+    chrome.storage.sync.get('options', function (data) {
+      var editorPattern = data.options && data.options.editorPattern;
+      if (editorPattern) {
+        emberDebugPort.postMessage({
+          type: 'view:editorUrlPatternReceived',
+          from: 'content-script',
+          value: editorPattern
+        });
+      }
+    });
   }
 
   // document.documentElement.dataset is not present for SVG elements

--- a/skeletons/web-extension/content-script.js
+++ b/skeletons/web-extension/content-script.js
@@ -53,6 +53,10 @@
 
     emberDebugPort.start();
 
+    /**
+     * On initial load of the extension pull from storage and pass
+     * via postMessage the user's stored preferred text editor pattern
+     */
     chrome.storage.sync.get('options', function (data) {
       var editorPattern = data.options && data.options.editorPattern;
       if (editorPattern) {
@@ -64,6 +68,9 @@
       }
     });
 
+    /**
+     * Pass along any new user editor selection value to any running instances
+     */
     chrome.storage.onChanged.addListener(function (changes) {
       if (changes.options) {
         var editorPattern = changes.options.newValue && changes.options.newValue.editorPattern;

--- a/skeletons/web-extension/content-script.js
+++ b/skeletons/web-extension/content-script.js
@@ -63,6 +63,17 @@
         });
       }
     });
+
+    chrome.storage.onChanged.addListener(function (changes) {
+      if (changes.options) {
+        var editorPattern = changes.options.newValue && changes.options.newValue.editorPattern;
+        emberDebugPort.postMessage({
+          type: 'view:editorUrlPatternReceived',
+          from: 'content-script',
+          value: editorPattern
+        });
+      }
+    });
   }
 
   // document.documentElement.dataset is not present for SVG elements

--- a/skeletons/web-extension/options-dialog.html
+++ b/skeletons/web-extension/options-dialog.html
@@ -10,12 +10,18 @@
   </style>
 </head>
 <body>
+  <h1>Ember Favicon</h1>
   <label>
     <input type="checkbox" data-settings="tomster">
     Display the Ember favicon
     <img src="/{{PANE_ROOT}}/assets/svg/ember-icon.svg" width="19" height="19">
     when a site runs Ember.js
   </label>
+  <hr />
+  <h1>Text Editor</h1>
+  <p>Open files from the inspector in your preferred editor or supply a custom URL scheme</p>
+  <div id="editor-selections"></div>
   <script src="options.js"></script>
 </body>
 </html>
+

--- a/skeletons/web-extension/options-dialog.html
+++ b/skeletons/web-extension/options-dialog.html
@@ -3,11 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>Options</title>
-  <style>
-    label img {
-      vertical-align: middle;
-    }
-  </style>
+  <link rel="stylesheet" href="options.css">
 </head>
 <body>
   <h1>Ember Favicon</h1>
@@ -19,7 +15,6 @@
   </label>
   <hr />
   <h1>Text Editor</h1>
-  <p>Open files from the inspector in your preferred editor or supply a custom URL scheme</p>
   <div id="editor-selections"></div>
   <script src="options.js"></script>
 </body>

--- a/skeletons/web-extension/options.css
+++ b/skeletons/web-extension/options.css
@@ -1,0 +1,22 @@
+label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+label img {
+  vertical-align: middle;
+}
+
+.editor-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 16px;
+  margin: 8px 0;
+}
+
+.editor-custom {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #ddd;
+}

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -3,7 +3,8 @@
 /**
  * Extension options for Chrome.
  * This allows the user to decide if the Ember icon should show when visiting
- * a webpage that has Ember running.
+ * a webpage that has Ember running and specify which text editor should be used
+ * for opening files from the inspector
  *
  * see:
  *     https://developer.chrome.com/extensions/options
@@ -11,15 +12,127 @@
 (function () {
   'use strict';
 
+  var TomsterSelector = '[data-settings=tomster]';
+  var Editors = [
+    {
+      id: 'no-selection',
+      name: 'Do not open in editor',
+      pattern: '{{file}}',
+    },
+    {
+      id: 'vscode',
+      name: 'VS Code',
+      pattern: 'vscode://file/{{file}}',
+    },
+    {
+      id: 'sublime',
+      name: 'Sublime Text',
+      pattern: 'subl://open?url=file://{{file}}',
+    },
+    {
+      id: 'jetbrains',
+      name: 'JetBrains IDEs (IntelliJ IDEA / WebStorm / PyCharm)',
+      pattern: 'idea://open?file={{file}}',
+    },
+    {
+      id: 'atom',
+      name: 'Atom',
+      pattern: 'atom://core/open/file?filename={{file}}',
+    },
+    {
+      id: 'vim',
+      name: 'Vim',
+      pattern: 'vim://open?url=file://{{file}}',
+    },
+    {
+      id: 'neovim',
+      name: 'Neovim',
+      pattern: 'nvim://open?url=file://{{file}}',
+    },
+    {
+      id: 'textmate',
+      name: 'TextMate',
+      pattern: 'txmt://open?url=file://{{file}}',
+    },
+    {
+      id: 'zed',
+      name: 'Zed',
+      pattern: 'zed://file/{{file}}',
+    },
+    {
+      id: 'custom',
+      name: 'Custom URL',
+      pattern: '{{file}}',
+    },
+  ];
+
+  function setTomsterIconSetting(showTomster) {
+    document.querySelector(TomsterSelector).checked = showTomster;
+  }
+
+  function loadTextEditorSetting(selectedEdtor, savedPattern) {
+    selectedEdtor = selectedEdtor || 'no-selection';
+
+    var editorSelectionsContainer =
+      document.querySelector('#editor-selections');
+    for (var editor of Editors) {
+      var { id, name, pattern } = editor;
+
+      var container = document.createElement('div');
+      var label = document.createElement('label');
+      var input = document.createElement('input');
+
+      input.type = 'radio';
+      input.name = 'text-editor-selection';
+      input.setAttribute('data-settings-editor', id);
+
+      if (id === selectedEdtor) {
+        input.checked = true;
+      }
+
+      // Add event listener to save editor selection when changed
+      input.addEventListener('change', function () {
+        saveEditorSelection();
+      });
+
+      label.appendChild(input);
+      label.appendChild(document.createTextNode(' ' + name));
+      container.appendChild(label);
+
+      if (id === 'custom') {
+        var customStringTemplate = document.createElement('input');
+        customStringTemplate.setAttribute('placeholder', pattern);
+        customStringTemplate.setAttribute('data-custom-pattern', '');
+
+        // Restore saved custom pattern if custom editor was selected
+        if (
+          selectedEdtor === 'custom' &&
+          savedPattern &&
+          savedPattern !== pattern
+        ) {
+          customStringTemplate.value = savedPattern;
+        }
+
+        label.appendChild(customStringTemplate);
+
+        // Save custom pattern on input
+        customStringTemplate.addEventListener('input', function () {
+          saveEditorSelection();
+        });
+      }
+
+      editorSelectionsContainer.appendChild(container);
+    }
+  }
+
   /**
    * Load the options from storage.
    */
-  function loadOptions() {
+  function initialRender() {
     chrome.storage.sync.get('options', function (data) {
-      var options = data.options;
-
-      document.querySelector('[data-settings=tomster]').checked =
-        options && options.showTomster;
+      var options = data.options || {};
+      setTomsterIconSetting(options.tomster);
+      loadTextEditorSetting(options.editor, options.editorPattern);
     });
   }
 
@@ -50,7 +163,41 @@
     storeOptions({ showTomster: this.checked });
   }
 
-  document.addEventListener('DOMContentLoaded', loadOptions);
+  function saveEditorSelection() {
+    var selectedInput = document.querySelector(
+      'input[name="text-editor-selection"]:checked',
+    );
+    if (!selectedInput) return;
+
+    var selectedEditorId = selectedInput.getAttribute('data-settings-editor');
+    var selectedEditor = Editors.find(function (e) {
+      return e.id === selectedEditorId;
+    });
+
+    if (!selectedEditor) return;
+
+    var editorPattern = null;
+
+    // Only save pattern if not 'no-selection'
+    if (selectedEditorId !== 'no-selection') {
+      editorPattern = selectedEditor.pattern;
+
+      // Handle custom pattern
+      if (selectedEditorId === 'custom') {
+        var customInput = document.querySelector('input[data-custom-pattern]');
+        if (customInput && customInput.value) {
+          editorPattern = customInput.value;
+        }
+      }
+    }
+
+    storeOptions({
+      editor: selectedEditorId,
+      editorPattern: editorPattern,
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', initialRender);
   document
     .querySelector('[data-settings=tomster]')
     .addEventListener('click', saveTomsterSetting);

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -26,7 +26,7 @@
     },
     {
       id: 'jetbrains',
-      name: 'JetBrains IDEs (IntelliJ IDEA / WebStorm / PyCharm)',
+      name: 'JetBrains IDEs',
       pattern: 'idea://open?file={{file}}',
     },
     {
@@ -76,20 +76,26 @@
     input.addEventListener('change', options.onChange);
 
     label.appendChild(input);
-    label.appendChild(document.createTextNode(' ' + options.label));
+    label.appendChild(document.createTextNode(options.label));
     container.appendChild(label);
 
     return container;
   }
 
-  function EditorPickerNoSelectionComponent(options) {
-    return EditorPickerComponent({
-      isChecked: options.selectedEditor === undefined || options.selectedEditor === NoSelectionId,
-      label: 'Do not open in an editor',
-      onChange: function () {
-        storeOptions({ editor: NoSelectionId, editorPattern: null });
-      },
-    });
+  function OpenInEditorToggleComponent(options) {
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.checked = options.isChecked;
+    checkbox.id = 'open-in-editor-toggle';
+
+    checkbox.addEventListener('change', options.onChange);
+
+    var label = document.createElement('label');
+    label.setAttribute('for', 'open-in-editor-toggle');
+    label.appendChild(checkbox);
+    label.appendChild(document.createTextNode('Open files from the inspector in your preferred editor'));
+
+    return label;
   }
 
   function renderCustomPatternOption(options) {
@@ -133,12 +139,34 @@
   function renderPreferredEditorIntegrationSettings(options) {
     var selectedEditor = options.selectedEditor;
     var savedPattern = options.savedPattern;
-    var editorSelectionsContainer =
-      document.querySelector('#editor-selections');
+    var editorSelectionsContainer = document.querySelector('#editor-selections');
 
-    for (var editor of Editors) {
-      var { id, name, pattern } = editor;
-      editorSelectionsContainer.appendChild(
+    var isEnabled = selectedEditor !== undefined && selectedEditor !== NoSelectionId;
+
+    var editorList = document.createElement('div');
+    editorList.className = 'editor-list';
+    editorList.style.display = isEnabled ? '' : 'none';
+
+    var editorGrid = document.createElement('div');
+    editorGrid.className = 'editor-grid';
+
+    var checkboxLabel = OpenInEditorToggleComponent({
+      isChecked: isEnabled,
+      onChange: function (event) {
+        if (event.target.checked) {
+          editorList.style.display = '';
+        } else {
+          editorList.style.display = 'none';
+          storeOptions({ editor: NoSelectionId, editorPattern: null });
+        }
+      },
+    });
+
+    Editors.forEach(function (editor) {
+      var id = editor.id;
+      var name = editor.name;
+      var pattern = editor.pattern;
+      editorGrid.appendChild(
         EditorPickerComponent({
           editorId: id,
           isChecked: id === selectedEditor,
@@ -148,21 +176,22 @@
           },
         })
       );
-    }
+    });
 
-    editorSelectionsContainer.appendChild(
-      renderCustomPatternOption({
-        editorId: CustomEditorPatternId,
-        isChecked: selectedEditor === CustomEditorPatternId,
-        pattern: savedPattern,
-      })
-    );
+    var customOption = renderCustomPatternOption({
+      editorId: CustomEditorPatternId,
+      isChecked: selectedEditor === CustomEditorPatternId,
+      pattern: savedPattern,
+    });
+    customOption.className = (customOption.className ? customOption.className + ' ' : '') + 'editor-custom';
 
-    editorSelectionsContainer.appendChild(
-      EditorPickerNoSelectionComponent({
-        selectedEditor: selectedEditor,
-      })
-    );
+    editorList.appendChild(editorGrid);
+    editorList.appendChild(customOption);
+
+    var fragment = document.createDocumentFragment();
+    fragment.appendChild(checkboxLabel);
+    fragment.appendChild(editorList);
+    editorSelectionsContainer.appendChild(fragment);
   }
 
   /**
@@ -184,6 +213,7 @@
    * stored in `chrome.storage` and saves the union of both to storage.
    */
   function storeOptions(newOptions) {
+    console.log('change Options:', newOptions);
     chrome.storage.sync.get('options', function (data) {
       var options = data.options || {};
       Object.assign(options, newOptions);

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -15,11 +15,6 @@
   var TomsterSelector = '[data-settings=tomster]';
   var Editors = [
     {
-      id: 'no-selection',
-      name: 'Do not open in editor',
-      pattern: '{{file}}',
-    },
-    {
       id: 'vscode',
       name: 'VS Code',
       pattern: 'vscode://file/{{file}}',
@@ -58,71 +53,116 @@
       id: 'zed',
       name: 'Zed',
       pattern: 'zed://file/{{file}}',
-    },
-    {
-      id: 'custom',
-      name: 'Custom URL',
-      pattern: '{{file}}',
-    },
+    }
   ];
+
+  var CustomEditorPatternId = '_custom_';
+  var NoSelectionId = 'no-selection';
+  var EditorRadioGroupName = 'text-editor-selection';
 
   function setTomsterIconSetting(showTomster) {
     document.querySelector(TomsterSelector).checked = showTomster;
   }
 
-  function loadTextEditorSetting(selectedEdtor, savedPattern) {
-    selectedEdtor = selectedEdtor || 'no-selection';
+  function EditorPickerComponent(options) {
+    var container = document.createElement('div');
+    var label = document.createElement('label');
+    var input = document.createElement('input');
 
+    input.type = 'radio';
+    input.name = EditorRadioGroupName;
+    input.checked = options.isChecked;
+
+    input.addEventListener('change', options.onChange);
+
+    label.appendChild(input);
+    label.appendChild(document.createTextNode(' ' + options.label));
+    container.appendChild(label);
+
+    return container;
+  }
+
+  function EditorPickerNoSelectionComponent(options) {
+    return EditorPickerComponent({
+      isChecked: options.selectedEditor === undefined || options.selectedEditor === NoSelectionId,
+      label: 'Do not open in an editor',
+      onChange: function () {
+        storeOptions({ editor: NoSelectionId, editorPattern: null });
+      },
+    });
+  }
+
+  function renderCustomPatternOption(options) {
+    var customStringTemplate = document.createElement('input');
+    customStringTemplate.type = 'text';
+    customStringTemplate.setAttribute('placeholder', 'editor://open?url={{file}}');
+
+    if (options.isChecked && options.pattern) {
+      customStringTemplate.value = options.pattern;
+    }
+
+    function saveCustom() {
+      storeOptions({
+        editor: CustomEditorPatternId,
+        editorPattern: customStringTemplate.value || null,
+      });
+    }
+
+    var container = EditorPickerComponent({
+      isChecked: options.isChecked,
+      label: 'Custom',
+      onChange: saveCustom,
+    });
+
+    customStringTemplate.addEventListener('input', function () {
+      if (container.querySelector('input[type=radio]').checked) {
+        saveCustom();
+      }
+    });
+
+    container.querySelector('label').appendChild(customStringTemplate);
+
+    return container;
+  }
+
+  /*
+    @options
+      @selectedEditor: string
+      @savedPattern: string template
+  */
+  function renderPreferredEditorIntegrationSettings(options) {
+    var selectedEditor = options.selectedEditor;
+    var savedPattern = options.savedPattern;
     var editorSelectionsContainer =
       document.querySelector('#editor-selections');
+
     for (var editor of Editors) {
       var { id, name, pattern } = editor;
-
-      var container = document.createElement('div');
-      var label = document.createElement('label');
-      var input = document.createElement('input');
-
-      input.type = 'radio';
-      input.name = 'text-editor-selection';
-      input.setAttribute('data-settings-editor', id);
-
-      if (id === selectedEdtor) {
-        input.checked = true;
-      }
-
-      // Add event listener to save editor selection when changed
-      input.addEventListener('change', function () {
-        saveEditorSelection();
-      });
-
-      label.appendChild(input);
-      label.appendChild(document.createTextNode(' ' + name));
-      container.appendChild(label);
-
-      if (id === 'custom') {
-        var customStringTemplate = document.createElement('input');
-        customStringTemplate.setAttribute('placeholder', pattern);
-        customStringTemplate.setAttribute('data-custom-pattern', '');
-
-        // Restore saved custom pattern if custom editor was selected
-        if (
-          selectedEdtor === 'custom' &&
-          savedPattern &&
-          savedPattern !== pattern
-        ) {
-          customStringTemplate.value = savedPattern;
-        }
-
-        label.appendChild(customStringTemplate);
-
-        // Save custom pattern on input
-        customStringTemplate.addEventListener('input', function () {
-          saveEditorSelection();
-        });
-      }
-
-      editorSelectionsContainer.appendChild(container);
+      editorSelectionsContainer.appendChild(
+        EditorPickerComponent({
+          editorId: id,
+          isChecked: id === selectedEditor,
+          label: name,
+          onChange: function () {
+            storeOptions({ editor: id, editorPattern: pattern });
+          },
+        })
+      );
     }
+
+    editorSelectionsContainer.appendChild(
+      renderCustomPatternOption({
+        editorId: CustomEditorPatternId,
+        isChecked: selectedEditor === CustomEditorPatternId,
+        pattern: savedPattern,
+      })
+    );
+
+    editorSelectionsContainer.appendChild(
+      EditorPickerNoSelectionComponent({
+        selectedEditor: selectedEditor,
+      })
+    );
   }
 
   /**
@@ -132,7 +172,10 @@
     chrome.storage.sync.get('options', function (data) {
       var options = data.options || {};
       setTomsterIconSetting(options.tomster);
-      loadTextEditorSetting(options.editor, options.editorPattern);
+      renderPreferredEditorIntegrationSettings({
+        selectedEditor: options.editor,
+        savedPattern: options.editorPattern,
+      });
     });
   }
 
@@ -161,43 +204,6 @@
    */
   function saveTomsterSetting() {
     storeOptions({ showTomster: this.checked });
-  }
-
-    /**
-   * Save the updated preferred text editor integration selection to storage.
-   */
-  function saveEditorSelection() {
-    var selectedInput = document.querySelector(
-      'input[name="text-editor-selection"]:checked',
-    );
-    if (!selectedInput) return;
-
-    var selectedEditorId = selectedInput.getAttribute('data-settings-editor');
-    var selectedEditor = Editors.find(function (e) {
-      return e.id === selectedEditorId;
-    });
-
-    if (!selectedEditor) return;
-
-    var editorPattern = null;
-
-    // Only save pattern if not 'no-selection'
-    if (selectedEditorId !== 'no-selection') {
-      editorPattern = selectedEditor.pattern;
-
-      // Handle custom pattern
-      if (selectedEditorId === 'custom') {
-        var customInput = document.querySelector('input[data-custom-pattern]');
-        if (customInput && customInput.value) {
-          editorPattern = customInput.value;
-        }
-      }
-    }
-
-    storeOptions({
-      editor: selectedEditorId,
-      editorPattern: editorPattern,
-    });
   }
 
   document.addEventListener('DOMContentLoaded', initialRender);

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -20,40 +20,20 @@
       pattern: 'vscode://file/{{file}}',
     },
     {
-      id: 'sublime',
-      name: 'Sublime Text',
-      pattern: 'subl://open?url=file://{{file}}',
-    },
-    {
-      id: 'jetbrains',
-      name: 'JetBrains IDEs',
-      pattern: 'idea://open?file={{file}}',
-    },
-    {
-      id: 'atom',
-      name: 'Atom',
-      pattern: 'atom://core/open/file?filename={{file}}',
-    },
-    {
-      id: 'vim',
-      name: 'Vim',
-      pattern: 'vim://open?url=file://{{file}}',
-    },
-    {
-      id: 'neovim',
-      name: 'Neovim',
-      pattern: 'nvim://open?url=file://{{file}}',
-    },
-    {
-      id: 'textmate',
-      name: 'TextMate',
-      pattern: 'txmt://open?url=file://{{file}}',
+      id: 'cursor',
+      name: 'Cursor',
+      pattern: 'cursor://file/{{file}}',
     },
     {
       id: 'zed',
       name: 'Zed',
       pattern: 'zed://file/{{file}}',
-    }
+    },
+    {
+      id: 'sublime',
+      name: 'Sublime Text',
+      pattern: 'subl://open?url=file://{{file}}',
+    },
   ];
 
   var CustomEditorPatternId = '_custom_';

--- a/skeletons/web-extension/options.js
+++ b/skeletons/web-extension/options.js
@@ -163,6 +163,9 @@
     storeOptions({ showTomster: this.checked });
   }
 
+    /**
+   * Save the updated preferred text editor integration selection to storage.
+   */
   function saveEditorSelection() {
     var selectedInput = document.querySelector(
       'input[name="text-editor-selection"]:checked',

--- a/tests/integration/injection-test.js
+++ b/tests/integration/injection-test.js
@@ -65,6 +65,9 @@ class ChromeApi {
       sync: {
         get() {},
       },
+      onChanged: {
+        addListener() {},
+      },
     };
 
     const contextMenuListeners = [];

--- a/tests/integration/options-test.js
+++ b/tests/integration/options-test.js
@@ -1,0 +1,191 @@
+import { module, test } from 'qunit';
+
+module('Integration | Options Page', function (hooks) {
+  let container, storedOptions, originalChrome;
+
+  function createChromeMock(initialOptions) {
+    storedOptions = initialOptions || {};
+    return {
+      storage: {
+        sync: {
+          get(_key, cb) {
+            cb({ options: Object.assign({}, storedOptions) });
+          },
+          set(data, cb) {
+            Object.assign(storedOptions, data.options);
+            if (cb) cb();
+          },
+        },
+      },
+    };
+  }
+
+  hooks.beforeEach(function () {
+    originalChrome = window.chrome;
+
+    container = document.createElement('div');
+    container.innerHTML = `
+      <input type="checkbox" data-settings="tomster">
+      <div id="editor-selections"></div>
+    `;
+    document.body.appendChild(container);
+  });
+
+  hooks.afterEach(function () {
+    container.remove();
+    window.chrome = originalChrome;
+  });
+
+  async function loadOptionsPage() {
+    const src = await (await fetch('/options.js')).text();
+    // eval the IIFE in a scope where `chrome` is the mock
+    eval(src);
+    // DOMContentLoaded has already fired, so dispatch it manually
+    // to trigger initialRender
+    document.dispatchEvent(new Event('DOMContentLoaded'));
+  }
+
+  test('renders editor radio buttons', async function (assert) {
+    const chrome = createChromeMock();
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    const radios = container.querySelectorAll(
+      'input[type=radio][name=text-editor-selection]',
+    );
+    assert.true(radios.length > 0, 'editor radio buttons are rendered');
+
+    const labels = [...container.querySelectorAll('.editor-grid label')].map(
+      (l) => l.textContent,
+    );
+    // Just picked on at random to verify.
+    assert.true(labels.includes('VS Code'), 'VS Code option exists');
+  });
+
+  test('selecting an editor stores the correct pattern', async function (assert) {
+    const chrome = createChromeMock();
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    // First enable the toggle
+    const toggle = container.querySelector('#open-in-editor-toggle');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change'));
+
+    const radios = container.querySelectorAll('.editor-grid input[type=radio]');
+
+    radios[0].checked = true;
+    radios[0].dispatchEvent(new Event('change'));
+
+    assert.strictEqual(storedOptions.editor, 'vscode', 'editor id is stored');
+    assert.strictEqual(
+      storedOptions.editorPattern,
+      'vscode://file/{{file}}',
+      'editor pattern is stored',
+    );
+  });
+
+  test('selecting a different editor updates storage', async function (assert) {
+    const chrome = createChromeMock({
+      editor: 'vscode',
+      editorPattern: 'vscode://file/{{file}}',
+    });
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    const radios = container.querySelectorAll('.editor-grid input[type=radio]');
+
+    // Find and click Sublime Text (second radio)
+    radios[1].checked = true;
+    radios[1].dispatchEvent(new Event('change'));
+
+    assert.strictEqual(
+      storedOptions.editor,
+      'sublime',
+      'editor id updated to sublime',
+    );
+    assert.strictEqual(
+      storedOptions.editorPattern,
+      'subl://open?url=file://{{file}}',
+      'editor pattern updated to sublime pattern',
+    );
+  });
+
+  test('disabling the toggle stores no-selection', async function (assert) {
+    const chrome = createChromeMock({ editor: 'vscode' });
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    const toggle = container.querySelector('#open-in-editor-toggle');
+    toggle.checked = false;
+    toggle.dispatchEvent(new Event('change'));
+
+    assert.strictEqual(
+      storedOptions.editor,
+      'no-selection',
+      'editor is set to no-selection',
+    );
+    assert.strictEqual(
+      storedOptions.editorPattern,
+      null,
+      'editor pattern is cleared',
+    );
+  });
+
+  test('previously selected editor is checked on load', async function (assert) {
+    const chrome = createChromeMock({
+      editor: 'jetbrains',
+      editorPattern: 'idea://open?file={{file}}',
+    });
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    const checkedRadio = container.querySelector(
+      '.editor-grid input[type=radio]:checked',
+    );
+
+    assert.ok(checkedRadio, 'a radio is checked');
+    assert.strictEqual(
+      checkedRadio.closest('label').textContent,
+      'JetBrains IDEs',
+      'JetBrains radio is the checked one',
+    );
+  });
+
+  test('custom editor pattern can be entered', async function (assert) {
+    const chrome = createChromeMock();
+    window.chrome = chrome;
+    await loadOptionsPage(chrome);
+
+    // Enable the toggle
+    const toggle = container.querySelector('#open-in-editor-toggle');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change'));
+
+    // Select the custom radio
+    const customRadio = container.querySelector(
+      '.editor-custom input[type=radio]',
+    );
+    customRadio.checked = true;
+    customRadio.dispatchEvent(new Event('change'));
+
+    assert.strictEqual(
+      storedOptions.editor,
+      '_custom_',
+      'custom editor id is stored',
+    );
+
+    // Type a custom pattern
+    const customInput = container.querySelector(
+      '.editor-custom input[type=text]',
+    );
+    customInput.value = 'myeditor://open?file={{file}}';
+    customInput.dispatchEvent(new Event('input'));
+
+    assert.strictEqual(
+      storedOptions.editorPattern,
+      'myeditor://open?file={{file}}',
+      'custom pattern is stored',
+    );
+  });
+});

--- a/tests/integration/options-test.js
+++ b/tests/integration/options-test.js
@@ -101,13 +101,13 @@ module('Integration | Options Page', function (hooks) {
 
     assert.strictEqual(
       storedOptions.editor,
-      'sublime',
+      'cursor',
       'editor id updated to sublime',
     );
     assert.strictEqual(
       storedOptions.editorPattern,
-      'subl://open?url=file://{{file}}',
-      'editor pattern updated to sublime pattern',
+      'cursor://file/{{file}}',
+      'editor pattern updated to cursor pattern',
     );
   });
 
@@ -134,8 +134,8 @@ module('Integration | Options Page', function (hooks) {
 
   test('previously selected editor is checked on load', async function (assert) {
     const chrome = createChromeMock({
-      editor: 'jetbrains',
-      editorPattern: 'idea://open?file={{file}}',
+      editor: 'cursor',
+      editorPattern: 'cursor://file/{{file}}',
     });
     window.chrome = chrome;
     await loadOptionsPage(chrome);
@@ -147,8 +147,8 @@ module('Integration | Options Page', function (hooks) {
     assert.ok(checkedRadio, 'a radio is checked');
     assert.strictEqual(
       checkedRadio.closest('label').textContent,
-      'JetBrains IDEs',
-      'JetBrains radio is the checked one',
+      'Cursor',
+      'Cursor radio is the checked one',
     );
   });
 


### PR DESCRIPTION
## Description

The inspector can already show a path to file on disk related to a component being inspected. This PR allows a user to
* set a preferred editor
* have files open in that editor when paths are clicked.

## Screenshots
### Preference Screen

https://github.com/user-attachments/assets/917e7c59-147e-4eba-bc0e-73c9d548b6a8



### The behavior in use
https://github.com/user-attachments/assets/b7db377c-a8be-456d-880d-5353c6826077

