### PR TITLE
Add time-travel debugging (record button + timeline slider)

### DIFF
--- a/packages/ember-debug/main.js
+++ b/packages/ember-debug/main.js
@@ -9,6 +9,7 @@ import DataDebug from './data-debug.js';
 import PromiseDebug from './promise-debug.js';
 import ContainerDebug from './container-debug.js';
 import DeprecationDebug from './deprecation-debug.js';
+import TimeTravelDebug from './time-travel-debug.js';
 import Session from './services/session.js';
 
 import { getApplications, getApplicationInstance } from './lib/applications.js';
@@ -79,6 +80,7 @@ export class EmberDebug extends BaseObject {
       'promiseDebug',
       'containerDebug',
       'deprecationDebug',
+      'timeTravelDebug',
       'objectInspector',
       'session',
     ].forEach((prop) => {
@@ -130,6 +132,7 @@ export class EmberDebug extends BaseObject {
       this.startModule('promiseDebug', PromiseDebug);
       this.startModule('containerDebug', ContainerDebug);
       this.startModule('deprecationDebug', DeprecationDebug);
+      this.startModule('timeTravelDebug', TimeTravelDebug);
 
       this.generalDebug.sendBooted();
     });

--- a/packages/ember-debug/time-travel-debug.js
+++ b/packages/ember-debug/time-travel-debug.js
@@ -1,0 +1,371 @@
+import DebugPort from './debug-port.js';
+import bound from './utils/bound-method.js';
+import { set } from './lib/ember.js';
+import { _backburner, debounce, join } from './lib/ember/runloop.js';
+
+/**
+ * Container types whose singletons hold long-lived application state.
+ * Components are deliberately excluded: they are transient, and their
+ * state is derived from these objects.
+ */
+const RECORDED_TYPES = ['service', 'controller'];
+
+/**
+ * Properties that exist on framework base classes and either aren't
+ * application state or are unsafe to write back.
+ */
+const SKIPPED_KEYS = new Set([
+  'concatenatedProperties',
+  'isDestroyed',
+  'isDestroying',
+  'mergedProperties',
+  'queryParams',
+  'store',
+  'target',
+]);
+
+const MAX_SNAPSHOTS = 200;
+
+/**
+ * Deep-clones a value if (and only if) it is plainly serializable:
+ * primitives, plain objects and arrays of serializable values. Class
+ * instances, DOM nodes, functions, promises etc. are rejected because
+ * cloning them would lose identity and writing the clone back on
+ * travel would corrupt the app.
+ *
+ * @return {{ ok: boolean, value: * }}
+ */
+export function cloneValue(value, depth = 0) {
+  if (depth > 8) {
+    return { ok: false };
+  }
+  switch (typeof value) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+    case 'undefined':
+      return { ok: true, value };
+    case 'object':
+      break;
+    default:
+      return { ok: false };
+  }
+  if (value === null) {
+    return { ok: true, value };
+  }
+  if (Array.isArray(value)) {
+    const result = [];
+    for (const item of value) {
+      const cloned = cloneValue(item, depth + 1);
+      if (!cloned.ok) {
+        return { ok: false };
+      }
+      result.push(cloned.value);
+    }
+    return { ok: true, value: result };
+  }
+  if (value instanceof Date) {
+    return { ok: true, value: new Date(value.getTime()) };
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) {
+    return { ok: false };
+  }
+  const result = {};
+  for (const key of Object.keys(value)) {
+    const cloned = cloneValue(value[key], depth + 1);
+    if (!cloned.ok) {
+      return { ok: false };
+    }
+    result[key] = cloned.value;
+  }
+  return { ok: true, value: result };
+}
+
+function valuesEqual(a, b) {
+  if (a === b) {
+    return true;
+  }
+  if (typeof a !== 'object' || typeof b !== 'object' || !a || !b) {
+    return false;
+  }
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Records snapshots of the serializable state of container singletons
+ * (services and controllers) at the end of every runloop, and can write
+ * any recorded snapshot back, which triggers Glimmer revalidation and
+ * re-renders the app at that point in time.
+ */
+export default class extends DebugPort {
+  recording = false;
+  snapshots = [];
+  currentIndex = -1;
+
+  // Set while a snapshot is being written back, so that the runloops
+  // caused by the restore don't get recorded as new snapshots.
+  _restoring = false;
+
+  get container() {
+    return this.namespace?.owner?.__container__;
+  }
+
+  static {
+    this.prototype.portNamespace = 'timeTravel';
+    this.prototype.messages = {
+      checkState() {
+        this.sendState();
+      },
+      startRecording() {
+        this.startRecording();
+      },
+      stopRecording() {
+        this.stopRecording();
+      },
+      clear() {
+        this.snapshots = [];
+        this.currentIndex = -1;
+        this.sendState();
+      },
+      travel(message) {
+        this.travelTo(message.index);
+      },
+    };
+  }
+
+  willDestroy() {
+    if (this.recording) {
+      this.recording = false;
+      _backburner.off('end', bound(this, this.capture));
+    }
+    super.willDestroy();
+  }
+
+  startRecording() {
+    if (this.recording) {
+      return;
+    }
+    this.recording = true;
+    _backburner.on('end', bound(this, this.capture));
+    // Capture the state as it is right now, so the slider always has a
+    // "before anything happened" origin to return to.
+    this.capture();
+    this.sendState();
+  }
+
+  stopRecording() {
+    if (!this.recording) {
+      return;
+    }
+    this.recording = false;
+    _backburner.off('end', bound(this, this.capture));
+    this.sendState();
+  }
+
+  /**
+   * Walks the container cache and captures every serializable property
+   * of services and controllers. Called after every runloop while
+   * recording; only stores a new snapshot when something changed.
+   */
+  capture() {
+    if (!this.recording || this._restoring || this.isDestroyed) {
+      return;
+    }
+    const objects = this.recordableObjects();
+    const states = [];
+    for (const { fullName, instance } of objects) {
+      const props = {};
+      let count = 0;
+      for (const key of this.recordableKeys(instance)) {
+        let value;
+        try {
+          value = instance.get ? instance.get(key) : instance[key];
+        } catch {
+          continue;
+        }
+        const cloned = cloneValue(value);
+        if (cloned.ok) {
+          props[key] = cloned.value;
+          count++;
+        }
+      }
+      if (count > 0) {
+        states.push({ fullName, props });
+      }
+    }
+
+    const serialized = JSON.stringify(states);
+    const last = this.snapshots[this.snapshots.length - 1];
+    if (last && last.serialized === serialized) {
+      return;
+    }
+
+    this.snapshots.push({
+      states,
+      serialized,
+      timestamp: Date.now(),
+      url: this.currentUrl(),
+    });
+    if (this.snapshots.length > MAX_SNAPSHOTS) {
+      this.snapshots.shift();
+    }
+    this.currentIndex = this.snapshots.length - 1;
+    debounce(this, this.sendState, 100);
+  }
+
+  /**
+   * Writes the snapshot at `index` back into the live objects. Only
+   * properties whose current value differs are set, so untouched state
+   * doesn't invalidate.
+   */
+  travelTo(index) {
+    const snapshot = this.snapshots[index];
+    if (!snapshot) {
+      return;
+    }
+    this._restoring = true;
+    try {
+      join(() => {
+        const cache = this.containerCache();
+        for (const { fullName, props } of snapshot.states) {
+          const instance = cache[fullName];
+          if (!instance || instance.isDestroyed || instance.isDestroying) {
+            continue;
+          }
+          for (const key of Object.keys(props)) {
+            const recorded = props[key];
+            let current;
+            try {
+              current = instance.get ? instance.get(key) : instance[key];
+            } catch {
+              continue;
+            }
+            if (valuesEqual(current, recorded)) {
+              continue;
+            }
+            const { ok, value } = cloneValue(recorded);
+            if (!ok) {
+              continue;
+            }
+            try {
+              if (instance.set) {
+                instance.set(key, value);
+              } else {
+                set(instance, key, value);
+              }
+            } catch {
+              // Read-only or getter-backed properties can't be restored.
+            }
+          }
+        }
+      });
+    } finally {
+      this._restoring = false;
+    }
+    this.currentIndex = index;
+    this.sendState();
+  }
+
+  sendState() {
+    if (this.isDestroyed) {
+      return;
+    }
+    this.sendMessage('state', {
+      recording: this.recording,
+      currentIndex: this.currentIndex,
+      snapshots: this.snapshots.map(({ timestamp, url }, index) => ({
+        index,
+        timestamp,
+        url,
+      })),
+    });
+  }
+
+  containerCache() {
+    const container = this.container;
+    if (!container) {
+      return {};
+    }
+    let cache = container.cache;
+    if (cache && typeof cache.dict !== 'undefined') {
+      cache = cache.dict;
+    }
+    return cache || {};
+  }
+
+  recordableObjects() {
+    const cache = this.containerCache();
+    const result = [];
+    for (const fullName of Object.keys(cache)) {
+      const type = fullName.split(':')[0];
+      if (!RECORDED_TYPES.includes(type)) {
+        continue;
+      }
+      const instance = cache[fullName];
+      if (
+        !instance ||
+        typeof instance !== 'object' ||
+        instance.isDestroyed ||
+        instance.isDestroying
+      ) {
+        continue;
+      }
+      result.push({ fullName, instance });
+    }
+    return result;
+  }
+
+  /**
+   * The keys worth snapshotting on an instance:
+   * - own enumerable data properties (classic Ember object state)
+   * - accessors with both a getter and a setter anywhere on the
+   *   prototype chain (this is the shape `@tracked` produces)
+   * Getter-only accessors are derived state and are skipped.
+   */
+  recordableKeys(instance) {
+    const keys = new Set();
+    for (const key of Object.keys(instance)) {
+      if (this.shouldSkipKey(key)) {
+        continue;
+      }
+      const descriptor = Object.getOwnPropertyDescriptor(instance, key);
+      if (descriptor && 'value' in descriptor) {
+        if (typeof descriptor.value !== 'function') {
+          keys.add(key);
+        }
+      } else if (descriptor?.get && descriptor?.set) {
+        keys.add(key);
+      }
+    }
+    let proto = Object.getPrototypeOf(instance);
+    while (proto && proto !== Object.prototype) {
+      const descriptors = Object.getOwnPropertyDescriptors(proto);
+      for (const key of Object.keys(descriptors)) {
+        if (this.shouldSkipKey(key) || keys.has(key)) {
+          continue;
+        }
+        const descriptor = descriptors[key];
+        if (descriptor.get && descriptor.set) {
+          keys.add(key);
+        }
+      }
+      proto = Object.getPrototypeOf(proto);
+    }
+    return keys;
+  }
+
+  shouldSkipKey(key) {
+    return key.startsWith('_') || SKIPPED_KEYS.has(key);
+  }
+
+  currentUrl() {
+    try {
+      // eslint-disable-next-line ember/no-private-routing-service
+      const router = this.container?.lookup('router:main');
+      return router?.get('currentURL') ?? undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/packages/ember-inspector/app/components/side-nav.js
+++ b/packages/ember-inspector/app/components/side-nav.js
@@ -87,6 +87,13 @@ export default class SideNav extends Component {
         title: 'Render Performance',
         pillCount: '',
       },
+      {
+        route: 'time-travel',
+        icon: 'nav-time-travel',
+        label: 'Time Travel',
+        title: 'Time Travel',
+        pillCount: '',
+      },
     ];
   }
 

--- a/packages/ember-inspector/app/components/time-travel-toolbar.hbs
+++ b/packages/ember-inspector/app/components/time-travel-toolbar.hbs
@@ -1,0 +1,16 @@
+<div class="toolbar">
+  <button
+    title={{if @recording "Stop recording" "Start recording"}}
+    class="toolbar-icon-button record-button
+      {{if @recording 'record-button--active'}}"
+    data-test-time-travel-record
+    type="button"
+    {{on "click" @toggleRecording}}
+  >
+    {{svg-jar "record" width="13px" height="13px"}}
+  </button>
+
+  <Ui::ToolbarDivider />
+
+  <Ui::ToolbarClearButton @action={{@clear}} data-test-time-travel-clear />
+</div>

--- a/packages/ember-inspector/app/controllers/time-travel.js
+++ b/packages/ember-inspector/app/controllers/time-travel.js
@@ -1,0 +1,71 @@
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+
+export default class TimeTravelController extends Controller {
+  @service port;
+
+  @tracked recording = false;
+  @tracked snapshots = [];
+  @tracked currentIndex = -1;
+
+  get hasSnapshots() {
+    return this.snapshots.length > 0;
+  }
+
+  get maxIndex() {
+    return Math.max(this.snapshots.length - 1, 0);
+  }
+
+  get displayIndex() {
+    return this.currentIndex + 1;
+  }
+
+  get isAtLatest() {
+    return this.currentIndex === this.snapshots.length - 1;
+  }
+
+  get selectedSnapshot() {
+    return this.snapshots[this.currentIndex];
+  }
+
+  get selectedTime() {
+    const snapshot = this.selectedSnapshot;
+    if (!snapshot) {
+      return '';
+    }
+    const date = new Date(snapshot.timestamp);
+    return `${date.toLocaleTimeString()}.${String(
+      date.getMilliseconds(),
+    ).padStart(3, '0')}`;
+  }
+
+  updateState({ recording, snapshots, currentIndex }) {
+    this.recording = recording;
+    this.snapshots = snapshots;
+    this.currentIndex = currentIndex;
+  }
+
+  @action
+  toggleRecording() {
+    this.port.send(
+      this.recording ? 'timeTravel:stopRecording' : 'timeTravel:startRecording',
+    );
+  }
+
+  @action
+  clear() {
+    this.port.send('timeTravel:clear');
+  }
+
+  @action
+  travel(event) {
+    const index = parseInt(event.target.value, 10);
+    if (isNaN(index) || !this.snapshots[index]) {
+      return;
+    }
+    this.currentIndex = index;
+    this.port.send('timeTravel:travel', { index });
+  }
+}

--- a/packages/ember-inspector/app/router.js
+++ b/packages/ember-inspector/app/router.js
@@ -39,5 +39,6 @@ Router.map(function () {
     });
 
     this.route('deprecations', { resetNamespace: true });
+    this.route('time-travel', { resetNamespace: true });
   });
 });

--- a/packages/ember-inspector/app/routes/time-travel.js
+++ b/packages/ember-inspector/app/routes/time-travel.js
@@ -1,0 +1,36 @@
+import { inject as service } from '@ember/service';
+import { Promise } from 'rsvp';
+import TabRoute from 'ember-inspector/routes/tab';
+
+export default class TimeTravelRoute extends TabRoute {
+  @service port;
+
+  model() {
+    return new Promise((resolve) => {
+      this.port.one('timeTravel:state', resolve);
+      this.port.send('timeTravel:checkState');
+    });
+  }
+
+  setupController(controller, message) {
+    super.setupController(...arguments);
+
+    controller.updateState(message);
+  }
+
+  activate() {
+    super.activate(...arguments);
+
+    this.port.on('timeTravel:state', this, this.stateUpdated);
+  }
+
+  deactivate() {
+    super.deactivate(...arguments);
+
+    this.port.off('timeTravel:state', this, this.stateUpdated);
+  }
+
+  stateUpdated(message) {
+    this.controller.updateState(message);
+  }
+}

--- a/packages/ember-inspector/app/styles/app.scss
+++ b/packages/ember-inspector/app/styles/app.scss
@@ -7,6 +7,7 @@
 @import "mixin";
 @import "object_inspector";
 @import "route_tree";
+@import "time_travel";
 @import "whats-new";
 @import "ember-table";
 @import "ui/ui";

--- a/packages/ember-inspector/app/styles/time_travel.scss
+++ b/packages/ember-inspector/app/styles/time_travel.scss
@@ -1,0 +1,53 @@
+.time-travel {
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+}
+
+.time-travel__scrubber {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.time-travel__slider {
+  accent-color: var(--focus);
+  width: 100%;
+}
+
+.time-travel__info {
+  color: var(--base09);
+  display: flex;
+  font-size: 12px;
+  justify-content: space-between;
+
+  code {
+    color: var(--base15);
+  }
+}
+
+.time-travel__recording-indicator {
+  color: #e04f4f;
+
+  &::before {
+    animation: time-travel-blink 1.2s ease-in-out infinite;
+    content: "●";
+    margin-right: 4px;
+  }
+}
+
+@keyframes time-travel-blink {
+  50% {
+    opacity: 0.25;
+  }
+}
+
+.record-button {
+  .record-icon-circle {
+    fill: var(--base09);
+  }
+
+  &.record-button--active .record-icon-circle {
+    fill: #e04f4f;
+  }
+}

--- a/packages/ember-inspector/app/templates/time-travel.hbs
+++ b/packages/ember-inspector/app/templates/time-travel.hbs
@@ -1,0 +1,62 @@
+{{#if this.toolbarContainer}}
+  {{#in-element this.toolbarContainer}}
+    <TimeTravelToolbar
+      @clear={{this.clear}}
+      @recording={{this.recording}}
+      @toggleRecording={{this.toggleRecording}}
+    />
+  {{/in-element}}
+{{/if}}
+
+{{#if this.hasSnapshots}}
+  <div class="time-travel js-time-travel">
+    <div class="time-travel__scrubber">
+      <input
+        aria-label="Snapshot timeline"
+        class="time-travel__slider js-time-travel-slider"
+        max={{this.maxIndex}}
+        min="0"
+        type="range"
+        value={{this.currentIndex}}
+        {{on "input" this.travel}}
+      />
+      <div class="time-travel__info js-time-travel-info">
+        <span>
+          Snapshot
+          {{this.displayIndex}}
+          of
+          {{this.snapshots.length}}
+          &mdash;
+          {{this.selectedTime}}
+          {{#if this.selectedSnapshot.url}}
+            at
+            <code>{{this.selectedSnapshot.url}}</code>
+          {{/if}}
+        </span>
+        {{#if this.recording}}
+          <span class="time-travel__recording-indicator">Recording</span>
+        {{else if this.isAtLatest}}
+          <span>Latest</span>
+        {{else}}
+          <span>Time traveling &mdash; drag to the end to return to the most
+            recent state</span>
+        {{/if}}
+      </div>
+    </div>
+  </div>
+{{else}}
+  <Ui::EmptyMessage>
+    <p>
+      No snapshots have been recorded yet. Press the record button in the
+      toolbar, then interact with your application. A snapshot of the tracked
+      state of your services and controllers is captured after every run loop,
+      and the slider lets you move the application back and forth through those
+      states.
+    </p>
+    <p>
+      Note: only serializable state (strings, numbers, booleans, dates, plain
+      arrays and objects) is recorded. Ember Data records, the router URL, and
+      component-local state are not restored.
+    </p>
+  </Ui::EmptyMessage>
+{{/if}}

--- a/packages/ember-inspector/public/assets/svg/nav-time-travel.svg
+++ b/packages/ember-inspector/public/assets/svg/nav-time-travel.svg
@@ -1,0 +1,4 @@
+<svg aria-hidden="true" version="1.1" width="20" height="20" viewBox="0 0 36 36" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+  <path class="nav-icon-stroke" d="M18,2A16,16,0,0,0,5.66,7.85L2.83,5,2,13l8-.83L7.08,9.27A14,14,0,1,1,4,18H2A16,16,0,1,0,18,2Z"></path>
+  <path class="nav-icon-stroke" d="M17,9V19.41l6.79,6.79,1.42-1.41L19,18.59V9Z"></path>
+</svg>

--- a/packages/ember-inspector/public/assets/svg/record.svg
+++ b/packages/ember-inspector/public/assets/svg/record.svg
@@ -1,0 +1,3 @@
+<svg aria-hidden="true" version="1.1" width="13" height="13" viewBox="0 0 16 16" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg">
+  <circle class="record-icon-circle" cx="8" cy="8" r="6"></circle>
+</svg>

--- a/packages/ember-inspector/tests/ember_debug/time-travel-debug-test.js
+++ b/packages/ember-inspector/tests/ember_debug/time-travel-debug-test.js
@@ -1,0 +1,134 @@
+import { module, test } from 'qunit';
+import { settled, visit, waitUntil } from '@ember/test-helpers';
+import Controller from '@ember/controller';
+import { tracked } from '@glimmer/tracking';
+// eslint-disable-next-line ember/no-runloop
+import { run } from '@ember/runloop';
+
+import EmberDebugImport from 'ember-debug/main';
+import setupEmberDebugTest from '../helpers/setup-ember-debug-test';
+
+let EmberDebug;
+
+module('Ember Debug - Time Travel', function (hooks) {
+  let stateMessages = [];
+
+  setupEmberDebugTest(hooks);
+
+  hooks.before(async function () {
+    EmberDebug = (await EmberDebugImport).default();
+  });
+
+  hooks.beforeEach(function () {
+    stateMessages = [];
+    EmberDebug.port.reopen({
+      send(name, message) {
+        if (name === 'timeTravel:state') {
+          stateMessages.push(message);
+        }
+      },
+    });
+
+    this.owner.register(
+      'controller:simple',
+      class SimpleController extends Controller {
+        @tracked count = 0;
+      },
+    );
+  });
+
+  hooks.afterEach(function () {
+    EmberDebug.timeTravelDebug?.stopRecording();
+  });
+
+  function lastState() {
+    return stateMessages[stateMessages.length - 1];
+  }
+
+  test('records snapshots while recording and restores them on travel', async function (assert) {
+    await visit('/simple');
+
+    const controller = this.owner.lookup('controller:simple');
+
+    EmberDebug.port.trigger('timeTravel:startRecording');
+    await settled();
+
+    assert.true(lastState().recording, 'recording is on');
+    assert.strictEqual(
+      lastState().snapshots.length,
+      1,
+      'initial snapshot was captured on start',
+    );
+
+    run(() => {
+      controller.count = 1;
+    });
+    await settled();
+
+    run(() => {
+      controller.count = 2;
+    });
+    await settled();
+
+    await waitUntil(() => lastState().snapshots.length === 3, {
+      timeout: 3000,
+    });
+
+    EmberDebug.port.trigger('timeTravel:stopRecording');
+    await settled();
+    assert.false(lastState().recording, 'recording is off');
+
+    EmberDebug.port.trigger('timeTravel:travel', { index: 0 });
+    await settled();
+
+    assert.strictEqual(
+      controller.count,
+      0,
+      'traveling to the first snapshot restored the tracked property',
+    );
+    assert.strictEqual(lastState().currentIndex, 0, 'currentIndex updated');
+
+    EmberDebug.port.trigger('timeTravel:travel', { index: 2 });
+    await settled();
+
+    assert.strictEqual(
+      controller.count,
+      2,
+      'traveling forward restored the later value',
+    );
+  });
+
+  test('identical runloops are deduplicated and clear resets', async function (assert) {
+    await visit('/simple');
+
+    const controller = this.owner.lookup('controller:simple');
+
+    EmberDebug.port.trigger('timeTravel:startRecording');
+    await settled();
+
+    // A runloop that doesn't change any recorded state
+    run(() => {});
+    await settled();
+
+    assert.strictEqual(
+      lastState().snapshots.length,
+      1,
+      'no snapshot for an unchanged runloop',
+    );
+
+    run(() => {
+      controller.count = 5;
+    });
+    await settled();
+
+    await waitUntil(() => lastState().snapshots.length === 2, {
+      timeout: 3000,
+    });
+
+    EmberDebug.port.trigger('timeTravel:clear');
+    await settled();
+
+    assert.strictEqual(lastState().snapshots.length, 0, 'snapshots cleared');
+    assert.strictEqual(lastState().currentIndex, -1, 'index reset');
+  });
+});


### PR DESCRIPTION
## Time-travel debugging

This PR adds a **Time Travel** tab to the inspector: a record button and a timeline slider that scrubs the inspected app's state back and forth.

![Time travel demo: recording state changes in an app, then scrubbing the timeline slider back and forth while the app's UI rewinds and replays](https://raw.githubusercontent.com/NullVoxPopuli-ai-agent/ember-inspector/demo-assets/demo.gif)

*([mp4](https://github.com/NullVoxPopuli-ai-agent/ember-inspector/raw/demo-assets/demo.mp4) / [webm](https://github.com/NullVoxPopuli-ai-agent/ember-inspector/raw/demo-assets/demo.webm) versions of the demo)*

### How it works

Ember has no single state atom, but long-lived app state overwhelmingly lives in tracked/settable properties on container-managed singletons. The new `ember-debug/time-travel-debug.js` module:

- **Record**: while recording, hooks `_backburner.on('end')` (the same "runloop settled" signal render-debug uses) and captures a snapshot of every serializable property of all `service:`/`controller:` singletons in the container cache. Consecutive identical states are deduplicated; the buffer is capped at 200 snapshots.
- **Travel**: writes a snapshot's values back through `set()` / tracked setters (only properties that actually differ), which triggers Glimmer revalidation — the app re-renders itself at that point in time. A guard prevents the restore's own runloops from being recorded.
- **Captured properties**: own enumerable data properties, plus prototype-chain accessors that have *both* a getter and a setter (the shape `@tracked` produces). Getter-only accessors are derived state and are skipped. Only plainly serializable values (primitives, dates, plain arrays/objects) are recorded — class instances are rejected so restoring can never corrupt identity-bearing objects.

The UI side is a standard tab (route/controller/template + nav entry) talking over the existing port protocol (`timeTravel:*` messages). The record button and clear button live in the toolbar; the slider sends `timeTravel:travel` on input, so scrubbing restores state live as you drag. The timeline shows the snapshot index, capture time, and the URL it was captured at.

### Known limitations (also explained in the tab's empty state)

- Component-local state, Ember Data records, and non-serializable objects are not restored.
- The router URL is captured for display but not restored (transitioning would re-run model hooks).

### Testing

- New `tests/ember_debug/time-travel-debug-test.js`: records tracked controller state, travels back/forward and asserts values are restored, verifies dedup of unchanged runloops and `clear`.
- Full Ember Debug suite passes (84 tests); eslint/template-lint/build clean.

### Notes from building the demo

The demo runs the bookmarklet build injected into `classic-test-app` (Ember 7). Two pre-existing issues bite late injection into webpack-built Ember 7 apps and had to be worked around in the demo harness (not addressed in this PR):

1. `entrypoints/utils/has-ember.js` never resolves: there is no `ember` barrel module and no `window.Ember` in Ember 7, and the `Ember` window event fired long before injection.
2. `object-inspector.js`'s `GlimmerValidator.tagFor`/`trackedData` patching throws (`Cannot set property tagFor of #<Object> which has only a getter`) because the webpack module namespace is getter-only — same problem the Vite guard (`globalThis.emberInspectorApps`) already dodges.

Happy to file these separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
