### PR TITLE
Modernize load_inspector

### DIFF
--- a/packages/ember-inspector/app/services/adapters/bookmarklet.js
+++ b/packages/ember-inspector/app/services/adapters/bookmarklet.js
@@ -17,7 +17,9 @@ export default class Bookmarklet extends BasicAdapter {
   }
 
   get inspectedWindowURL() {
-    return loadPageVar('inspectedWindowURL');
+    return new URLSearchParams(window.location.search).get(
+      'inspectedWindowURL',
+    );
   }
 
   sendMessage(message) {
@@ -50,19 +52,4 @@ export default class Bookmarklet extends BasicAdapter {
       }
     });
   }
-}
-
-function loadPageVar(sVar) {
-  return decodeURI(
-    window.location.search.replace(
-      new RegExp(
-        `^(?:.*[&\\?]${encodeURI(sVar).replace(
-          /[\.\+\*]/g,
-          '\\$&',
-        )}(?:\\=([^&]*))?)?.*$`,
-        'i',
-      ),
-      '$1',
-    ),
-  );
 }

--- a/packages/ember-inspector/skeletons/bookmarklet/load_inspector.js
+++ b/packages/ember-inspector/skeletons/bookmarklet/load_inspector.js
@@ -1,107 +1,47 @@
 (function () {
   'use strict';
 
-  function getScriptURL() {
-    var scripts = document.getElementsByTagName('script');
-    if (scripts && scripts.length) {
-      for (var i = 0; i < scripts.length; i++) {
-        if (scripts[i].src && scripts[i].src.match(/load_inspector.js$/)) {
-          return scripts[i].src.replace(/\/load_inspector.js$/, '');
-        }
-      }
-    }
-    return null;
-  }
+  const baseUrl = document.currentScript.src.replace(/\/load_inspector.js$/, '');
 
-  var url = getScriptURL();
-  var windowUrl =
-    url +
-    '/{{PANE_ROOT}}' +
-    '/index.html' +
-    '?inspectedWindowURL=' +
-    locationOrigin();
-  var inspectorWindow;
+  const inject = (fileName) => {
+    const script = document.createElement('script');
 
-  var pathArray = url.split('/');
-  var base = pathArray[0] + '//' + pathArray[2];
-
-  if (!supportsPopup()) {
-    var iframe = document.createElement('iframe');
-    iframe.width = '100%';
-    iframe.height = '300';
-    iframe.style.backgroundColor = 'white';
-    iframe.style.position = 'absolute';
-    iframe.style.bottom = '0';
-    iframe.style.right = '0';
-    iframe.style.zIndex = 100000;
-    iframe.src = windowUrl;
-    document.body.appendChild(iframe);
-    inspectorWindow = iframe.contentWindow;
-  } else {
-    inspectorWindow = window.open(encodeURI(windowUrl), 'ember-inspector');
-  }
-
-  window.emberInspector = {
-    w: inspectorWindow,
-    url: base,
-  };
-
-  /**
-   * Handle Ember version mismatch. Re-injects
-   * another version of ember-debug.
-   *
-   */
-  window.addEventListener('message', function (e) {
-    if (e.origin !== window.emberInspector.url) {
-      return;
-    }
-    if (e.data.name === 'version-mismatch') {
-      injectEmberDebug(
-        'panes-' + e.data.version.replace(/\./g, '-') + '/ember_debug.js',
-      );
-    }
-  });
-
-  if (!window.emberInspector) {
-    alert(
-      'Unable to open the inspector in a popup.  Please enable popups and retry.',
-    );
-    return;
-  }
-  document.documentElement.dataset.emberExtension = 1;
-
-  function injectEmberDebug(fileName) {
-    var script = document.createElement('script');
     script.type = 'module';
-    script.src = url + '/' + fileName;
+    script.src = `${baseUrl}/${fileName}`;
+
     document.body.appendChild(script);
   }
 
-  injectEmberDebug('{{PANE_ROOT}}/ember_debug.js');
+  const remoteUrl = new URL(baseUrl);
 
-  function locationOrigin() {
-    var origin = window.location.origin;
-    if (!origin) {
-      origin =
-        window.location.protocol +
-        '//' +
-        window.location.hostname +
-        (window.location.port ? ':' + window.location.port : '');
+  remoteUrl.pathname += '/{{PANE_ROOT}}/index.html';
+  remoteUrl.searchParams.set('inspectedWindowURL', window.location.origin.toString());
+
+  window.emberInspector = {
+    w: window.open(remoteUrl, 'ember-inspector'),
+    url: remoteUrl.origin,
+  };
+
+  if (!window.emberInspector.w) {
+    alert('Unable to open the inspector in a popup. Please enable popups and retry.');
+
+    return;
+  }
+
+  /**
+   * Handle Ember version mismatch. Re-injects another version of ember-debug.
+   */
+  window.addEventListener('message', function ({ origin, data }) {
+    if (origin !== window.emberInspector.url) {
+      return;
     }
-    return origin;
-  }
 
-  function supportsPopup() {
-    return !isIE();
-  }
+    if (data.name === 'version-mismatch') {
+      inject(`panes-${data.version.replace(/\./g, '-')}/ember_debug.js`);
+    }
+  });
 
-  function isIE() {
-    return (
-      navigator.appName == 'Microsoft Internet Explorer' ||
-      (navigator.appName == 'Netscape' &&
-        new RegExp('Trident/.*rv:([0-9]{1,}[\.0-9]{0,})').exec(
-          navigator.userAgent,
-        ) != null)
-    );
-  }
+  document.documentElement.dataset.emberExtension = 1;
+
+  inject('{{PANE_ROOT}}/ember_debug.js');
 })();


### PR DESCRIPTION
The injection script hasn't been touched since it was made and just accumulated so much cruft.

- Replace usage of regular expressions with native URL and URLSearchParams APIs
- Remove support for Internet Explorer

We probably need to discuss this further before merging, which is why I'm making it a draft. 