### PR TITLE
Security: Untrusted link opening can enable reverse-tabnabbing and script-scheme execution

### DIFF
--- a/app/components/ui/open-links-in-new-window.js
+++ b/app/components/ui/open-links-in-new-window.js
@@ -2,9 +2,24 @@ import Component from '@glimmer/component';
 
 export default class OpenLinksInNewWindow extends Component {
   linkClicked(e) {
-    if (e.target.tagName.toLowerCase() === 'a') {
-      e.preventDefault();
-      window.open(e.target.href);
+    const link = e.target.closest?.('a');
+
+    if (!link || !link.href) {
+      return;
+    }
+
+    e.preventDefault();
+
+    try {
+      const url = new URL(link.href);
+
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return;
+      }
+
+      window.open(url.href, '_blank', 'noopener,noreferrer');
+    } catch {
+      return;
     }
   }
 }


### PR DESCRIPTION
## Summary

Security: Untrusted link opening can enable reverse-tabnabbing and script-scheme execution

## Problem

**Severity**: `Medium` | **File**: `app/components/ui/open-links-in-new-window.js:L5`

The click handler opens any anchor `href` via `window.open(e.target.href)` without `noopener/noreferrer` protections and without validating URL schemes. If a malicious link is rendered (e.g., `javascript:` or attacker-controlled external URL), this can lead to opener manipulation (reverse tabnabbing) or unsafe navigation behavior.

## Solution

Validate the URL before opening (allow only `http:`/`https:` as needed), and open with `noopener,noreferrer` (e.g., `window.open(url, '_blank', 'noopener,noreferrer')`). Also consider resolving the nearest `<a>` via `closest('a')` and rejecting missing/invalid hrefs.

## Changes

- `app/components/ui/open-links-in-new-window.js` (modified)