### PR TITLE
Use import for compareVersions

### DIFF
--- a/packages/ember-inspector/app/routes/launch.js
+++ b/packages/ember-inspector/app/routes/launch.js
@@ -5,6 +5,7 @@ import Route from '@ember/routing/route';
 import RSVP from 'rsvp';
 const { Promise } = RSVP;
 import { LOCAL_STORAGE_SUPPORTED } from 'ember-inspector/services/storage/local';
+import { compareVersions } from 'compare-versions';
 
 const chromeStoreSupported = !!window.chrome && !!window.chrome.storage;
 const storageSupported = chromeStoreSupported || LOCAL_STORAGE_SUPPORTED;
@@ -25,7 +26,7 @@ export default class LaunchRoute extends Route {
       this.setLastVersionOpened(currentVersion);
       if (
         storageSupported &&
-        window.compareVersions(currentVersion, lastVersion) > 0
+        compareVersions(currentVersion, lastVersion) > 0
       ) {
         targetRoute = 'whats-new';
       }

--- a/packages/ember-inspector/ember-cli-build.js
+++ b/packages/ember-inspector/ember-cli-build.js
@@ -87,7 +87,6 @@ module.exports = function (defaults) {
   app.import('node_modules/basiccontext/dist/basicContext.min.css');
   app.import('node_modules/basiccontext/dist/themes/default.min.css');
   app.import('node_modules/basiccontext/dist/basicContext.min.js');
-  app.import('node_modules/compare-versions/index.js');
   app.import('node_modules/normalize.css/normalize.css');
 
   const previousEmberVersionsSupportedString = JSON.stringify(

--- a/packages/ember-inspector/package.json
+++ b/packages/ember-inspector/package.json
@@ -65,7 +65,7 @@
     "broccoli-stew": "^3.0.0",
     "broccoli-string-replace": "^0.1.2",
     "codeclimate-test-reporter": "^0.5.1",
-    "compare-versions": "^4.1.4",
+    "compare-versions": "^6.1.1",
     "del": "^6.1.1",
     "ember-auto-import": "^2.10.0",
     "ember-cli": "~6.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       compare-versions:
-        specifier: ^4.1.4
-        version: 4.1.4
+        specifier: ^6.1.1
+        version: 6.1.1
       del:
         specifier: ^6.1.1
         version: 6.1.1
@@ -3910,8 +3910,8 @@ packages:
     engines: {node: '>= 0.8'}
     hasBin: true
 
-  compare-versions@4.1.4:
-    resolution: {integrity: sha512-FemMreK9xNyL8gQevsdRMrvO4lFCkQP7qbuktn1q8ndcNk1+0mz7lgE7b/sNvbhVgY4w6tMN1FDp6aADjqw2rw==}
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -15527,7 +15527,7 @@ snapshots:
       q: 1.5.1
       recast: 0.11.23
 
-  compare-versions@4.1.4: {}
+  compare-versions@6.1.1: {}
 
   component-emitter@1.3.1: {}
 


### PR DESCRIPTION
The previous approach was obsolete with ember-auto-import and will blow up when moving to Vite

