### PR TITLE
Separate prettier from eslint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,19 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 26
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm lint
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -43,14 +56,6 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install
-      - name: Lint ember-inspector (hbs)
-        run: pnpm --filter ember-inspector lint:hbs
-      - name: Lint ember-inspector (js)
-        run: pnpm --filter ember-inspector lint:js
-      - name: Lint ember-inspector (css)
-        run: pnpm --filter ember-inspector lint:css
-      - name: Lint ember-debug
-        run: pnpm --filter ember-debug lint
       - name: Run tests
         run: pnpm test:ember
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 /.env*
 /.pnp*
 .eslintcache
+/packages/*/.eslintcache
 /coverage/
 /npm-debug.log*
 /testem.log

--- a/packages/ember-debug/eslint.config.mjs
+++ b/packages/ember-debug/eslint.config.mjs
@@ -3,12 +3,12 @@ import ember from 'eslint-plugin-ember/recommended';
 import globals from 'globals';
 import importPlugin from 'eslint-plugin-import';
 import js from '@eslint/js';
-import prettier from 'eslint-plugin-prettier/recommended';
+import prettierConfig from 'eslint-config-prettier';
 
 export default [
   js.configs.recommended,
   ember.configs.base,
-  prettier,
+  prettierConfig,
   {
     ignores: ['dist/', 'vendor/startup-wrapper.js'],
   },

--- a/packages/ember-debug/package.json
+++ b/packages/ember-debug/package.json
@@ -7,8 +7,12 @@
     "build": "rollup --config",
     "watch": "pnpm build --watch",
     "prepare": "pnpm build",
-    "lint": "eslint . && prettier --check .",
-    "lint:fix": "eslint . --fix && prettier --write ."
+    "lint": "pnpm \"/^lint:(?!fix$)[^:]+$/\"",
+    "lint:fix": "pnpm \"/^lint:[^:]+:fix$/\" && pnpm format",
+    "lint:js": "eslint . --cache",
+    "lint:js:fix": "eslint . --fix",
+    "lint:format": "prettier --cache --check \"**/*.{js,cjs,mjs}\"",
+    "format": "prettier --cache --write \"**/*.{js,cjs,mjs}\""
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
@@ -17,7 +21,7 @@
     "eslint": "^9.17.0",
     "eslint-plugin-ember": "^12.3.3",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-prettier": "^5.2.1",
+    "eslint-config-prettier": "^9.1.0",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
     "@babel/plugin-proposal-decorators": "^7.25.9",

--- a/packages/ember-inspector/.prettierignore
+++ b/packages/ember-inspector/.prettierignore
@@ -12,3 +12,8 @@
 
 # ember-try
 /.node_modules.ember-try/
+
+# vendor
+/vendor/
+
+/skeletons

--- a/packages/ember-inspector/config/deprecation-workflow.js
+++ b/packages/ember-inspector/config/deprecation-workflow.js
@@ -1,9 +1,8 @@
-/* eslint-disable */
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
   workflow: [
     { handler: 'silence', matchId: 'ember.built-in-components.import' },
     { handler: 'silence', matchId: 'implicit-injections' },
-    { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' }
+    { handler: 'silence', matchId: 'manager-capabilities.modifiers-3-13' },
   ],
 };

--- a/packages/ember-inspector/eslint.config.mjs
+++ b/packages/ember-inspector/eslint.config.mjs
@@ -17,7 +17,7 @@ import js from '@eslint/js';
 
 import ember from 'eslint-plugin-ember/recommended';
 
-import prettier from 'eslint-plugin-prettier/recommended';
+import prettierConfig from 'eslint-config-prettier';
 import qunit from 'eslint-plugin-qunit';
 import n from 'eslint-plugin-n';
 
@@ -45,7 +45,7 @@ export default [
   js.configs.recommended,
   ember.configs.base,
   ember.configs.gjs,
-  prettier,
+  prettierConfig,
   /**
    * Ignores must be in their own object
    * https://eslint.org/docs/latest/use/configure/ignore

--- a/packages/ember-inspector/package.json
+++ b/packages/ember-inspector/package.json
@@ -18,12 +18,14 @@
     "panes:download": "EMBER_ENV=production node scripts/download-panes.js",
     "panes:compress": "gulp compress:chrome-pane && gulp compress:firefox-pane && gulp compress:bookmarklet-pane",
     "extensions:compress": "gulp compress:chrome && gulp compress:firefox && gulp clean-tmp",
-    "lint": "concurrently \"pnpm:lint:*(!fix)\" --names \"lint:\" --prefixColors auto",
+    "lint": "pnpm \"/^lint:(?!fix$)[^:]+$/\"",
     "lint:css": "stylelint \"**/*.scss\"",
     "lint:css:fix": "stylelint \"**/*.scss\" --fix",
-    "lint:fix": "concurrently \"pnpm:lint:*:fix\" --names \"fix:\" --prefixColors auto",
+    "lint:fix": "pnpm \"/^lint:[^:]+:fix$/\" && pnpm format",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
+    "lint:format": "prettier --cache --check \"**/*.{js,cjs,mjs}\"",
+    "format": "prettier --cache --write \"**/*.{js,cjs,mjs}\"",
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "lock-version": "pnpm build:production && pnpm panes:compress",
@@ -69,7 +71,6 @@
     "broccoli-string-replace": "^0.1.2",
     "codeclimate-test-reporter": "^0.5.1",
     "compare-versions": "^4.1.4",
-    "concurrently": "^9.1.0",
     "del": "^6.1.1",
     "ember-auto-import": "^2.10.0",
     "ember-cli": "~6.1.0",
@@ -115,7 +116,6 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^12.3.3",
     "eslint-plugin-n": "^17.15.1",
-    "eslint-plugin-prettier": "^5.2.1",
     "eslint-plugin-qunit": "^8.1.2",
     "fstream": "^1.0.12",
     "globals": "^15.14.0",
@@ -146,8 +146,15 @@
   "ember": {
     "edition": "octane"
   },
-  "emberVersionsSupported": ["3.16.0", ""],
-  "previousEmberVersionsSupported": ["0.0.0", "2.7.0", "3.4.0"],
+  "emberVersionsSupported": [
+    "3.16.0",
+    ""
+  ],
+  "previousEmberVersionsSupported": [
+    "0.0.0",
+    "2.7.0",
+    "3.4.0"
+  ],
   "release-it": {
     "plugins": {
       "release-it-lerna-changelog": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,15 +48,15 @@ importers:
       eslint:
         specifier: ^9.17.0
         version: 9.18.0
+      eslint-config-prettier:
+        specifier: ^9.1.0
+        version: 9.1.0(eslint@9.18.0)
       eslint-plugin-ember:
         specifier: ^12.3.3
         version: 12.3.3(@babel/core@7.26.0)(@typescript-eslint/parser@8.21.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)
-      eslint-plugin-prettier:
-        specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.18.0))(eslint@9.18.0)(prettier@3.4.2)
       glob:
         specifier: ^13.0.6
         version: 13.0.6
@@ -175,9 +175,6 @@ importers:
       compare-versions:
         specifier: ^4.1.4
         version: 4.1.4
-      concurrently:
-        specifier: ^9.1.0
-        version: 9.1.2
       del:
         specifier: ^6.1.1
         version: 6.1.1
@@ -313,9 +310,6 @@ importers:
       eslint-plugin-n:
         specifier: ^17.15.1
         version: 17.15.1(eslint@9.18.0)
-      eslint-plugin-prettier:
-        specifier: ^5.2.1
-        version: 5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.18.0))(eslint@9.18.0)(prettier@3.4.2)
       eslint-plugin-qunit:
         specifier: ^8.1.2
         version: 8.1.2(eslint@9.18.0)
@@ -1658,10 +1652,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@pkgr/core@0.1.1':
-    resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
-    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3438,11 +3428,6 @@ packages:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
 
-  concurrently@9.1.2:
-    resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
@@ -4660,20 +4645,6 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: '>=8.23.0'
-
-  eslint-plugin-prettier@5.2.1:
-    resolution: {integrity: sha512-gH3iR3g4JfF+yYPaJYkN7jEl9QbweL/YfkoRlNnuIEHEz1vHVlCmWOS+eGGiRuzHQXdJFCOTxRgvju9b8VUmrw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      '@types/eslint': '>=8.0.0'
-      eslint: '>=8.0.0'
-      eslint-config-prettier: '*'
-      prettier: '>=3.0.0'
-    peerDependenciesMeta:
-      '@types/eslint':
-        optional: true
-      eslint-config-prettier:
-        optional: true
 
   eslint-plugin-qunit@8.1.2:
     resolution: {integrity: sha512-2gDQdHlQW8GVXD7YYkO8vbm9Ldc60JeGMuQN5QlD48OeZ8znBvvoHWZZMeXjvoDPReGaLEvyuWrDtrI8bDbcqw==}
@@ -7770,10 +7741,6 @@ packages:
   pretender@3.4.7:
     resolution: {integrity: sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==}
 
-  prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
-
   prettier-linter-helpers@1.0.1:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
@@ -8494,9 +8461,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-
   shelljs@0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
     engines: {node: '>=4'}
@@ -8957,10 +8921,6 @@ packages:
     resolution: {integrity: sha512-vngT2JmkSapgq0z7uIoYtB9kWOOzMihAAYq/D3Pjm/ODOGMgS4r++B+OZ09U4hWR6EaOdy9eqQ7/8ygbH3wehA==}
     engines: {node: 8.* || >= 10.*}
 
-  synckit@0.9.2:
-    resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
@@ -9126,10 +9086,6 @@ packages:
     peerDependenciesMeta:
       ember-source:
         optional: true
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   tree-sync@1.4.0:
     resolution: {integrity: sha512-YvYllqh3qrR5TAYZZTXdspnIhlKAYezPYw11ntmweoceu4VK+keN356phHRIIo1d+RDmLpHZrUlmxga2gc9kSQ==}
@@ -11473,8 +11429,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pkgr/core@0.1.1': {}
-
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/constants@10.0.0': {}
@@ -13770,16 +13724,6 @@ snapshots:
       readable-stream: 2.3.8
       typedarray: 0.0.6
 
-  concurrently@9.1.2:
-    dependencies:
-      chalk: 4.1.2
-      lodash: 4.17.21
-      rxjs: 7.8.1
-      shell-quote: 1.8.1
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
-
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
@@ -15645,16 +15589,6 @@ snapshots:
       ignore: 5.3.2
       minimatch: 9.0.9
       semver: 7.6.3
-
-  eslint-plugin-prettier@5.2.1(@types/eslint@9.6.1)(eslint-config-prettier@9.1.0(eslint@9.18.0))(eslint@9.18.0)(prettier@3.4.2):
-    dependencies:
-      eslint: 9.18.0
-      prettier: 3.4.2
-      prettier-linter-helpers: 1.0.0
-      synckit: 0.9.2
-    optionalDependencies:
-      '@types/eslint': 9.6.1
-      eslint-config-prettier: 9.1.0(eslint@9.18.0)
 
   eslint-plugin-qunit@8.1.2(eslint@9.18.0):
     dependencies:
@@ -19177,10 +19111,6 @@ snapshots:
       fake-xml-http-request: 2.1.2
       route-recognizer: 0.3.4
 
-  prettier-linter-helpers@1.0.0:
-    dependencies:
-      fast-diff: 1.3.0
-
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
@@ -20078,8 +20008,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.1: {}
-
   shelljs@0.8.5:
     dependencies:
       glob: 7.2.3
@@ -20661,11 +20589,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  synckit@0.9.2:
-    dependencies:
-      '@pkgr/core': 0.1.1
-      tslib: 2.7.0
-
   table@6.9.0:
     dependencies:
       ajv: 8.18.0
@@ -20926,8 +20849,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
-
-  tree-kill@1.2.2: {}
 
   tree-sync@1.4.0:
     dependencies:


### PR DESCRIPTION
Prettier no longer recommends using it through ESLint so I separated them. 

Prettier remains limited to JS files until we decide otherwise: There are quite a few files in the project that do not match prettiers formatting and fixing them would create a bunch of noise for this PR.

This also removes the `concurrently` package from the codebase completely, pnpm works just fine now.