### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/ember-debug/utils/base-object.js
+++ b/packages/ember-debug/utils/base-object.js
@@ -1,7 +1,20 @@
+function safeAssign(target, source) {
+  if (!source) {
+    return target;
+  }
+  for (let key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      continue;
+    }
+    target[key] = source[key];
+  }
+  return target;
+}
+
 export default class BaseObject {
   isDestroyed = false;
   constructor(data) {
-    Object.assign(this, data || {});
+    safeAssign(this, data);
     this.init();
   }
 
@@ -16,6 +29,6 @@ export default class BaseObject {
   }
 
   reopen(data) {
-    Object.assign(this, data);
+    safeAssign(this, data);
   }
 }

--- a/packages/ember-inspector/app/helpers/build-style.js
+++ b/packages/ember-inspector/app/helpers/build-style.js
@@ -13,9 +13,24 @@ import { helper } from '@ember/component/helper';
 import { htmlSafe } from '@ember/template';
 const { keys } = Object;
 
+function sanitizeStyleValue(value) {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return '';
+  }
+  const str = String(value);
+  // Block dangerous CSS patterns that could lead to XSS
+  if (/[<>{]|javascript:|expression\(|@import/i.test(str)) {
+    return '';
+  }
+  return str;
+}
+
 export function buildStyle(_, options) {
   return htmlSafe(
-    keys(options).reduce((style, key) => `${style}${key}:${options[key]};`, ''),
+    keys(options).reduce((style, key) => {
+      const value = sanitizeStyleValue(options[key]);
+      return value ? `${style}${key}:${value};` : style;
+    }, ''),
   );
 }
 


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `packages/ember-debug/utils/base-object.js:L4`

The `BaseObject` class uses `Object.assign(this, data || {})` in its constructor, which can lead to prototype pollution if an attacker provides a specially crafted object with `__proto__`, `constructor`, or `prototype` keys. This could allow modification of the Object prototype, leading to arbitrary code execution or other security issues. Additionally, the `reopen` method has the same vulnerability.

## Solution

Use a safe assignment method that only copies own properties and skips prototype-related keys. Consider using `Object.assign` with a null prototype object or explicitly filtering out dangerous keys like `__proto__`, `constructor`, and `prototype`.

## Changes

- `packages/ember-debug/utils/base-object.js` (modified)
- `packages/ember-inspector/app/helpers/build-style.js` (modified)