### PR TITLE
Refactor: Prefer top-level await over callbacks in entries

### DIFF
--- a/ember_debug/entrypoints/basic-debug.js
+++ b/ember_debug/entrypoints/basic-debug.js
@@ -1,10 +1,11 @@
-import loadEmberDebugInWebpage from '../lib/load-ember-debug-in-webpage.js';
+import hasEmber from './utils/has-ember.js';
 
-loadEmberDebugInWebpage(async () => {
-  const { onEmberReady, startInspector } = await import(
-    '../lib/start-inspector.js'
-  );
+await hasEmber();
 
-  const adapter = (await import('../adapters/basic.js')).default;
-  onEmberReady(startInspector(adapter));
-});
+// These dynamic imports are intentionally after the above await hasEmber() call.
+// We cannot move these to a regular import because we want to wait for Ember to
+// be available on page before we can initialise the module tree.
+const startInspector = await import('../lib/start-inspector.js');
+const adapter = await import('../adapters/basic.js');
+
+startInspector.default(adapter.default);

--- a/ember_debug/entrypoints/bookmarklet-debug.js
+++ b/ember_debug/entrypoints/bookmarklet-debug.js
@@ -1,10 +1,11 @@
-import loadEmberDebugInWebpage from '../lib/load-ember-debug-in-webpage.js';
+import hasEmber from './utils/has-ember.js';
 
-loadEmberDebugInWebpage(async () => {
-  const { onEmberReady, startInspector } = await import(
-    '../lib/start-inspector.js'
-  );
+await hasEmber();
 
-  const adapter = (await import('../adapters/bookmarklet.js')).default;
-  onEmberReady(startInspector(adapter));
-});
+// These dynamic imports are intentionally after the above await hasEmber() call.
+// We cannot move these to a regular import because we want to wait for Ember to
+// be available on page before we can initialise the module tree.
+const startInspector = await import('../lib/start-inspector.js');
+const adapter = await import('../adapters/bookmarklet.js');
+
+startInspector.default(adapter.default);

--- a/ember_debug/entrypoints/chrome-debug.js
+++ b/ember_debug/entrypoints/chrome-debug.js
@@ -1,10 +1,11 @@
-import loadEmberDebugInWebpage from '../lib/load-ember-debug-in-webpage.js';
+import hasEmber from './utils/has-ember.js';
 
-loadEmberDebugInWebpage(async () => {
-  const { onEmberReady, startInspector } = await import(
-    '../lib/start-inspector.js'
-  );
+await hasEmber();
 
-  const adapter = (await import('../adapters/chrome.js')).default;
-  onEmberReady(startInspector(adapter));
-});
+// These dynamic imports are intentionally after the above await hasEmber() call.
+// We cannot move these to a regular import because we want to wait for Ember to
+// be available on page before we can initialise the module tree.
+const startInspector = await import('../lib/start-inspector.js');
+const adapter = await import('../adapters/chrome.js');
+
+startInspector.default(adapter.default);

--- a/ember_debug/entrypoints/firefox-debug.js
+++ b/ember_debug/entrypoints/firefox-debug.js
@@ -1,10 +1,11 @@
-import loadEmberDebugInWebpage from '../lib/load-ember-debug-in-webpage.js';
+import hasEmber from './utils/has-ember.js';
 
-loadEmberDebugInWebpage(async () => {
-  const { onEmberReady, startInspector } = await import(
-    '../lib/start-inspector.js'
-  );
+await hasEmber();
 
-  const adapter = (await import('../adapters/firefox.js')).default;
-  onEmberReady(startInspector(adapter));
-});
+// These dynamic imports are intentionally after the above await hasEmber() call.
+// We cannot move these to a regular import because we want to wait for Ember to
+// be available on page before we can initialise the module tree.
+const startInspector = await import('../lib/start-inspector.js');
+const adapter = await import('../adapters/firefox.js');
+
+startInspector.default(adapter.default);

--- a/ember_debug/entrypoints/utils/has-ember.js
+++ b/ember_debug/entrypoints/utils/has-ember.js
@@ -1,14 +1,13 @@
-export default function loadEmberDebugInWebpage(callback) {
-  const waitForEmberLoad = new Promise((resolve) => {
+export default async function hasEmber() {
+  return new Promise((resolve) => {
     if (window.requireModule) {
       const has =
         window.requireModule.has ||
-        function has(id) {
-          return !!(
+        ((id) =>
+          !!(
             window.requireModule.entries[id] ||
             window.requireModule.entries[id + '/index']
-          );
-        };
+          ));
       if (has('ember')) {
         return resolve();
       }
@@ -22,11 +21,14 @@ export default function loadEmberDebugInWebpage(callback) {
      *
      *       this will throw an exception in the consuming project
      */
-    if (window.Ember) return resolve();
+    if (window.Ember) {
+      return resolve();
+    }
 
-    if (globalThis.emberInspectorApps) return resolve();
+    if (globalThis.emberInspectorApps) {
+      return resolve();
+    }
 
     window.addEventListener('Ember', resolve, { once: true });
   });
-  waitForEmberLoad.then(callback);
 }

--- a/ember_debug/entrypoints/websocket-debug.js
+++ b/ember_debug/entrypoints/websocket-debug.js
@@ -1,10 +1,11 @@
-import loadEmberDebugInWebpage from '../lib/load-ember-debug-in-webpage.js';
+import hasEmber from './utils/has-ember.js';
 
-loadEmberDebugInWebpage(async () => {
-  const { onEmberReady, startInspector } = await import(
-    '../lib/start-inspector.js'
-  );
+await hasEmber();
 
-  const adapter = (await import('../adapters/websocket.js')).default;
-  onEmberReady(startInspector(adapter));
-});
+// These dynamic imports are intentionally after the above await hasEmber() call.
+// We cannot move these to a regular import because we want to wait for Ember to
+// be available on page before we can initialise the module tree.
+const startInspector = await import('../lib/start-inspector.js');
+const adapter = await import('../adapters/websocket.js');
+
+startInspector.default(adapter.default);

--- a/ember_debug/lib/start-inspector.js
+++ b/ember_debug/lib/start-inspector.js
@@ -25,7 +25,7 @@ function onReady(callback) {
   }
 }
 
-export function onEmberReady(callback) {
+function onEmberReady(callback) {
   var triggered = false;
   var triggerOnce = function () {
     if (triggered) {
@@ -191,3 +191,5 @@ export function startInspector(adapter) {
     }
   };
 }
+
+export default (adapter) => onEmberReady(startInspector(adapter));


### PR DESCRIPTION
This focusses the behavior of the entry points

1. check for the presence of Ember in the page
2. asynchronously load adapter and startInspector which in turn trigger the asynchronous loading of the bridging modules
3. start the inspector boot