### PR TITLE
Reduce complexity in startInspector

### DIFF
--- a/ember_debug/lib/applications.js
+++ b/ember_debug/lib/applications.js
@@ -1,26 +1,26 @@
 import { Application, Namespace, guidFor } from './ember.js';
 
+export function getApplications() {
+  return Namespace.NAMESPACES.filter(function (namespace) {
+    return namespace instanceof Application;
+  });
+}
+
+// FIXME: This shouldn't mutate the applications
 /**
  * Get all the Ember.Application instances from Ember.Namespace.NAMESPACES
  * and add our own applicationId and applicationName to them
  * @return {*}
  */
-export function getApplications() {
-  var namespaces = Namespace.NAMESPACES;
-
-  var apps = namespaces.filter(function (namespace) {
-    return namespace instanceof Application;
-  });
-
-  return apps.map(function (app) {
+export function getApplicationWithDescriptors() {
+  return getApplications().map(function (app) {
     // Add applicationId and applicationName to the app
-    var applicationId = guidFor(app);
-    var applicationName =
-      app.name || app.modulePrefix || `(unknown app - ${applicationId})`;
+    const id = guidFor(app);
+    const name = app.name || app.modulePrefix || `(unknown app - ${id})`;
 
     Object.assign(app, {
-      applicationId,
-      applicationName,
+      applicationId: id,
+      applicationName: name,
     });
 
     return app;

--- a/ember_debug/lib/applications.js
+++ b/ember_debug/lib/applications.js
@@ -41,3 +41,13 @@ export function sendApplications(adapter, apps) {
     from: 'inspectedWindow',
   });
 }
+
+export function getApplicationInstance(app) {
+  if (app._applicationInstances) {
+    return [...app._applicationInstances][0];
+  } else if (app.__deprecatedInstance__) {
+    return app.__deprecatedInstance__;
+  }
+
+  return undefined;
+}

--- a/ember_debug/lib/start-inspector.js
+++ b/ember_debug/lib/start-inspector.js
@@ -1,192 +1,159 @@
 import versionTest from '../utils/version-test.js';
 import { EMBER_VERSIONS_SUPPORTED } from '../utils/versions.js';
-import { getApplications, sendApplications } from './applications.js';
+import {
+  getApplications,
+  sendApplications,
+  getApplicationInstance,
+} from './applications.js';
 import bootEmberInspector from './boot-ember-inspector.js';
 import setupInstanceInitializer from './setup-instance-initializer.js';
 import sendVersionMiss from './send-version-miss.js';
+import getEmberDebug from '../main.js';
 import { guidFor, Application, VERSION } from './ember.js';
-import getEmberDebug from '../main';
+import { onEmberReady } from '../utils/on-ready.js';
 
-function onReady(callback) {
-  if (
-    document.readyState === 'complete' ||
-    document.readyState === 'interactive'
-  ) {
-    setTimeout(completed);
-  } else {
-    document.addEventListener('DOMContentLoaded', completed, false);
-    // For some reason DOMContentLoaded doesn't always work
-    window.addEventListener('load', completed, false);
-  }
+function appStarted(instance) {
+  const app = instance.application;
 
-  function completed() {
-    document.removeEventListener('DOMContentLoaded', completed, false);
-    window.removeEventListener('load', completed, false);
-    callback();
-  }
-}
-
-function onEmberReady(callback) {
-  var triggered = false;
-  var triggerOnce = function () {
-    if (triggered) {
-      return;
-    }
-
-    triggered = true;
-    callback();
-  };
-
-  // Newest Ember versions >= 1.10
-
-  const later = () => setTimeout(triggerOnce, 0);
-  window.addEventListener('Ember', later, { once: true });
-  // Oldest Ember versions or if this was injected after Ember has loaded.
-  onReady(triggerOnce);
-}
-
-export function startInspector(adapter) {
-  // There's probably a better way
-  // to determine when the application starts
-  // but this definitely works
-  function onApplicationStart(callback) {
-    const adapterInstance = new adapter();
-
-    adapterInstance.onMessageReceived(function (message) {
-      if (message.type === 'app-picker-loaded') {
-        sendApplications(adapterInstance, getApplications());
-      }
-
-      if (message.type === 'app-selected') {
-        let current = window.EmberInspector._application;
-        let selected = getApplications().find(
-          (app) => guidFor(app) === message.applicationId,
-        );
-
-        if (
-          selected &&
-          current !== selected &&
-          selected.__deprecatedInstance__
-        ) {
-          bootEmberInspector(selected.__deprecatedInstance__);
-        }
-      }
-    });
-
-    var apps = getApplications();
-
-    sendApplications(adapterInstance, apps);
-
-    function loadInstance(app) {
-      const applicationInstances = app._applicationInstances && [
-        ...app._applicationInstances,
-      ];
-      let instance = app.__deprecatedInstance__ || applicationInstances[0];
-      if (instance) {
-        // App started
-        setupInstanceInitializer(app, callback);
-        callback(instance);
-        return true;
-      }
-    }
-
-    var app;
-    for (var i = 0, l = apps.length; i < l; i++) {
-      app = apps[i];
-      // We check for the existance of an application instance because
-      // in Ember > 3 tests don't destroy the app when they're done but the app has no booted instances.
-      if (app._readinessDeferrals === 0) {
-        if (loadInstance(app)) {
-          break;
-        }
-      }
-
-      // app already run initializers, but no instance, use _bootPromise and didBecomeReady
-      if (app._bootPromise) {
-        app._bootPromise.then((app) => {
-          loadInstance(app);
-        });
-      }
-
-      app.reopen({
-        didBecomeReady() {
-          this._super.apply(this, arguments);
-          setTimeout(() => loadInstance(app), 0);
-        },
-      });
-    }
-    Application.initializer({
-      name: 'ember-inspector-booted',
-      initialize: function (app) {
-        setupInstanceInitializer(app, callback);
+  if (!('__inspector__booted' in app)) {
+    // Watch for app reset/destroy
+    app.reopen({
+      reset: function () {
+        this.__inspector__booted = false;
+        this._super.apply(this, arguments);
       },
     });
   }
 
-  return async function startInspector() {
-    // global to prevent injection
-    if (window.NO_EMBER_DEBUG) {
-      return;
-    }
-
-    /**
-     * If we don't have a way to know the Ember version at this point
-     * because the Ember app has not loaded and provided it somehow,
-     * we can't continue (we need the version to know what version of
-     * the Inspector to load).
-     */
-    if (!VERSION) {
-      return;
-    }
-
-    /**
-     * This is used to redirect to an old snapshot of the Inspector if the
-     * inspected app uses an older Ember version than supported versions.
-     * The code fits the Inspector supporting Ember back to 3.16: any version
-     * before 3.16 is necessarily a classic Ember app with Ember defined.
-     */
-    if ((VERSION, !versionTest(VERSION, EMBER_VERSIONS_SUPPORTED))) {
-      // Wrong inspector version. Redirect to the correct version.
-      sendVersionMiss(VERSION);
-      return;
-    }
-
-    // prevent from injecting twice
-    if (!window.EmberInspector) {
-      window.EmberInspector = getEmberDebug();
-      window.EmberInspector.Adapter = adapter;
-
-      onApplicationStart(function appStarted(instance) {
-        let app = instance.application;
-        if (!('__inspector__booted' in app)) {
-          // Watch for app reset/destroy
-          app.reopen({
-            reset: function () {
-              this.__inspector__booted = false;
-              this._super.apply(this, arguments);
-            },
-          });
+  if (instance && !('__inspector__booted' in instance)) {
+    instance.reopen({
+      // Clean up on instance destruction
+      willDestroy() {
+        if (window.EmberInspector.owner === instance) {
+          window.EmberInspector.destroyContainer();
+          window.EmberInspector.clear();
         }
+        return this._super.apply(this, arguments);
+      },
+    });
 
-        if (instance && !('__inspector__booted' in instance)) {
-          instance.reopen({
-            // Clean up on instance destruction
-            willDestroy() {
-              if (window.EmberInspector.owner === instance) {
-                window.EmberInspector.destroyContainer();
-                window.EmberInspector.clear();
-              }
-              return this._super.apply(this, arguments);
-            },
-          });
-
-          if (!window.EmberInspector._application) {
-            setTimeout(() => bootEmberInspector(instance), 0);
-          }
-        }
-      });
+    if (!window.EmberInspector._application) {
+      setTimeout(() => bootEmberInspector(instance), 0);
     }
-  };
+  }
 }
 
-export default (adapter) => onEmberReady(startInspector(adapter));
+async function startInspector(Adapter) {
+  // global to prevent injection
+  if (window.NO_EMBER_DEBUG) {
+    return;
+  }
+
+  /**
+   * If we don't have a way to know the Ember version at this point
+   * because the Ember app has not loaded and provided it somehow,
+   * we can't continue (we need the version to know what version of
+   * the Inspector to load).
+   */
+  if (!VERSION) {
+    return;
+  }
+
+  /**
+   * This is used to redirect to an old snapshot of the Inspector if the
+   * inspected app uses an older Ember version than supported versions.
+   * The code fits the Inspector supporting Ember back to 3.16: any version
+   * before 3.16 is necessarily a classic Ember app with Ember defined.
+   */
+  if ((VERSION, !versionTest(VERSION, EMBER_VERSIONS_SUPPORTED))) {
+    // Wrong inspector version. Redirect to the correct version.
+    sendVersionMiss(VERSION);
+    return;
+  }
+
+  // prevent from injecting twice
+  if (window.EmberInspector) {
+    return;
+  }
+
+  window.EmberInspector = getEmberDebug();
+  window.EmberInspector.Adapter = Adapter;
+
+  const adapterInstance = new Adapter();
+
+  // There's probably a better way
+  // to determine when the application starts
+  // but this definitely works
+  adapterInstance.onMessageReceived(function (message) {
+    if (message.type === 'app-picker-loaded') {
+      sendApplications(adapterInstance, getApplications());
+    }
+
+    if (message.type === 'app-selected') {
+      const current = window.EmberInspector._application;
+      const selected = getApplications().find(
+        (app) => guidFor(app) === message.applicationId,
+      );
+
+      if (selected && current !== selected) {
+        const instance = getApplicationInstance(selected);
+
+        if (instance) {
+          bootEmberInspector(instance);
+        }
+      }
+    }
+  });
+
+  const apps = getApplications();
+
+  sendApplications(adapterInstance, apps);
+
+  const loadInstance = (app) => {
+    const instance = getApplicationInstance(app);
+
+    if (instance) {
+      // App started
+      setupInstanceInitializer(app, appStarted);
+      appStarted(instance);
+      return true;
+    }
+  };
+
+  for (const app of apps) {
+    // We check for the existance of an application instance because
+    // in Ember > 3 tests don't destroy the app when they're done but the app has no booted instances.
+    if (app._readinessDeferrals === 0) {
+      if (loadInstance(app)) {
+        break;
+      }
+    }
+
+    // app already run initializers, but no instance, use _bootPromise and didBecomeReady
+    if (app._bootPromise) {
+      app._bootPromise.then((app) => {
+        loadInstance(app);
+      });
+    }
+
+    app.reopen({
+      didBecomeReady() {
+        this._super.apply(this, arguments);
+        setTimeout(() => loadInstance(app), 0);
+      },
+    });
+  }
+
+  Application.initializer({
+    name: 'ember-inspector-booted',
+    initialize: (app) => {
+      setupInstanceInitializer(app, appStarted);
+    },
+  });
+}
+
+/**
+ * Wait for document and Ember to be ready before beginning with the Inspector start
+ * @param {*} Adapter
+ */
+export default (Adapter) => onEmberReady(() => startInspector(Adapter));

--- a/ember_debug/lib/start-inspector.js
+++ b/ember_debug/lib/start-inspector.js
@@ -5,6 +5,7 @@ import bootEmberInspector from './boot-ember-inspector.js';
 import setupInstanceInitializer from './setup-instance-initializer.js';
 import sendVersionMiss from './send-version-miss.js';
 import { guidFor, Application, VERSION } from './ember.js';
+import getEmberDebug from '../main';
 
 function onReady(callback) {
   if (
@@ -152,11 +153,7 @@ export function startInspector(adapter) {
 
     // prevent from injecting twice
     if (!window.EmberInspector) {
-      let emberDebugMainModule = (await import('../main.js')).default;
-      if (!emberDebugMainModule) {
-        return;
-      }
-      window.EmberInspector = emberDebugMainModule;
+      window.EmberInspector = getEmberDebug();
       window.EmberInspector.Adapter = adapter;
 
       onApplicationStart(function appStarted(instance) {

--- a/ember_debug/lib/start-inspector.js
+++ b/ember_debug/lib/start-inspector.js
@@ -1,7 +1,7 @@
 import versionTest from '../utils/version-test.js';
 import { EMBER_VERSIONS_SUPPORTED } from '../utils/versions.js';
 import {
-  getApplications,
+  getApplicationWithDescriptors,
   sendApplications,
   getApplicationInstance,
 } from './applications.js';
@@ -86,12 +86,12 @@ async function startInspector(Adapter) {
   // but this definitely works
   adapterInstance.onMessageReceived(function (message) {
     if (message.type === 'app-picker-loaded') {
-      sendApplications(adapterInstance, getApplications());
+      sendApplications(adapterInstance, getApplicationWithDescriptors());
     }
 
     if (message.type === 'app-selected') {
       const current = window.EmberInspector._application;
-      const selected = getApplications().find(
+      const selected = getApplicationWithDescriptors().find(
         (app) => guidFor(app) === message.applicationId,
       );
 
@@ -105,7 +105,7 @@ async function startInspector(Adapter) {
     }
   });
 
-  const apps = getApplications();
+  const apps = getApplicationWithDescriptors();
 
   sendApplications(adapterInstance, apps);
 

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -11,6 +11,7 @@ import ContainerDebug from './container-debug.js';
 import DeprecationDebug from './deprecation-debug.js';
 import Session from './services/session.js';
 
+import { getApplicationInstance } from './lib/applications.js';
 import { Application, Namespace } from './lib/ember.js';
 import { guidFor, setGuidPrefix } from './lib/ember/object/internals.js';
 import { run } from './lib/ember/runloop.js';
@@ -101,10 +102,13 @@ export class EmberDebug extends BaseObject {
 
   reset($keepAdapter) {
     setGuidPrefix(Math.random().toString());
+
     if (!this.isTesting && !this.owner) {
-      this.owner = getOwner(this._application);
+      this.owner = getApplicationInstance(this._application);
     }
+
     this.destroyContainer();
+
     run(() => {
       // Adapters don't have state depending on the application itself.
       // They also maintain connections with the inspector which we will
@@ -112,6 +116,7 @@ export class EmberDebug extends BaseObject {
       if (!this.adapter || !$keepAdapter) {
         this.startModule('adapter', this.Adapter);
       }
+
       if (!this.port || !$keepAdapter) {
         this.startModule('port', this.Port);
       }
@@ -158,20 +163,10 @@ function getApplication() {
   return application;
 }
 
-function getOwner(application) {
-  if (application.autoboot) {
-    return application.__deprecatedInstance__;
-  } else if (application._applicationInstances /* Ember 3.1+ */) {
-    return [...application._applicationInstances][0];
-  }
-}
-
-let instance;
+let emberDebug;
 
 export default () => {
-  instance ??= new EmberDebug();
+  emberDebug ??= new EmberDebug();
 
-  return instance;
+  return emberDebug;
 };
-
-// export default new EmberDebug();

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -16,7 +16,7 @@ import { guidFor, setGuidPrefix } from './lib/ember/object/internals.js';
 import { run } from './lib/ember/runloop.js';
 import BaseObject from './utils/base-object.js';
 
-class EmberDebug extends BaseObject {
+export class EmberDebug extends BaseObject {
   /**
    * Set to true during testing.
    *
@@ -166,4 +166,12 @@ function getOwner(application) {
   }
 }
 
-export default new EmberDebug();
+let instance;
+
+export default () => {
+  instance ??= new EmberDebug();
+
+  return instance;
+};
+
+// export default new EmberDebug();

--- a/ember_debug/main.js
+++ b/ember_debug/main.js
@@ -11,8 +11,7 @@ import ContainerDebug from './container-debug.js';
 import DeprecationDebug from './deprecation-debug.js';
 import Session from './services/session.js';
 
-import { getApplicationInstance } from './lib/applications.js';
-import { Application, Namespace } from './lib/ember.js';
+import { getApplications, getApplicationInstance } from './lib/applications.js';
 import { guidFor, setGuidPrefix } from './lib/ember/object/internals.js';
 import { run } from './lib/ember/runloop.js';
 import BaseObject from './utils/base-object.js';
@@ -55,7 +54,7 @@ export class EmberDebug extends BaseObject {
       return;
     }
     if (!this._application && !this.isTesting) {
-      this._application = getApplication();
+      this._application = getApplications()[0];
     }
     this.started = true;
 
@@ -148,19 +147,6 @@ export class EmberDebug extends BaseObject {
       owner: null,
     });
   }
-}
-
-function getApplication() {
-  let namespaces = Namespace.NAMESPACES;
-  let application;
-
-  namespaces.forEach((namespace) => {
-    if (namespace instanceof Application) {
-      application = namespace;
-      return false;
-    }
-  });
-  return application;
 }
 
 let emberDebug;

--- a/ember_debug/utils/on-ready.js
+++ b/ember_debug/utils/on-ready.js
@@ -1,18 +1,32 @@
+import once from './once.js';
+
 export function onReady(callback) {
+  const completed = () => {
+    document.removeEventListener('DOMContentLoaded', completed, false);
+    window.removeEventListener('load', completed, false);
+    callback();
+  };
+
   if (
     document.readyState === 'complete' ||
     document.readyState === 'interactive'
   ) {
-    setTimeout(completed);
+    setTimeout(completed, 0);
   } else {
     document.addEventListener('DOMContentLoaded', completed, false);
     // For some reason DOMContentLoaded doesn't always work
     window.addEventListener('load', completed, false);
   }
+}
 
-  function completed() {
-    document.removeEventListener('DOMContentLoaded', completed, false);
-    window.removeEventListener('load', completed, false);
-    callback();
-  }
+export function onEmberReady(callback) {
+  const callbackOnce = once(callback);
+
+  // Newest Ember versions >= 1.10
+  window.addEventListener('Ember', () => setTimeout(callbackOnce, 0), {
+    once: true,
+  });
+
+  // Oldest Ember versions or if this was injected after Ember has loaded.
+  onReady(callbackOnce);
 }

--- a/ember_debug/utils/once.js
+++ b/ember_debug/utils/once.js
@@ -1,0 +1,12 @@
+export default function once(callback) {
+  let triggered = false;
+
+  return () => {
+    if (triggered) {
+      return;
+    }
+
+    triggered = true;
+    callback();
+  };
+}

--- a/tests/ember_debug/container-debug-test.js
+++ b/tests/ember_debug/container-debug-test.js
@@ -2,14 +2,20 @@ import { module, skip } from 'qunit';
 import { settled, visit, waitUntil } from '@ember/test-helpers';
 import { A as emberA } from '@ember/array';
 
-import EmberDebug from 'ember-debug/main';
+import EmberDebugImport from 'ember-debug/main';
 import setupEmberDebugTest from '../helpers/setup-ember-debug-test';
+
+let EmberDebug;
 
 // TODO: Figure out why these tests are flaky and enable them again
 module('Ember Debug - Container', function (hooks) {
   let name, message;
 
   setupEmberDebugTest(hooks);
+
+  hooks.before(async function () {
+    EmberDebug = (await EmberDebugImport).default();
+  });
 
   skip('#getTypes', async function t(assert) {
     await visit('/simple');

--- a/tests/ember_debug/deprecation-debug-test.js
+++ b/tests/ember_debug/deprecation-debug-test.js
@@ -11,7 +11,7 @@ let EmberDebug;
 
 module('Ember Debug - Deprecation', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks);

--- a/tests/ember_debug/ember-data-test.js
+++ b/tests/ember_debug/ember-data-test.js
@@ -3,7 +3,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import EmberObject from '@ember/object';
 
 import EmberDebugImport from 'ember-debug/main';
-let EmberDebug = EmberDebugImport;
+let EmberDebug;
 
 class Adapter extends EmberObject {
   watchModelTypes() {}
@@ -13,7 +13,7 @@ module('Ember Debug - Data', function (hooks) {
   setupApplicationTest(hooks);
 
   hooks.before(async function () {
-    EmberDebug = (await EmberDebug).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   hooks.beforeEach(function () {

--- a/tests/ember_debug/ember-debug-test.js
+++ b/tests/ember_debug/ember-debug-test.js
@@ -10,7 +10,7 @@ module('Ember Debug', function (hooks) {
   let name, adapter;
 
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks);

--- a/tests/ember_debug/object-inspector-test.js
+++ b/tests/ember_debug/object-inspector-test.js
@@ -25,7 +25,7 @@ import Controller from '@ember/controller';
 import { setOwner } from '@ember/application';
 
 import EmberDebugImport from 'ember-debug/main';
-let EmberDebug = EmberDebugImport;
+let EmberDebug;
 
 const GlimmerComponent = (function () {
   try {
@@ -80,7 +80,7 @@ async function inspectObject(object) {
 
 module('Ember Debug - Object Inspector', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks, {

--- a/tests/ember_debug/profile-manager-test.js
+++ b/tests/ember_debug/profile-manager-test.js
@@ -389,7 +389,7 @@ async function highlightsPromise(testedRoute, isGlimmerComponent) {
 
 module('Ember Debug - profile manager component highlight', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
     let VERSION = (await EmberImport).VERSION;
     isComponentHighlightSupported = compareVersion(VERSION, '3.20.0') !== -1;
   });

--- a/tests/ember_debug/promise-debug-test.js
+++ b/tests/ember_debug/promise-debug-test.js
@@ -21,7 +21,7 @@ module('Ember Debug - Promise Debug', function (hooks) {
   let name, message;
 
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks);

--- a/tests/ember_debug/render-debug-test.js
+++ b/tests/ember_debug/render-debug-test.js
@@ -8,7 +8,7 @@ let EmberDebug;
 
 module('Ember Debug - Render Debug', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks, {

--- a/tests/ember_debug/route-debug-test.js
+++ b/tests/ember_debug/route-debug-test.js
@@ -5,6 +5,7 @@ import Route from '@ember/routing/route';
 import { module, test } from 'qunit';
 import setupEmberDebugTest from '../helpers/setup-ember-debug-test';
 import EmberDebugImport from 'ember-debug/main';
+
 let EmberDebug;
 
 function getChildrenProperty(route, prop) {
@@ -13,7 +14,7 @@ function getChildrenProperty(route, prop) {
 
 module('Ember Debug - Route Tree', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
   });
 
   setupEmberDebugTest(hooks, {

--- a/tests/ember_debug/view-debug-test.js
+++ b/tests/ember_debug/view-debug-test.js
@@ -373,7 +373,7 @@ function findInspectorElement(kind) {
 
 module('Ember Debug - View', function (hooks) {
   hooks.before(async function () {
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
     VERSION = (await EmberImport).VERSION;
   });
 

--- a/tests/helpers/setup-ember-debug-test.js
+++ b/tests/helpers/setup-ember-debug-test.js
@@ -27,7 +27,7 @@ export default function setupEmberDebugTest(hooks, options = {}) {
 
   hooks.beforeEach(async function () {
     Port = (await PortImport).default;
-    EmberDebug = (await EmberDebugImport).default;
+    EmberDebug = (await EmberDebugImport).default();
     originalPort = EmberDebug.Port;
     originalApp = getApplication();
     originalIgnoreDeprecations = EmberDebug.IGNORE_DEPRECATIONS;


### PR DESCRIPTION
- flatter overall function structure
- replace dynamic imports with static import. The deferred dynamic imports are handled by the entry points already
- extracted helpers for `getApplicationInstance`, `getApplications`, etc. also reusing already existing helpers like `onReady`
- Don't eagerly instantiate EmberDebug in `main.js`

This should be functionally equal to before. The main goal was to get rid of the chaos and prepare the code for future changes. This should make it much easier to separate the functional patches to Ember classes like Application and ApplicationInstance from the actual boot process in a next step. 