### PR TITLE
ember-codemod-remove-inject-as-service

### DIFF
--- a/packages/ember-inspector/app/components/app-picker.js
+++ b/packages/ember-inspector/app/components/app-picker.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class AppPickerComponent extends Component {
   @service port;

--- a/packages/ember-inspector/app/components/component-tree-arg.js
+++ b/packages/ember-inspector/app/components/component-tree-arg.js
@@ -1,7 +1,7 @@
 import Component from '@glimmer/component';
 import truncate from 'ember-inspector/utils/truncate';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ComponentTreeArg extends Component {
   @service port;

--- a/packages/ember-inspector/app/components/deprecation-item-source.js
+++ b/packages/ember-inspector/app/components/deprecation-item-source.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import Component from '@glimmer/component';
 export default class DeprecationItemSource extends Component {

--- a/packages/ember-inspector/app/components/list-content.js
+++ b/packages/ember-inspector/app/components/list-content.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Component from '@glimmer/component';
 import { htmlSafe } from '@ember/template';
 import { schedule } from '@ember/runloop';

--- a/packages/ember-inspector/app/components/list.js
+++ b/packages/ember-inspector/app/components/list.js
@@ -6,7 +6,7 @@ import { localCopy } from 'tracked-toolbox';
 import { bind, scheduleOnce } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
 import ResizableColumns from 'ember-inspector/libs/resizable-columns';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 const CHECK_HTML = '&#10003;';

--- a/packages/ember-inspector/app/components/object-inspector.js
+++ b/packages/ember-inspector/app/components/object-inspector.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class ObjectInspector extends Component {

--- a/packages/ember-inspector/app/components/object-inspector/properties-all.js
+++ b/packages/ember-inspector/app/components/object-inspector/properties-all.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import PropertiesBase from 'ember-inspector/components/object-inspector/properties-base';
 
 const findMixin = function (mixins, property) {

--- a/packages/ember-inspector/app/components/object-inspector/properties-base.js
+++ b/packages/ember-inspector/app/components/object-inspector/properties-base.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class PropertiesBase extends Component {

--- a/packages/ember-inspector/app/components/object-inspector/properties-grouped.js
+++ b/packages/ember-inspector/app/components/object-inspector/properties-grouped.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import PropertiesBase from 'ember-inspector/components/object-inspector/properties-base';
 
 export default class PropertiesGrouped extends PropertiesBase {

--- a/packages/ember-inspector/app/components/object-inspector/toggle.js
+++ b/packages/ember-inspector/app/components/object-inspector/toggle.js
@@ -1,5 +1,5 @@
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class PropertiesGrouped extends Component {
   @service layout;

--- a/packages/ember-inspector/app/components/side-nav.js
+++ b/packages/ember-inspector/app/components/side-nav.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class SideNav extends Component {

--- a/packages/ember-inspector/app/components/ui/draggable-column.js
+++ b/packages/ember-inspector/app/components/ui/draggable-column.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 export default class DraggableColumnComponent extends Component {

--- a/packages/ember-inspector/app/controllers/application.js
+++ b/packages/ember-inspector/app/controllers/application.js
@@ -2,7 +2,7 @@ import Controller, { inject as controller } from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 import { debounce, schedule } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import { TrackedArray, TrackedObject } from 'tracked-built-ins';
 

--- a/packages/ember-inspector/app/controllers/component-tree.js
+++ b/packages/ember-inspector/app/controllers/component-tree.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { debounce } from '@ember/runloop';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { htmlSafe } from '@ember/template';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/ember-inspector/app/controllers/container-type.js
+++ b/packages/ember-inspector/app/controllers/container-type.js
@@ -1,5 +1,5 @@
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { action, computed, set } from '@ember/object';
 import debounceComputed from 'ember-inspector/computed/debounce';

--- a/packages/ember-inspector/app/controllers/container-types.js
+++ b/packages/ember-inspector/app/controllers/container-types.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { sort } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 
 export default class ContainerTypesController extends Controller {

--- a/packages/ember-inspector/app/controllers/container-types/index.js
+++ b/packages/ember-inspector/app/controllers/container-types/index.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 export default class ContainerTypesIndexController extends Controller {
   @service port;

--- a/packages/ember-inspector/app/controllers/deprecations.js
+++ b/packages/ember-inspector/app/controllers/deprecations.js
@@ -1,5 +1,5 @@
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/ember-inspector/app/controllers/model-types.js
+++ b/packages/ember-inspector/app/controllers/model-types.js
@@ -1,6 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 const HIDE_EMPTY_MODELS_KEY = 'are-model-types-hidden';
 const ORDER_MODELS_BY_COUNT_KEY = 'are-models-ordered-by-record-count';

--- a/packages/ember-inspector/app/controllers/promise-tree.js
+++ b/packages/ember-inspector/app/controllers/promise-tree.js
@@ -1,6 +1,6 @@
 import { action } from '@ember/object';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { debounce, once } from '@ember/runloop';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/ember-inspector/app/controllers/records.js
+++ b/packages/ember-inspector/app/controllers/records.js
@@ -1,7 +1,7 @@
 import { isEmpty } from '@ember/utils';
 import { action, get, set } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 import escapeRegExp from '../utils/escape-reg-exp';

--- a/packages/ember-inspector/app/controllers/render-tree.js
+++ b/packages/ember-inspector/app/controllers/render-tree.js
@@ -2,7 +2,7 @@
 import { action, computed } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import Controller from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 
 import escapeRegExp from '../utils/escape-reg-exp';
 import debounceComputed from '../computed/debounce';

--- a/packages/ember-inspector/app/controllers/route-tree.js
+++ b/packages/ember-inspector/app/controllers/route-tree.js
@@ -3,7 +3,7 @@ import { alias } from '@ember/object/computed';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { action, computed, set } from '@ember/object';
 import Controller, { inject as controller } from '@ember/controller';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import checkCurrentRoute from 'ember-inspector/utils/check-current-route';
 import searchMatch from 'ember-inspector/utils/search-match';
 import isRouteSubstate from 'ember-inspector/utils/is-route-substate';

--- a/packages/ember-inspector/app/routes/app-config.js
+++ b/packages/ember-inspector/app/routes/app-config.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import TabRoute from 'ember-inspector/routes/tab';
 
 export default class AppConfigRoute extends TabRoute {

--- a/packages/ember-inspector/app/routes/app-detected.js
+++ b/packages/ember-inspector/app/routes/app-detected.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { Promise } from 'rsvp';
 import { getOwner } from '@ember/application';

--- a/packages/ember-inspector/app/routes/application.js
+++ b/packages/ember-inspector/app/routes/application.js
@@ -1,5 +1,5 @@
 /* eslint-disable ember/no-controller-access-in-routes */
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action, set } from '@ember/object';
 import Route from '@ember/routing/route';
 import Ember from 'ember';

--- a/packages/ember-inspector/app/routes/component-tree.js
+++ b/packages/ember-inspector/app/routes/component-tree.js
@@ -1,5 +1,5 @@
 import { Promise } from 'rsvp';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import TabRoute from 'ember-inspector/routes/tab';
 
 export default class ComponentTreeRoute extends TabRoute {

--- a/packages/ember-inspector/app/routes/container-type.js
+++ b/packages/ember-inspector/app/routes/container-type.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Promise } from 'rsvp';
 import { action } from '@ember/object';
 import TabRoute from 'ember-inspector/routes/tab';

--- a/packages/ember-inspector/app/routes/container-types.js
+++ b/packages/ember-inspector/app/routes/container-types.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { Promise } from 'rsvp';
 

--- a/packages/ember-inspector/app/routes/data/index.js
+++ b/packages/ember-inspector/app/routes/data/index.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { Promise } from 'rsvp';
 

--- a/packages/ember-inspector/app/routes/deprecations.js
+++ b/packages/ember-inspector/app/routes/deprecations.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Promise } from 'rsvp';
 import { setProperties } from '@ember/object';
 import TabRoute from 'ember-inspector/routes/tab';

--- a/packages/ember-inspector/app/routes/info-index.js
+++ b/packages/ember-inspector/app/routes/info-index.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 
 export default class InfoIndexRoute extends Route {

--- a/packages/ember-inspector/app/routes/launch.js
+++ b/packages/ember-inspector/app/routes/launch.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { readOnly } from '@ember/object/computed';
 import Route from '@ember/routing/route';

--- a/packages/ember-inspector/app/routes/libraries.js
+++ b/packages/ember-inspector/app/routes/libraries.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { readOnly } from '@ember/object/computed';
 import { Promise } from 'rsvp';

--- a/packages/ember-inspector/app/routes/model-type.js
+++ b/packages/ember-inspector/app/routes/model-type.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import Route from '@ember/routing/route';
 import { Promise } from 'rsvp';
 

--- a/packages/ember-inspector/app/routes/model-types.js
+++ b/packages/ember-inspector/app/routes/model-types.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 
 import { TrackedArray } from 'tracked-built-ins';

--- a/packages/ember-inspector/app/routes/promise-tree.js
+++ b/packages/ember-inspector/app/routes/promise-tree.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Promise } from 'rsvp';
 
 import PromiseAssembler from '../libs/promise-assembler';

--- a/packages/ember-inspector/app/routes/records.js
+++ b/packages/ember-inspector/app/routes/records.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 
 import { TrackedArray } from 'tracked-built-ins';

--- a/packages/ember-inspector/app/routes/render-tree.js
+++ b/packages/ember-inspector/app/routes/render-tree.js
@@ -1,5 +1,5 @@
 import EmberObject, { set } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { Promise } from 'rsvp';
 
 import { TrackedArray } from 'tracked-built-ins';

--- a/packages/ember-inspector/app/routes/route-tree.js
+++ b/packages/ember-inspector/app/routes/route-tree.js
@@ -1,4 +1,4 @@
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { set } from '@ember/object';
 import TabRoute from 'ember-inspector/routes/tab';
 

--- a/packages/ember-inspector/app/routes/whats-new.js
+++ b/packages/ember-inspector/app/routes/whats-new.js
@@ -1,5 +1,5 @@
 import TabRoute from 'ember-inspector/routes/tab';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 
 function checkStatus(response) {

--- a/packages/ember-inspector/app/services/adapters/basic.js
+++ b/packages/ember-inspector/app/services/adapters/basic.js
@@ -11,7 +11,7 @@
  * });
  * ```
  */
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 import config from 'ember-inspector/config/environment';

--- a/packages/ember-inspector/app/services/port.js
+++ b/packages/ember-inspector/app/services/port.js
@@ -1,7 +1,7 @@
 import { action, set, setProperties } from '@ember/object';
 import { addListener, removeListener, sendEvent } from '@ember/object/events';
 import { hasListeners } from '@ember/-internals/metal';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 
 export default class PortService extends Service {
   @service adapter;

--- a/packages/ember-inspector/app/services/storage.js
+++ b/packages/ember-inspector/app/services/storage.js
@@ -1,4 +1,4 @@
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { LOCAL_STORAGE_SUPPORTED } from './storage/local';
 import { tracked } from '@glimmer/tracking';
 

--- a/packages/ember-inspector/tests/ember_debug/object-inspector-test.js
+++ b/packages/ember-inspector/tests/ember_debug/object-inspector-test.js
@@ -11,7 +11,7 @@ import EmberObject, { computed } from '@ember/object';
 import MutableArray from '@ember/array/mutable';
 import ArrayProxy from '@ember/array/proxy';
 import ObjectProxy from '@ember/object/proxy';
-import Service, { inject as service } from '@ember/service';
+import Service, { service } from '@ember/service';
 import { VERSION } from '@ember/version';
 import { tracked } from '@glimmer/tracking';
 import { module, skip, test } from 'qunit';


### PR DESCRIPTION
Edit: This one only makes sense once we can separate the tests against different Ember versions from the Inspector UI.

Apply the codemod to remove the deprecation: https://deprecations.emberjs.com/id/importing-inject-from-ember-service/