### PR TITLE
handleRedirect must preventDefault when attached to an anchor

### DIFF
--- a/packages/ember-inspector/app/components/deprecation-item-source.js
+++ b/packages/ember-inspector/app/components/deprecation-item-source.js
@@ -32,7 +32,9 @@ export default class DeprecationItemSource extends Component {
   }
 
   @action
-  handleRedirect() {
+  handleRedirect(event) {
+    // FIXME: this should be attached to a <button> not an <a>
+    event.preventDefault();
     this.args.openResource?.(this.args.itemModel?.map);
   }
 }


### PR DESCRIPTION
This is a temporary (forever) measure to prevent the test in question to blank the page because clicking an `<a href="#">` will navigate to `/#` otherwise.

Semantically the `<a>` in question should be a `<button>`, but I don't have time to fix the styling for that.