### PR TITLE
move release-plan back to a root dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ember-inspector-workspace",
   "version": "0.0.0",
   "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:emberjs/ember-inspector.git"
+  },
   "scripts": {
     "build": "pnpm --filter ember-debug build && pnpm --filter ember-inspector build",
     "build:ember-debug": "pnpm --filter ember-debug build",
@@ -9,6 +13,7 @@
     "build:production": "pnpm --filter ember-debug build && pnpm --filter ember-inspector build:production",
     "lint": "pnpm --parallel -r --aggregate-output lint",
     "lint:fix": "pnpm --parallel -r --aggregate-output lint:fix",
+    "serve:bookmarklet": "pnpm --filter ember-inspector serve:bookmarklet",
     "start": "pnpm --filter ember-inspector start",
     "test": "pnpm lint && pnpm \"/^test:/\"",
     "test:ember": "pnpm --filter ember-debug build && pnpm --filter ember-inspector test",
@@ -17,8 +22,10 @@
     "watch:inspector-ui": "pnpm --filter ember-inspector watch",
     "watch-test": "pnpm \"/watch-test:/\"",
     "watch-test:ember-debug": "pnpm --filter ember-debug watch",
-    "watch-test:inspector-ui": "pnpm --filter ember-inspector watch-test",
-    "serve:bookmarklet": "pnpm --filter ember-inspector serve:bookmarklet"
+    "watch-test:inspector-ui": "pnpm --filter ember-inspector watch-test"
+  },
+  "devDependencies": {
+    "release-plan": "^0.18.0"
   },
   "packageManager": "pnpm@9.12.1",
   "engines": {

--- a/packages/ember-inspector/package.json
+++ b/packages/ember-inspector/package.json
@@ -122,7 +122,6 @@
     "prettier-plugin-ember-template-tag": "^2.0.4",
     "qunit": "^2.23.1",
     "qunit-dom": "^3.4.0",
-    "release-plan": "^0.18.0",
     "sass": "^1.79.4",
     "stylelint": "^16.13.2",
     "stylelint-config-standard-scss": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,11 @@ patchedDependencies:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      release-plan:
+        specifier: ^0.18.0
+        version: 0.18.0
 
   packages/ember-debug:
     devDependencies:
@@ -331,9 +335,6 @@ importers:
       qunit-dom:
         specifier: ^3.4.0
         version: 3.4.0
-      release-plan:
-        specifier: ^0.18.0
-        version: 0.18.0
       sass:
         specifier: ^1.79.4
         version: 1.97.3


### PR DESCRIPTION
in #2752 we accidentally moved release-plan to the new package. This devDependency needs to stay at the root 👍 